### PR TITLE
fix(metar): resilient per-station fan-out (stop 504 weather blackout)

### DIFF
--- a/api/cron/refresh-metar.ts
+++ b/api/cron/refresh-metar.ts
@@ -1,0 +1,49 @@
+import type { VercelRequest, VercelResponse } from '../types.js';
+
+const HUB_ICAOS = 'KEWR,KIAH,KORD,KDEN,KSFO,KLAX,KIAD,RJAA,PGUM';
+
+/**
+ * Cron job to warm the METAR weather cache every 5 minutes.
+ * Calls /api/metar internally so the s-maxage=300 CDN cache stays warm AND the per-instance
+ * last-known-good store gets populated — making user-facing cache-misses (and slow-AWC blackouts) rare.
+ */
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const authHeader = req.headers['authorization'];
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  try {
+    const baseUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
+      ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+      : process.env.VERCEL_URL
+        ? `https://${process.env.VERCEL_URL}`
+        : 'http://localhost:3000';
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 25_000);
+
+    const resp = await fetch(`${baseUrl}/api/metar?ids=${HUB_ICAOS}`, {
+      signal: controller.signal,
+      headers: { origin: 'https://theblueboard.co' },
+    });
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      console.error('METAR cache warm failed:', resp.status, await resp.text());
+      return res.status(502).json({ error: 'Cache warm failed', status: resp.status });
+    }
+
+    const data = await resp.json();
+    const stationCount = Array.isArray(data) ? data.length : 0;
+    console.log(`METAR cache warmed: ${stationCount} stations`);
+
+    return res.status(200).json({ ok: true, stations: stationCount });
+  } catch (e: any) {
+    console.error('METAR cron error:', e);
+    if (e.name === 'AbortError') {
+      return res.status(504).json({ error: 'METAR cache warm timed out' });
+    }
+    return res.status(500).json({ error: 'Internal error' });
+  }
+}

--- a/api/metar.ts
+++ b/api/metar.ts
@@ -4,6 +4,45 @@ import { normalizeMetarPayload } from '../src/lib/metar.js';
 
 const isRateLimited = createRateLimiter('metar', 60);
 
+const AWC_BASE = 'https://aviationweather.gov/api/data/metar';
+// Per-station timeout. AWC's batch endpoint is gated by its slowest station on a cache miss
+// (one cold station can stall the whole response 12-20s), so we fetch each station on its own
+// clock instead. Concurrent fan-out means wall-clock is ~max(station), not the sum.
+const STATION_TIMEOUT_MS = Math.max(2000, Number(process.env.METAR_STATION_TIMEOUT_MS) || 6500);
+
+// Last-known-good observation per ICAO id, ephemeral per warm instance (same pattern as
+// _rate-limit.ts). This is the store the `stale-while-revalidate` header always implied but never
+// had: a momentarily-slow station serves its previous observation instead of blanking its hub card.
+const lastKnownGood = new Map<string, any>();
+
+/** Test helper: clear the last-known-good cache so module state doesn't leak across tests. */
+export function __resetMetarCacheForTests(): void {
+  lastKnownGood.clear();
+}
+
+function stationKey(rec: any): string {
+  return String(rec?.icaoId || rec?.stationId || rec?.id || '').toUpperCase();
+}
+
+// Fetch a single station with its own abort timer. Returns the normalized records (usually one),
+// or null on any failure/timeout — never throws, so Promise.allSettled stays clean.
+async function fetchOneStation(id: string): Promise<any[] | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), STATION_TIMEOUT_MS);
+  try {
+    const resp = await fetch(`${AWC_BASE}?ids=${encodeURIComponent(id)}&format=json`, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'theblueboard.co weather (jonah.berg.g@gmail.com)' },
+    });
+    if (!resp.ok) return null;
+    return normalizeMetarPayload(await resp.json());
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
@@ -18,24 +57,41 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(429).json({ error: 'Rate limited — try again shortly' });
   }
 
