### PR TITLE
v1.5.22 feat(delay-explain): route Anthropic calls through Vercel AI Gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.22] - 2026-06-29
+
+### Changed
+- The "Explain Delay Risk" AI analysis now runs through Vercel AI Gateway instead of calling Anthropic directly, so its spend is tracked in one shared dashboard alongside the project's other AI features — at zero markup, with the same Claude Haiku model and prompt caching preserved. Graceful degradation is unchanged: a budget or credit outage (the gateway's `402`, the analog of Anthropic's billing `400`) trips the same circuit breaker and shows the calm "AI delay analysis is temporarily unavailable" message, with the risk score and contributing factors still visible.
+
 ## [1.5.21] - 2026-06-19
 
 ### Fixed

--- a/api/delay-explain.ts
+++ b/api/delay-explain.ts
@@ -8,7 +8,21 @@ const isRateLimited = createRateLimiter('delay-explain', 20);
 let client: Anthropic | null = null;
 function getClient(): Anthropic {
   if (!client) {
-    client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+    // Route through Vercel AI Gateway's Anthropic-compatible endpoint so spend
+    // lands in the shared AI Gateway dashboard (unified with Plaincast) at zero
+    // markup. The @anthropic-ai/sdk speaks the gateway's /v1/messages contract
+    // 1:1, so the call below is unchanged; auth is the gateway key sent as a
+    // Bearer token (authToken), not Anthropic's x-api-key. Override the host
+    // with AI_GATEWAY_BASE_URL if needed (e.g. to fall back to Anthropic-direct).
+    client = new Anthropic({
+      baseURL: process.env.AI_GATEWAY_BASE_URL || 'https://ai-gateway.vercel.sh',
+      // apiKey: null suppresses @anthropic-ai/sdk's default ANTHROPIC_API_KEY env
+      // read. Without it the SDK sends BOTH x-api-key (the old, now-unused
+      // Anthropic key still in Vercel env for rollback) AND Authorization: Bearer
+      // (the gateway key) on every request. Bearer-only is what the gateway wants.
+      apiKey: null,
+      authToken: process.env.AI_GATEWAY_API_KEY,
+    });
   }
   return client;
 }
@@ -83,7 +97,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(429).json({ error: 'Rate limited — try again shortly' });
   }
 
-  if (!process.env.ANTHROPIC_API_KEY) {
+  if (!process.env.AI_GATEWAY_API_KEY) {
     return res.status(503).json({ error: 'AI analysis unavailable — no API key configured' });
   }
 
@@ -191,6 +205,14 @@ Deliver 2-4 sentences of direct, specific analysis grounded in the provided data
     }
     if (e.status === 401) return res.status(503).json({ error: 'Invalid API key' });
     if (e.status === 429) return res.status(429).json({ error: 'AI rate limited — try again shortly' });
