### PR TITLE
v1.5.24 fix(audit-jul2): false STARLINK integrity alert, unservable FR24 windows, honest logs, status casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.24] - 2026-07-02
+
+### Fixed
+- The STARLINK tab no longer raises a false "INTEGRITY ALERT" during the normal sync window. The served fleet comes from a 4-hourly snapshot while the disputed-tails ledger is near-live, so a tail verified minutes ago could look like a pipeline fault for up to 4 hours (observed live for N34131). The alert now fires only when the served snapshot post-dates the verification and still contains the tail — a genuine pipeline problem.
+- Schedule status text no longer mixes casings: provider-confirmed rows ("departed", "expected") are capitalized to match the inferred statuses ("Departed", "Landed") in the same column.
+- The FR24 official fallback no longer attempts tomorrow-window boards it can never serve — FR24 rejects any window starting tomorrow (UTC) with a validation 400, so each attempt only wasted an upstream call, a circuit-breaker slot, and produced recurring error-log noise (222 occurrences for EWR alone since April).
+- Quota-block log lines no longer print nonsense negative durations ("active for -1783016316s") on serverless instances that learned of the block from the Supabase mirror rather than seeing the 402 themselves.
+
+### Changed
+- The sync-starlink cron now logs a one-line success summary (aircraft count + sync time), so a silently shrinking fleet or a snapshot write degrading to a no-op is visible in runtime logs instead of hiding behind a bare 200.
+
 ## [1.5.23] - 2026-06-29
 
 ### Fixed

--- a/api/cron/sync-starlink.ts
+++ b/api/cron/sync-starlink.ts
@@ -47,6 +47,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // unconfigured, so the cron still reports success and the endpoint falls back to direct fetch.
     await saveStarlinkSnapshot(enriched);
 