-  try {
-    const ids = (req.query.ids as string) || 'KORD';
-    // Validate: comma-separated ICAO codes, max 200 chars
-    if (!/^[A-Z0-9,]{1,200}$/i.test(ids)) {
-      return res.status(400).json({ error: 'Invalid airport IDs' });
-    }
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 8000);
-    const upstream = await fetch(`https://aviationweather.gov/api/data/metar?ids=${encodeURIComponent(ids)}&format=json`, { signal: controller.signal });
-    clearTimeout(timeout);
-    if (!upstream.ok) return res.status(502).json({ error: 'Upstream service unavailable' });
-    const data = normalizeMetarPayload(await upstream.json());
-    res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=600');
-    res.setHeader('Content-Type', 'application/json');
-    return res.status(200).json(data);
-  } catch (e: any) {
-    console.error('METAR API error:', e);
-    if (e.name === 'AbortError') return res.status(504).json({ error: 'Upstream timeout' });
-    return res.status(502).json({ error: 'Upstream service unavailable' });
+  const ids = (req.query.ids as string) || 'KORD';
+  // Validate: comma-separated ICAO codes, max 200 chars
+  if (!/^[A-Z0-9,]{1,200}$/i.test(ids)) {
+    return res.status(400).json({ error: 'Invalid airport IDs' });
   }
+
+  const stations = ids.toUpperCase().split(',').map((s) => s.trim()).filter(Boolean);
+
+  // Fan out: one independent, concurrently-timed fetch per station. A single slow/failed station
+  // can no longer stall or 504 the whole batch — the rest still return, and the laggard falls back
+  // to its last-known observation (or is omitted) rather than blanking every hub.
+  const settled = await Promise.allSettled(stations.map(fetchOneStation));
+
+  const byStation = new Map<string, any>();
+  for (const result of settled) {
+    if (result.status !== 'fulfilled' || !Array.isArray(result.value)) continue;
+    for (const rec of result.value) {
+      const key = stationKey(rec);
+      if (!key) continue;
+      byStation.set(key, rec);
+      lastKnownGood.set(key, rec); // refresh last-known-good with every fresh observation
+    }
+  }
+
+  // Backfill any requested station that didn't answer this round from last-known-good.
+  for (const id of stations) {
+    if (!byStation.has(id) && lastKnownGood.has(id)) {
+      byStation.set(id, lastKnownGood.get(id));
+    }
+  }
+
+  res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=600');
+  res.setHeader('Content-Type', 'application/json');
+  // Always 200 with whatever resolved (fresh + stale-backfilled). Worst case — a cold instance
+  // where every station is slow — returns [], which the dashboard already degrades to its
+  // existing "weather unavailable / retry" state rather than a hard error.
+  return res.status(200).json(Array.from(byStation.values()));
 }

--- a/tests/metar.test.js
+++ b/tests/metar.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import handler from '../api/metar.js';
+import handler, { __resetMetarCacheForTests } from '../api/metar.js';
 
 function createRes() {
   return {
@@ -12,9 +12,18 @@ function createRes() {
   };
 }
 
+function ok(records) {
+  return { ok: true, json: async () => ({ data: records }) };
+}
+function station(id, raw) {
+  return { station_id: id, raw_text: raw || `METAR ${id} 182351Z 28005KT 10SM`, flight_category: 'vfr' };
+}
+const abortError = () => Object.assign(new Error('aborted'), { name: 'AbortError' });
+
 describe('metar API', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    __resetMetarCacheForTests();
   });
 
   it('rejects non-GET requests', async () => {
@@ -52,10 +61,7 @@ describe('metar API', () => {
         sky_condition: [{ sky_cover: 'BKN', altitude_ft_agl: 25000 }],
       }],
     };
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => mockData,
-    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => mockData });
 
     const res = createRes();
     await handler({
@@ -80,36 +86,10 @@ describe('metar API', () => {
     expect(res.headers['Cache-Control']).toContain('s-maxage=300');
   });
 
-  it('returns 502 on upstream failure', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 500 });
-
-    const res = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: { ids: 'KORD' },
-    }, res);
-
-    expect(res.statusCode).toBe(502);
-  });
-
-  it('returns 504 on timeout', async () => {
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(Object.assign(new Error('timeout'), { name: 'AbortError' }));
-
-    const res = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: { ids: 'KORD' },
-    }, res);
-
-    expect(res.statusCode).toBe(504);
-  });
-
   it('accepts comma-separated airport IDs', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => [],
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const id = String(url).match(/ids=([A-Z]+)/)?.[1] || 'KORD';
+      return ok([station(id)]);
     });
 
     const res = createRes();
