### PR TITLE
feat(dashboard): promote Starlink to a top-level nav tab

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -203,6 +203,7 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
   <button class="tab-btn active" data-tab="tab-live" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-live"><span aria-hidden="true">📡</span> LIVE OPS</button>
   <button class="tab-btn" data-tab="tab-schedule" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-schedule"><span aria-hidden="true">📅</span> SCHEDULE</button>
   <button class="tab-btn" data-tab="tab-fleet" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-fleet"><span aria-hidden="true">✈️</span> FLEET</button>
+  <button class="tab-btn" data-tab="tab-starlink" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-fleet"><span aria-hidden="true">🛰️</span> STARLINK</button>
   <button class="tab-btn" data-tab="tab-weather" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-weather"><span aria-hidden="true">🌦</span> DELAYS · WEATHER · HUBS</button>
   <button class="tab-btn" data-tab="tab-analytics" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-analytics" aria-label="Stats"><span aria-hidden="true">📊</span> STATS</button>
   <button class="tab-btn" data-tab="tab-sources" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-sources"><span aria-hidden="true">ℹ️</span> SOURCES</button>
@@ -220,6 +221,7 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
   <button id="mobile-more-btn" aria-label="More tabs" aria-expanded="false" aria-controls="mobile-more-menu"><span class="bnav-icon" aria-hidden="true">▾</span><span class="bnav-label">More</span></button>
 </nav>
 <div id="mobile-more-menu" aria-label="Additional navigation tabs">
+  <button data-tab="tab-starlink"><span class="bnav-icon" aria-hidden="true">🛰️</span> Starlink</button>
   <button data-tab="tab-myflight"><span class="bnav-icon" aria-hidden="true">🎫</span> My Flights</button>
   <button data-tab="tab-analytics"><span class="bnav-icon" aria-hidden="true">📊</span> Stats</button>
   <button data-tab="tab-sources"><span class="bnav-icon" aria-hidden="true">ℹ️</span> Sources</button>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -386,7 +386,12 @@ function switchToTab(tabId, updateHash) {
   btn.classList.add('active');
   btn.setAttribute('aria-selected', 'true');
   btn.setAttribute('tabindex', '0');
-  document.getElementById(tabId).classList.add('active');
+  // STARLINK is a top-level shortcut tab: the Starlink table lives inside #tab-fleet (as a
+  // fleet sub-view), so map the virtual tab-starlink to the fleet content panel and auto-select
+  // the Starlink sub-view below. Null-guard keeps every other tab's behaviour identical.
+  const contentId = tabId === 'tab-starlink' ? 'tab-fleet' : tabId;
+  const contentEl = document.getElementById(contentId);
+  if (contentEl) contentEl.classList.add('active');
   if (updateHash !== false && TAB_HASHES[tabId]) history.replaceState(null, '', TAB_HASHES[tabId]);
   // Defer heavy tab-specific init to next frame so the click event completes fast (INP fix)
   requestAnimationFrame(() => {
@@ -394,6 +399,7 @@ function switchToTab(tabId, updateHash) {
     if (tabId === 'tab-live' && map) map.invalidateSize();
     if (tabId === 'tab-schedule') { initScheduleTab(); if (schedInitialized && !schedAllFlights.length && !schedLoading) loadScheduleData(); }
     if (tabId === 'tab-fleet') { if (!allFlights.length && !flightsLoading) refreshFlights(); updateLiveFleetPanel(); }
+    if (tabId === 'tab-starlink') { if (!allFlights.length && !flightsLoading) refreshFlights(); updateLiveFleetPanel(); if (typeof switchFleetView === 'function') switchFleetView('starlink'); document.getElementById('fleet-subtab-bar')?.scrollIntoView({ block: 'start' }); }
     if (tabId === 'tab-weather') initWeatherTab();
     if (tabId === 'tab-analytics') updateAnalytics();
   });


### PR DESCRIPTION
## Summary
Starlink coverage was only reachable as a **sub-tab under FLEET**, so it was easy to miss ("where's my Starlink data?"). It's now a first-class top-level tab.

- **`public/index.html`**: "🛰️ STARLINK" button added to the desktop `#tab-bar` (between FLEET and WEATHER) + the mobile overflow menu.
- **`src/dashboard/main.js` (`switchToTab`)**: `tab-starlink` is a top-level shortcut to the existing Starlink view (which lives inside `#tab-fleet`). On activation it shows the fleet content, auto-selects the Starlink sub-view via `switchFleetView('starlink')`, and **scrolls to the subtab bar** so the user lands directly on the Starlink table (not the fleet summary above it). STARLINK highlights in the nav (not FLEET). A null-guard keeps every other tab identical — **no DOM moved, no existing Fleet/Starlink logic changed.**

## Verification (in-browser, local build)
- ✅ STARLINK appears in nav; clicking it → `starlinkBtnActive`, `fleetContentActive`, `starlinkViewVisible`, `starlinkSubtabSelected` all true, `fleetBtnActive` false
- ✅ Scrolls to the Starlink table (258 rows from the static fallback locally; 369 live)
- ✅ `bun run build` bundles main.js clean

🤖 Per your request to promote Starlink from a Fleet sub-tab.