### PR TITLE
fix(delay-explain): graceful 200 + circuit breaker for Anthropic credit/billing 400

### DIFF
--- a/api/delay-explain.ts
+++ b/api/delay-explain.ts
@@ -15,6 +15,25 @@ function getClient(): Anthropic {
 
 const cache = new CacheStore<string>('delay-explain', { maxSize: 200, defaultTTL: 5 * 60 * 1000 });
 
+// Calm, non-alarming copy the modal renders as plain text (frontend shows `explanation` verbatim
+// in the normal `.delay-explain-text` style on a 200; only non-2xx shows the ⚠️ error styling).
+// The risk score + contributing factors stay visible regardless, so this degrades gracefully.
+const AI_UNAVAILABLE_MSG =
+  'AI delay analysis is temporarily unavailable. The risk score and contributing factors shown above still reflect current conditions.';
+
+// Circuit breaker for billing/credit outages. When Anthropic rejects with a credit/billing 400 it
+// bills no tokens, but without this every "Explain Delay Risk" click would re-hit the API and log a
+// fresh 5xx — a daily error-feed flood for zero benefit. One billing error opens the circuit for a
+// cooldown; while open we short-circuit to the graceful 200 without calling Anthropic. Per-instance
+// (matches the rest of this codebase's serverless state model); a cold instance simply tries once.
+const AI_UNAVAILABLE_COOLDOWN_MS = 5 * 60 * 1000;
+let aiUnavailableUntil = 0;
+
+// Per-request input spend cap. Output is already bounded by max_tokens: 400; this bounds input so a
+// crafted-but-origin-valid POST can't inflate prompt tokens. Each field is already truncated by
+// sanitize(); this is a belt-and-suspenders ceiling on the assembled prompt.
+const MAX_PROMPT_CHARS = 2400;
+
 interface DelayContext {
   flight: string;
   route?: string;
@@ -81,6 +100,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(200).json({ explanation: cached, cached: true });
     }
 
+    // Billing circuit open: serve the graceful message without calling Anthropic.
+    if (Date.now() < aiUnavailableUntil) {
+      return res.status(200).json({ explanation: AI_UNAVAILABLE_MSG, unavailable: true });
+    }
+
     // Build context prompt with aircraft journey chain
     // All fields sanitized to mitigate prompt injection via crafted POST bodies
     const flight = sanitize(ctx.flight, 20);
@@ -110,6 +134,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // SDK call would keep running past the Lambda kill, Anthropic keeps
     // billing tokens, and the user sees a generic 5xx. 12s leaves a 3s
     // budget for handler teardown and response formatting.
+    // Per-request input ceiling (see MAX_PROMPT_CHARS): sanitize() already truncates each field;
+    // this bounds the assembled total so prompt-token spend per call can't be inflated.
+    const userPrompt = lines.join('\n').slice(0, MAX_PROMPT_CHARS);
+
     const anthropicAbort = new AbortController();
     const anthropicTimer = setTimeout(() => anthropicAbort.abort(), 12_000);
 
@@ -141,7 +169,7 @@ Analysis framework — discuss ONLY topics where data is provided:
 For LOW-risk flights with clean conditions, say so positively and briefly.
 
 Deliver 2-4 sentences of direct, specific analysis grounded in the provided data. Write in plain text only — no markdown, no headers, no bold, no bullet points.`,
-          messages: [{ role: 'user', content: lines.join('\n') }],
+          messages: [{ role: 'user', content: userPrompt }],
         },
         { signal: anthropicAbort.signal }
       );
@@ -163,6 +191,20 @@ Deliver 2-4 sentences of direct, specific analysis grounded in the provided data
     }
     if (e.status === 401) return res.status(503).json({ error: 'Invalid API key' });
     if (e.status === 429) return res.status(429).json({ error: 'AI rate limited — try again shortly' });
+    // Anthropic rejects a credit/billing problem as a 400 (no tokens billed). Don't surface it as a
+    // 5xx on every click: trip the circuit so we stop calling the API, and return a calm 200 the
+    // modal renders as plain text. Other client 400s (malformed request) are also non-retryable, so
+    // serve the same graceful message rather than a 502 error-feed entry — but don't open the
+    // circuit for those, since they're request-specific, not an account-wide outage.
+    if (e.status === 400) {
+      const msg = String(e?.error?.error?.message || e?.message || '').toLowerCase();
+      const isBilling = /credit balance|too low|billing|payment|insufficient|quota|upgrade|plan/.test(msg);
+      if (isBilling) {
+        aiUnavailableUntil = Date.now() + AI_UNAVAILABLE_COOLDOWN_MS;
+        console.warn(`Delay explain: Anthropic billing/credit error — AI-unavailable circuit open ${AI_UNAVAILABLE_COOLDOWN_MS / 1000}s`);
+      }
+      return res.status(200).json({ explanation: AI_UNAVAILABLE_MSG, unavailable: true });
+    }
     return res.status(502).json({ error: 'AI analysis temporarily unavailable' });
   }
 }

--- a/tests/delay-explain.test.js
+++ b/tests/delay-explain.test.js
@@ -203,4 +203,42 @@ describe('delay-explain API', () => {
     expect(prompt).toContain('100/100');
     expect(prompt).not.toContain('999');
   });
+
+  // --- Graceful AI-unavailable handling (must stay LAST: the billing case opens a module-level
+  // circuit breaker for 5 min, which would short-circuit any normal test that ran after it) ---
+
+  it('returns a graceful 200 (not 502) for a non-billing Anthropic 400, leaving the circuit closed', async () => {
+    mockCreate.mockRejectedValueOnce(Object.assign(new Error('invalid request: bad field'), { status: 400 }));
+    const res1 = createRes();
+    await handler(makeReq(), res1);
+    expect(res1.statusCode).toBe(200);
+    expect(res1.body.unavailable).toBe(true);
+    expect(res1.body.explanation).toMatch(/temporarily unavailable/i);
+
+    // Circuit must NOT be open for a generic 400 — the next call still reaches Anthropic.
+    mockCreate.mockResolvedValueOnce({ content: [{ type: 'text', text: 'fresh analysis' }] });
+    const res2 = createRes();
+    await handler(makeReq(), res2);
+    expect(res2.statusCode).toBe(200);
+    expect(res2.body.explanation).toBe('fresh analysis');
+  });
+
+  it('returns a graceful 200 for an Anthropic credit/billing 400 and opens the circuit', async () => {
+    mockCreate.mockRejectedValueOnce(
+      Object.assign(new Error('Your credit balance is too low to access the Anthropic API'), { status: 400 }),
+    );
+    const res = createRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.unavailable).toBe(true);
+    expect(res.body.explanation).toMatch(/temporarily unavailable/i);
+
+    // Circuit now open: a subsequent click serves the graceful message WITHOUT calling Anthropic.
+    mockCreate.mockClear();
+    const res2 = createRes();
+    await handler(makeReq(), res2);
+    expect(res2.statusCode).toBe(200);
+    expect(res2.body.unavailable).toBe(true);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Problem
`/api/delay-explain` is returning **502** in prod on every "Explain Delay Risk" click. Root cause: the BB Anthropic key is out of credit, so Anthropic rejects with a **400 "Your credit balance is too low"** — which fell through the catch block (handles only 401/429/AbortError) to the generic `502`. A 400 bills **no tokens**, so this is pure UX + error-feed damage, not a cost leak (the daily ~2× 502s the Jun-29 audit flagged).

## Fix (backend-only, no frontend change)
The dashboard renders `data.explanation` as plain text on a 200 and shows `err.error` with a ⚠️ on any non-200, so returning a calm 200 degrades gracefully on its own.

- **Credit/billing 400 → 200** with `{ explanation: "AI delay analysis is temporarily unavailable…", unavailable: true }`. The risk score + contributing factors above it stay visible.
- **Circuit breaker:** one billing error opens a 5-min per-instance circuit; subsequent clicks short-circuit to the graceful message **without calling Anthropic** — kills the repeated-error-log flood and pointless API calls during an outage.
- **Non-billing Anthropic 400s** also return the graceful 200 (instead of 502) but do **not** open the circuit (request-specific, not account-wide).
- **Per-request input cap** (`MAX_PROMPT_CHARS = 2400`) alongside the existing `max_tokens: 400` output cap.

## Tests
- +2 cases: billing 400 → 200 + circuit opens (next call skips Anthropic); non-billing 400 → 200 with circuit left closed (next call still reaches Anthropic).
- Circuit tests placed **last** in the describe block (module-level breaker state would pollute later tests otherwise).
- `bun run typecheck` clean · `bun run test` **747 pass** · `bun run build` ✓

## Still required separately
This only stops the broken error path. To restore *actual* explanations, **top up `ANTHROPIC_API_KEY` on `united-noc-vercel`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)