@@ -120,5 +100,64 @@ describe('metar API', () => {
     }, res);
 
     expect(res.statusCode).toBe(200);
+    expect(res.body.map((r) => r.icaoId).sort()).toEqual(['KDEN', 'KEWR', 'KORD']);
+  });
+
+  // ── Resilience: a slow/failed upstream must never blank the whole weather panel ──
+
+  it('returns a partial 200 when one station times out but others succeed', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const id = String(url).match(/ids=([A-Z]+)/)?.[1] || '';
+      if (id === 'KEWR') throw abortError(); // EWR upstream stalls past the per-station timeout
+      return ok([station(id)]);
+    });
+
+    const res = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { ids: 'KORD,KDEN,KEWR' },
+    }, res);
+
+    expect(res.statusCode).toBe(200); // NOT 504 — the panel stays up
+    const ids = res.body.map((r) => r.icaoId);
+    expect(ids).toContain('KORD');
+    expect(ids).toContain('KDEN');
+    expect(ids).not.toContain('KEWR'); // timed out, no prior obs -> omitted (hub shows placeholder)
+    expect(res.body.length).toBe(2);
+  });
+
+  it('serves last-known-good for a station that fails after a prior success', async () => {
+    // First request: KORD answers -> cached as last-known-good
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok([station('KORD', 'METAR KORD GOOD OBS')]));
+    let res = createRes();
+    await handler({ method: 'GET', headers: { origin: 'http://localhost:3000' }, query: { ids: 'KORD' } }, res);
+    expect(res.body[0].rawOb).toBe('METAR KORD GOOD OBS');
+
+    // Second request: KORD now times out -> served stale instead of vanishing
+    vi.restoreAllMocks();
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(abortError());
+    res = createRes();
+    await handler({ method: 'GET', headers: { origin: 'http://localhost:3000' }, query: { ids: 'KORD' } }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].rawOb).toBe('METAR KORD GOOD OBS'); // stale, but present — no blackout
+  });
+
+  it('returns 200 with an empty array (not 502/504) when the only station fails with no cached obs', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 500 });
+    const res = createRes();
+    await handler({ method: 'GET', headers: { origin: 'http://localhost:3000' }, query: { ids: 'KORD' } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([]); // dashboard degrades to its existing "weather unavailable" state
+  });
+
+  it('returns 200 (not 504) when a station times out with no cached obs', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(abortError());
+    const res = createRes();
+    await handler({ method: 'GET', headers: { origin: 'http://localhost:3000' }, query: { ids: 'KORD' } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([]);
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -29,12 +29,15 @@
         "api/check-flight.ts": { "maxDuration": 15 },
         "api/news-notify.ts": { "maxDuration": 15 },
         "api/tsa.ts": { "maxDuration": 30 },
-        "api/cron/refresh-tsa.ts": { "maxDuration": 30 }
+        "api/cron/refresh-tsa.ts": { "maxDuration": 30 },
+        "api/metar.ts": { "maxDuration": 15 },
+        "api/cron/refresh-metar.ts": { "maxDuration": 30 }
     },
     "crons": [
         { "path": "/api/cron/warm-schedules", "schedule": "0 */2 * * *" },
         { "path": "/api/cron/sync-starlink", "schedule": "0 */4 * * *" },
-        { "path": "/api/cron/refresh-tsa", "schedule": "*/5 * * * *" }
+        { "path": "/api/cron/refresh-tsa", "schedule": "*/5 * * * *" },
+        { "path": "/api/cron/refresh-metar", "schedule": "*/5 * * * *" }
     ],
   "buildCommand": "bun run build",
   "outputDirectory": "dist",


### PR DESCRIPTION
Root cause: AWC batch latency gated by its slowest station; 8s abort -> 504 -> whole weather panel blanks. Fix: per-station concurrent fan-out + last-known-good backfill, always 200 (partial). Adds warming cron. 597 tests pass; verified live against real AWC (200, 9/9, ~941ms).