+    // The 200 body is not captured in runtime logs, so without this line a healthy run is
+    // indistinguishable from a silently-degrading one (shrinking fleet, snapshot no-op).
+    console.log(`Cron sync-starlink: ${enriched.aircraft.length} aircraft synced at ${enriched.syncedAt}`);
+
     return res.status(200).json({
       status: 'ok',
       aircraft_count: enriched.aircraft.length,

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -917,7 +917,10 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
     return null;
   }
   if (isOfficialQuotaBlocked()) {
-    const secondsRemaining = Math.ceil((officialQuotaBlockedUntil - Date.now()) / 1000);
+    // Include the Supabase-mirrored block: on an instance that never saw the 402 itself the
+    // local blockedUntil is 0 and this log printed a nonsense negative epoch.
+    const blockedUntil = Math.max(officialQuotaBlockedUntil, getMirroredQuotaBlockedUntil());
+    const secondsRemaining = Math.ceil((blockedUntil - Date.now()) / 1000);
     console.warn(`Official FR24 API: quota block active for ${logHub}, skipping for ${secondsRemaining}s`);
     return null;
   }
@@ -928,6 +931,15 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
 
   const dayStart = new Date(ts * 1000);
   const dayEnd = new Date((ts + 86400 - 1) * 1000);
+
+  // FR24 rejects any window whose "from" falls on tomorrow's UTC date or later ("The flight
+  // datetime from field must be a date before tomorrow"), so a tomorrow-day board can never be
+  // served here — skip instead of burning an upstream call, a circuit-breaker slot, and log noise.
+  const tomorrowUtcMidnightMs = new Date().setUTCHours(0, 0, 0, 0) + 86400_000;
+  if (dayStart.getTime() >= tomorrowUtcMidnightMs) {
+    console.log(`Official FR24 API: window for ${logHub} ${dir} starts ${formatForFR24(dayStart)} (tomorrow UTC or later) — FR24 cannot serve it, skipping`);
+    return null;
+  }
 
   console.log(`Official FR24 API: fetching ${logHub} ${dir} (filter=${dir === 'departures' ? 'outbound' : 'inbound'}:${logHub}) from=${formatForFR24(dayStart)} to=${formatForFR24(dayEnd)} limit=${OFFICIAL_API_PAGE_SIZE}`);
 
@@ -1211,7 +1223,10 @@ const MAX_FALLBACKS_PER_WINDOW = 5;
 
 export function shouldAttemptOfficialFallback(): boolean {
   if (isOfficialQuotaBlocked()) {
-    const secondsRemaining = Math.ceil((officialQuotaBlockedUntil - Date.now()) / 1000);
+    // Mirror-aware, same as isOfficialQuotaBlocked(): local-only blockedUntil is 0 on instances
+    // that never saw the 402 themselves, which printed "-<epoch>s" here.
+    const blockedUntil = Math.max(officialQuotaBlockedUntil, getMirroredQuotaBlockedUntil());
+    const secondsRemaining = Math.ceil((blockedUntil - Date.now()) / 1000);
     console.warn(`Circuit breaker tripped: official API quota block active for ${secondsRemaining}s, skipping`);
     return false;
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.23",
+  "version": "1.5.24",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -56,6 +56,7 @@ let STARLINK_TAILS = new Set();
 let STARLINK_FLIGHTS_BY_TAIL = {};  // upcoming flights keyed by tail number
 let STARLINK_FLEET_STATS = null;    // { mainline, express, total }
 let STARLINK_LAST_UPDATED = null;   // ISO timestamp from upstream
+let STARLINK_SYNCED_AT = null;      // ISO timestamp of the served snapshot (BB sync-starlink cron)
 let STARLINK_INDUSTRY = null;       // [{ code, name, installed, total, percentage }] from /api/fleet-summary
 let pendingFleetDeepLinkFilter = null;
 
@@ -82,6 +83,7 @@ async function loadFleetData() {
       STARLINK_FLIGHTS_BY_TAIL = starlinkResult.flightsByTail || {};
       STARLINK_FLEET_STATS = starlinkResult.fleetStats || null;
       STARLINK_LAST_UPDATED = starlinkResult.lastUpdated || null;
+      STARLINK_SYNCED_AT = starlinkResult.syncedAt || null;
       starlinkLoaded = true;
     }
 
@@ -2668,13 +2670,23 @@ function fetchStarlinkMismatches() {
 }
 
 // Render-time integrity tripwire: disputed tails that upstream STILL serves in the equipped fleet.
-// Today this is empty (0 of the disputed set appear in STARLINK_TAILS), so the panel stays quiet.
 // If it ever becomes non-empty, renderSlVerification() raises an INTEGRITY ALERT and renderSlTable()
 // flags the offending rows.
+//
+// Propagation guard: the fleet comes from the 4-hourly sync-starlink snapshot while the disputed
+// ledger is near-live (45-min cache), so a tail verified AFTER the served snapshot was taken is a
+// normal, self-healing race (next cron prunes it) — not a pipeline fault. Alert only when the
+// snapshot POST-dates the verification and still contains the tail. Observed live Jul 2 2026:
+// N34131 verified 18:17Z against a 16:00Z snapshot rendered a false "check the data pipeline".
 function getServedConflictTails() {
   const set = new Set();
+  const syncedMs = STARLINK_SYNCED_AT ? Date.parse(STARLINK_SYNCED_AT) : NaN;
   for (const d of STARLINK_DISPUTED) {
-    if (d && d.tail && STARLINK_TAILS.has(d.tail)) set.add(d.tail);
+    if (!d || !d.tail || !STARLINK_TAILS.has(d.tail)) continue;
+    const verifiedMs = d.verifiedAt ? Date.parse(d.verifiedAt) : NaN;
+    // Both timestamps known and the dispute is newer than the served snapshot → propagation lag.
+    if (!isNaN(syncedMs) && !isNaN(verifiedMs) && verifiedMs > syncedMs) continue;
+    set.add(d.tail);
   }
   return set;
 }

--- a/src/lib/schedule-status.js
+++ b/src/lib/schedule-status.js
@@ -45,13 +45,19 @@ function effectiveTime(scheduled, estimated) {
   return e || s || 0;
 }
 
+// Provider status text arrives lowercase ('departed', 'expected') while inferred statuses are
+// title-case ('Departed'), so the same status column mixed casings. Capitalize at the source.
+function cap(text) {
+  return text ? text.charAt(0).toUpperCase() + text.slice(1) : text;
+}
+
 // Base classification from provider status text. Mirrors the original inline
 // classifySchedStatus logic exactly; the time-aware override is layered on top below.
 function classifyBase(flight) {
   const s = flight.status;
   if (!s) return { text: 'Unknown', cls: 'unknown', key: 'unknown' };
   const generic = s.generic?.status;
-  const txt = s.text || '';
+  const txt = cap(s.text || '');
   const statusText = generic?.text || '';
   const diverted = generic?.diverted;
   const txtLower = txt.toLowerCase();


### PR DESCRIPTION
Code half of the Jul 2 audit fixes (env half — AERODATABOX_DAILY_UNIT_BUDGET=700, SCHEDULE_OFFICIAL_FALLBACK_ENABLED=false, TIER_GATING_ENABLED removed — is already applied in Vercel and activates with this deploy).

## Fixes
- **STARLINK false INTEGRITY ALERT**: the fleet snapshot is 4-hourly while the disputed ledger is near-live, so a freshly verified tail (N34131, live Jul 2) rendered an alarming "check the data pipeline" for a normal self-healing propagation window. Alert now fires only when the served snapshot post-dates the verification and still contains the tail.
- **FR24 official fallback skips tomorrow-UTC windows** it can never serve (FR24 validation 400 — 222 wasted attempts for EWR alone since April; each also burned a circuit-breaker slot).
- **Quota-block logs**: no more `active for -1783016316s` — remaining time now computed from max(local, Supabase-mirrored) blockedUntil.
- **sync-starlink success log line** (count + syncedAt) — was a bare 200 with zero app output, invisible to log-based health checks.
- **Status casing**: provider "departed"/"expected" capitalized to match inferred "Departed"/"Landed".

## Verification
- `bun run typecheck` ✓, `bun run build` ✓
- `bun run test`: 760/761 — the 1 failure (`schedule.test.js` "persisted partial snapshot on cold start") fails identically on unmodified main at this UTC hour (pre-existing time-of-day-dependent flake; suite was 761/761 green this morning on the same commit).
- Targeted suites for touched modules (schedule-status, warm-schedules): 37/37 ✓

Deliberately deferred: NRT/GUM day-rollover warm gap (P2) — fixing it inside the warm ring risks the cron's 300s budget or skipped ring slots; needs its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)