### PR TITLE
feat(alerting): Discord alert when schedule warming is degraded [audit P1]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,12 @@ SCRAPINGBEE_API_KEY=
 # Vercel Cron Secret (required for cron job auth)
 CRON_SECRET=
 
+# Operational alerting (optional): Discord webhook URL. When set, the warm-schedules cron POSTs a
+# compact alert whenever the schedule pipeline is degraded (mostly-failed warms, 0-flight boards,
+# or starlink down). Leave unset to disable alerting entirely. For Slack, the helper in
+# api/_alert.ts would need `text` instead of `content`.
+ALERT_WEBHOOK_URL=
+
 # Supabase (waitlist / email capture)
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here

--- a/api/_alert.ts
+++ b/api/_alert.ts
@@ -1,0 +1,42 @@
+// Lightweight, env-gated operational alerting.
+//
+// POSTs a compact message to a Discord webhook configured via ALERT_WEBHOOK_URL.
+// - No-ops when ALERT_WEBHOOK_URL is unset, so callers can invoke it unconditionally.
+// - Best-effort: never throws into the caller, uses a short timeout, and swallows its own errors.
+// - Throttled per-instance to avoid spamming on every cron tick. (The throttle is module-level
+//   state and therefore per-lambda; on serverless this is "good enough" for a */15 cron that
+//   normally runs on a single warm instance — it is a noise guard, not a hard global limit.)
+//
+// Discord webhooks accept a JSON body with a `content` field; we also include `username` for a
+// friendly sender name. (For Slack, swap `content` -> `text`.)
+// Audit P1: "No alerting/monitoring on the schedule/credit subsystem."
+
+let lastAlertAt = 0;
+const MIN_ALERT_INTERVAL_MS = 5 * 60 * 1000;
+
+export async function sendAlert(title: string, lines: string[] = []): Promise<void> {
+  const url = process.env.ALERT_WEBHOOK_URL;
+  if (!url) return;
+
+  const now = Date.now();
+  if (now - lastAlertAt < MIN_ALERT_INTERVAL_MS) return;
+  lastAlertAt = now;
+
+  // Discord hard-caps message content at 2000 chars; stay well under.
+  const content = [`**${title}**`, ...lines].join('\n').slice(0, 1900);
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content, username: 'Blue Board' }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+  } catch (e: any) {
+    // Never let alerting failures affect the caller's control flow.
+    console.error('Alert webhook failed:', e?.message || e);
+  }
+}

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -4,6 +4,7 @@
 
 import type { VercelRequest, VercelResponse } from '../types.js';
 import { getStartOfDayForHub } from '../irops.js';
+import { sendAlert } from '../_alert.js';
 
 const HUBS = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM'];
 // Serialized with INTER_TASK_DELAY_MS between tasks. Budget math: each task
@@ -148,6 +149,28 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   console.log(`Cron warm-schedules: ${warmed} warmed, ${failed} failed`, { warmPlan, results });
+
+  // Operational alerting (env-gated; no-op without ALERT_WEBHOOK_URL). The warm cron is the
+  // natural heartbeat for the schedule pipeline: if warming is mostly failing, returning
+  // 0-flight ("degraded_empty") boards, or starlink is down, the live site is degraded RIGHT
+  // NOW. Surface it proactively instead of waiting for a user to complain.
+  // (Audit P1: no-alerting-blind-pipeline.)
+  const degradedEmptyHubs = Object.entries(results)
+    .filter(([, r]) => r?.status === 'degraded_empty')
+    .map(([k]) => k);
+  const erroredKeys = Object.entries(results)
+    .filter(([, r]) => r?.status === 'error' || String(r?.status || '').startsWith('http_'))
+    .map(([k]) => k);
+  const starlinkStatus = results['starlink-data']?.status;
+  if (failed > warmed || degradedEmptyHubs.length > 0 || (starlinkStatus && starlinkStatus !== 'ok')) {
+    await sendAlert('⚠️ Blue Board schedule warm degraded', [
+      `warmed=${warmed} failed=${failed} (plan size ${warmPlan.length})`,
+      degradedEmptyHubs.length ? `0-flight boards: ${degradedEmptyHubs.join(', ')}` : '',
+      erroredKeys.length ? `errors/http: ${erroredKeys.join(', ')}` : '',
+      `starlink: ${starlinkStatus || 'n/a'}`,
+    ].filter(Boolean));
+  }
+
   return res.status(200).json({
     warmed,
     failed,


### PR DESCRIPTION
## Summary (Audit P1 — HIGH, category: reliability)

There was **no alerting anywhere** on the most fragile, most expensive subsystem. The schedule/FR24 pipeline only `console.log`'d into Vercel logs nobody watches, so a renewed Cloudflare block, a 0-flight cascade, or `402` credit exhaustion would degrade every board with **zero proactive signal** — a primary reason the site "feels like it's silently falling apart."

## Changes

- **`api/_alert.ts`** (new): a best-effort, env-gated webhook poster (`ALERT_WEBHOOK_URL`, Discord `content` format). No-ops when unset, never throws into the caller, 5s timeout, per-instance throttle to avoid tick spam.
- **`api/cron/warm-schedules.ts`**: wires `sendAlert` into the `*/15` warm heartbeat. Fires when `failed > warmed`, any hub returns a 0-flight `degraded_empty` board, or starlink is down. Reuses already-computed `warmed`/`failed`/`results` — **no new dependency, no data-path change.**
- **`.env.example`**: documents `ALERT_WEBHOOK_URL`.

Set `ALERT_WEBHOOK_URL` to a Discord webhook URL to turn it on; leave unset to keep alerting disabled.

## Verification
- ✅ `warm-schedules` (7) + `refresh-tsa` (7) + `sync-starlink` tests pass
- ✅ build clean, `tsc --noEmit` no new errors

**Follow-up** (needs the confirmed FR24 `/api/usage` payload schema — a documented audit gap): add a ~80% credit-threshold alert so credit exhaustion is caught *before* it zeroes out.

🤖 Part of the full-sweep audit of theblueboard.co (P1 wave).