+    // Vercel AI Gateway returns 402 (Payment Required) when its budget/credit ceiling is hit — the
+    // gateway analog of Anthropic's billing-400 below. Trip the same circuit so we stop hammering it
+    // and serve the calm 200 the modal renders as plain text.
+    if (e.status === 402) {
+      aiUnavailableUntil = Date.now() + AI_UNAVAILABLE_COOLDOWN_MS;
+      console.warn(`Delay explain: AI Gateway budget/credit error (402) — AI-unavailable circuit open ${AI_UNAVAILABLE_COOLDOWN_MS / 1000}s`);
+      return res.status(200).json({ explanation: AI_UNAVAILABLE_MSG, unavailable: true });
+    }
     // Anthropic rejects a credit/billing problem as a 400 (no tokens billed). Don't surface it as a
     // 5xx on every click: trip the circuit so we stop calling the API, and return a calm 200 the
     // modal renders as plain text. Other client 400s (malformed request) are also non-retryable, so

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.21",
+  "version": "1.5.22",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/tests/delay-explain.test.js
+++ b/tests/delay-explain.test.js
@@ -39,7 +39,7 @@ describe('delay-explain API', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     mockCreate.mockReset();
-    process.env.ANTHROPIC_API_KEY = 'test-key';
+    process.env.AI_GATEWAY_API_KEY = 'test-key';
     mockCreate.mockResolvedValue({
       content: [{ type: 'text', text: 'This flight is delayed due to weather.' }],
     });
@@ -67,8 +67,8 @@ describe('delay-explain API', () => {
     expect(res.statusCode).toBe(200);
   });
 
-  it('returns 503 when ANTHROPIC_API_KEY is missing', async () => {
-    delete process.env.ANTHROPIC_API_KEY;
+  it('returns 503 when AI_GATEWAY_API_KEY is missing', async () => {
+    delete process.env.AI_GATEWAY_API_KEY;
     const res = createRes();
     await handler(makeReq(), res);
     expect(res.statusCode).toBe(503);
@@ -237,6 +237,33 @@ describe('delay-explain API', () => {
     mockCreate.mockClear();
     const res2 = createRes();
     await handler(makeReq(), res2);
+    expect(res2.statusCode).toBe(200);
+    expect(res2.body.unavailable).toBe(true);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // Gateway budget/credit failure (402) trips the same circuit breaker as the
+  // billing-400 case above. Isolated via resetModules + dynamic re-import so it
+  // runs against a CLOSED circuit — the billing-400 test above leaves the shared
+  // module's circuit open, and without a fresh module the early circuit-open
+  // return would make this pass vacuously without ever exercising the 402 branch.
+  it('returns a graceful 200 for a gateway 402 and opens the circuit', async () => {
+    vi.resetModules();
+    const { default: freshHandler } = await import('../api/delay-explain.js');
+    mockCreate.mockReset();
+    process.env.AI_GATEWAY_API_KEY = 'test-key';
+
+    mockCreate.mockRejectedValueOnce(Object.assign(new Error('Payment Required'), { status: 402 }));
+    const res = createRes();
+    await freshHandler(makeReq({ body: { flight: 'UAGW402' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.unavailable).toBe(true);
+    expect(res.body.explanation).toMatch(/temporarily unavailable/i);
+
+    // Circuit now open: a subsequent click serves the graceful message WITHOUT calling the gateway.
+    mockCreate.mockClear();
+    const res2 = createRes();
+    await freshHandler(makeReq({ body: { flight: 'UAGW402B' } }), res2);
     expect(res2.statusCode).toBe(200);
     expect(res2.body.unavailable).toBe(true);
     expect(mockCreate).not.toHaveBeenCalled();


### PR DESCRIPTION
## What

Reroute the **Explain Delay Risk** AI call (`api/delay-explain.ts`) from Anthropic-direct to **Vercel AI Gateway's Anthropic-compatible endpoint**, so Blueboard's LLM spend lands in the same shared Gateway dashboard/bill as the team's other AI projects — at zero markup, same Claude Haiku model, prompt caching preserved.

## How

- `getClient()` now targets `https://ai-gateway.vercel.sh` via `baseURL` + the gateway key as a Bearer `authToken`. `apiKey: null` suppresses the SDK's default `ANTHROPIC_API_KEY` env read (otherwise it would send both `x-api-key` *and* `Authorization: Bearer`).
- Env guard switched to `AI_GATEWAY_API_KEY`.
- Added a `402` branch (the gateway's budget/credit code) to the existing circuit breaker that already handles Anthropic's billing-`400` — graceful degradation preserved.
- The model call, prompt-cache semantics, 12s abort, sanitization, and cache are unchanged.

## Verification

- **Live smoke test** against the gateway: HTTP 200, `model: claude-haiku-4-5` accepted, `content[0].text` shape correct, `cache_*` tokens present (caching preserved).
- `bun run typecheck` ✅ · `bun run test` ✅ **748 pass** (added an isolated 402 circuit-breaker test) · `bun run build` ✅
- Independent pre-landing review (caught the dual-auth-header issue → `apiKey: null`).

## Deploy / rollback

- `AI_GATEWAY_API_KEY` is set in the Vercel **production** env (encrypted).
- Old `ANTHROPIC_API_KEY` left in place → rollback is a revert + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
