### PR TITLE
v1.5.26: data-quality release — IROPS-honest statuses, reconciling stats, NOW-anchored boards, revived flight-times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.26] - 2026-07-03
+
+### Fixed
+- **Flight time lookups work again** (`/api/flight-times`): FlightAware's bot-wall returns a parseable-but-empty response, which was treated as "no active flight" for every flight — silently breaking My Flights card statuses ("LOADING..." forever, "() → ()" routes) and the Check-a-Connection tool. An empty parse now falls back to the FR24 Official API (only when the official-API kill switch is on) and then to the schedule snapshot layer, so times survive even with FlightAware blocked and FR24 credits exhausted. Failures now say why.
+- **Parked aircraft are no longer shown as "Departed" during delay programs.** The one-hour time-inference grace was systematically wrong under a ground-delay program (162 false "Departed" rows at ORD during the Jul 3 GDP; spot-checked aircraft were physically parked 3-4 hours). Boards now carry the hub's live FAA disruption magnitude, the inference grace stretches with it, and every time-inferred row is labeled "Departed*" with an explanation instead of masquerading as confirmed.
+- **"CanceledUncertain" is no longer a hard cancellation** (UA4809 was shown Canceled and flew on time — and the status rendered as the literal string "Canceleduncertain"). It is now its own soft "Likely Canceled" state, amber not red, grouped under the Canceled filter, overridden the moment real times arrive.
+- **One takeoff, one row, one OTP entry.** Schedule revisions produced duplicate rows for the same physical departure (counted both On Time and 2h48m Late), operating-carrier clones duplicated United Express flights ("GoJet to London Heathrow"), and foreign airlines leaked onto United boards (a Spirit flight on EWR). Boards now collapse revision and operator-code duplicates and drop foreign rows, with the collapse counts exposed in `meta.dedupe`.
+- **The stat strip no longer hides a third of the board.** Canceled flights (70 at ORD on Jul 3) were computed and thrown away; the cards did not sum to the total. There is now a CANCELED card, a presumed-departed chip, and an explicit "uncategorized" remainder — the cards reconcile with the total by construction, with a unit-tested invariant.
+- **The header ticker can no longer say "All systems normal" beside a red IROPS wall.** Ticker state now derives from the same hub-health/FAA/IROPS inputs as the Delays tab (ground stop > low OTP > GDP precedence), and the bare IROPS number is labeled ("IROPS 56.7/100") with an explainer.
+- **The DELAY column now contains the delay.** Departed/landed rows show the real delta (tabular figures, `+2h20m` formatting) instead of hiding it as fine print in the TIME cell, and AI predictions are labeled as predictions ("RISK: HIGH") instead of reading as facts. Column renamed "Delay / Risk".
+- **Today boards anchor at NOW.** A sticky "── NOW · 9:12 PM CDT ──" divider separates flown from upcoming, the board auto-scrolls there on load, yesterday's delayed-overnight rows carry a date chip ("Jul 2") instead of being indistinguishable from tonight's same-numbered flights, and a "Jump to now" pill returns you there.
+- **"Unknown" is no longer a passenger-facing status.** Rows the stale pipeline could not refresh (168 in one evening) render as "Scheduled · as of 7:12 PM CDT" instead of "Unknown"; the stale banner states an absolute as-of time and consequence instead of a vague age.
+- **OTP has a single writer.** The header hub percentages flapped (DEN 68→100→68) because a client-side recomputation with a 5-flight floor overwrote the server value on every refresh; the server IROPS value is now authoritative, and the client only fills gaps with a 25-flight minimum.
+- **Risk badges agree with themselves.** The same flight showed V.HIGH on the Schedule board and LOW on its My Flights card (missing inputs defaulted to LOW); cards now reuse the board's computed score, or say "RISK N/A" — never a fabricated LOW.
+- The dead "Delayed" status filter works: the provider's Delayed status now maps to the delayed key instead of disappearing into "Estimated".
+- Aircraft registrations are validated (a model string like "B737M9" served in the registration field now renders as "—" instead of passing through).
+- Starlink departures board times are hub-local with a timezone label, matching the Schedule tab (they were unlabeled viewer-local — the same flight showed two different wall clocks on one page).
+- Schedule search is findable and consistent: a "Find in board" input on the toolbar filters rows live (the only board filter used to hide inside the collapsed Filter drawer), the header search placeholder no longer switches to aircraft-lookup wording on the Schedule tab, and a failed lookup shows inline feedback instead of a blocking modal.
+- Watch notifications no longer fire on transitions into "Unknown" ("UA675: Unknown (was: Departed)" was pure noise); only meaningful status changes notify.
+- The Check-a-Connection inputs submit on Enter.
+- The GATE column is honestly labeled TERMINAL, both OTP tooltips state the same definition ("% of operated departures within 30 min of schedule"), "(412 opr)" reads "(412 operated)", and the mobile first viewport now shows the data-attribution and not-affiliated disclaimer via the ticker rotation.
+
+### Added
+- **IROPS-aware cache warming**: when a hub has an active FAA program, its today board jumps the warm-cron queue every run (displacing lower-priority slots, never growing the cron's budget) — attacking the root cause of stale boards during disruptions.
+
 ## [1.5.25] - 2026-07-03
 
 ### Fixed

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -91,7 +91,7 @@ function toUnixDateTime(value: any): number | null {
   return toUnixDateTime(value.utc || value.local);
 }
 
-function mapAeroStatus(status: any) {
+export function mapAeroStatus(status: any) {
   const s = String(status || '').trim();
   let text = 'scheduled';
   let type = '';
@@ -99,10 +99,17 @@ function mapAeroStatus(status: any) {
   let live = false;
   let icon = '';
 
-  if (s === 'Canceled' || s === 'CanceledUncertain') {
+  if (s === 'Canceled') {
     type = 'canceled';
     text = 'canceled';
     icon = 'red';
+  } else if (s === 'CanceledUncertain') {
+    // SOFT state: the provider suspects a cancellation but has not confirmed it. Keep it
+    // distinct from hard 'canceled' so classifySchedStatus can render "Likely Canceled" (warn)
+    // instead of red Canceled — the UI used to show the raw string "Canceleduncertain".
+    type = 'canceled_uncertain';
+    text = 'canceled_uncertain';
+    icon = 'yellow';
   } else if (s === 'Diverted') {
     diverted = true;
     text = 'landed';
@@ -119,7 +126,9 @@ function mapAeroStatus(status: any) {
     live = true;
     icon = 'green';
   } else if (s === 'Delayed') {
-    text = 'estimated';
+    // Map to the dedicated 'delayed' key (schedule-status.js already classifies it): the old
+    // generic 'estimated' mapping left the UI's "Delayed" filter permanently empty.
+    text = 'delayed';
     icon = 'yellow';
   }
 
@@ -129,6 +138,30 @@ function mapAeroStatus(status: any) {
     icon,
     live,
   };
+}
+
+// ── Registration validation ──
+// AeroDataBox occasionally puts an aircraft MODEL string in the reg field (observed live:
+// reg "B737M9" on ORD board rows). Validate the shape and drop anything that is not a
+// plausible tail number; the UI already renders a missing reg as "—".
+//   - US N-number fast path: N + 1-5 digits (no leading zero) + up to 2 trailing letters.
+//   - Hyphenated intl: 1-2 char country prefix, hyphen, 1-5 alphanumerics (C-FABC, B-1234, D-ABCD).
+//   - Common hyphenless intl forms the provider emits without the hyphen: JA#### (Japan),
+//     HL#### (Korea), B#### (exactly 4 digits, China/Taiwan — 3-digit/trailing-letter shapes
+//     like "B788"/"B38M"/"B77W" are aircraft MODEL codes, not tails).
+// A bare "letters+alnum" regex would pass "B737M9" (prefix B + 737M9), so hyphenless forms are
+// allowlisted narrowly instead.
+const REG_N_NUMBER = /^N[1-9]\d{0,4}[A-Z]{0,2}$/;
+const REG_HYPHENATED = /^[A-Z0-9]{1,2}-[A-Z0-9]{1,5}$/;
+const REG_HYPHENLESS_INTL = /^(JA\d{2,4}[A-Z]{0,2}|HL\d{4}|B\d{4})$/;
+
+export function validateRegistration(raw: any): string | null {
+  const reg = String(raw || '').trim().toUpperCase();
+  if (!reg || reg.length > 8) return null;
+  if (REG_N_NUMBER.test(reg) && reg.length <= 6) return reg;
+  if (REG_HYPHENATED.test(reg)) return reg;
+  if (REG_HYPHENLESS_INTL.test(reg)) return reg;
+  return null;
 }
 
 function isUnitedFlight(flight: any): boolean {
@@ -228,7 +261,7 @@ function normalizeFlight(flight: any, hub: string, dir: string) {
     },
     aircraft: {
       model: { code: '', text: flight?.aircraft?.model || '' },
-      registration: flight?.aircraft?.reg || '',
+      registration: validateRegistration(flight?.aircraft?.reg) || '',
     },
     _source: {
       provider: 'aerodatabox',
@@ -239,6 +272,114 @@ function normalizeFlight(flight: any, hub: string, dir: string) {
       ],
     },
   };
+}
+
+// ── Board-level dedupe + foreign-row filter ──
+// Observed live during the Jul 3 2026 ORD GDP:
+//   (a) schedule REVISIONS produce two rows for one physical departure (the legacy dedupe key
+//       includes the scheduled time, so a revised row survives it) — UA5982 counted both
+//       "On Time" and "+2h48 Late"; 16 dup groups at ORD.
+//   (b) operating-carrier CLONES: the same physical flight listed under both its UA marketing
+//       ident and the United Express operator ident ("G7929 to LHR").
+//   (c) clearly FOREIGN rows (NK/DL/AA idents) leaking through the codeshare filter (Spirit
+//       NK3005 on the EWR board).
+const UNITED_EXPRESS_CARRIERS = new Set(['OO', 'YV', 'YX', 'ZW', 'G7', 'C5', 'AX', 'EV']);
+const OPERATOR_CLONE_TOLERANCE_S = 300; // "same time" window for SCHEDULED clone matching (±5 min)
+// Real (runway/actual) timestamps are precise: two rows that both physically moved more than
+// 2 min apart are two aircraft, not one flight under two idents — never collapse them.
+const OPERATOR_CLONE_REAL_TOLERANCE_S = 120;
+
+function boardCarrierCode(flight: any): string {
+  const ident = String(flight?.identification?.number?.default || '').toUpperCase();
+  const m = /^([A-Z][A-Z0-9])\d/.exec(ident);
+  return m ? m[1] : '';
+}
+
+function boardRoute(flight: any): string {
+  return `${flight?.airport?.origin?.code?.iata || ''}>${flight?.airport?.destination?.code?.iata || ''}`;
+}
+
+function timesMatch(a: number | null | undefined, b: number | null | undefined, tolS: number): boolean {
+  return !!a && !!b && Math.abs(a - b) <= tolS;
+}
+
+export function dedupeBoardFlights(
+  flights: any[],
+  dir: string
+): { flights: any[]; dedupe: { revisions: number; operatorClones: number; foreign: number } } {
+  const isDep = dir === 'departures';
+  const dedupe = { revisions: 0, operatorClones: 0, foreign: 0 };
+
+  // (a) Collapse schedule-revision dupes: rows sharing flight number + the same REAL departure
+  // (or arrival) timestamp describe one physical movement; keep the row with the EARLIEST
+  // scheduled time (the ORIGINAL baseline). Both rows carry the same real timestamp, so keeping
+  // the original schedule preserves the true delay — keeping the latest revision (revised
+  // schedule ≈ real time) rendered UA5982's +2h48m GDP delay as "On Time". Rows without a real
+  // timestamp are never collapsed here — two same-numbered rows with different scheduled times
+  // and no actuals are legitimately two flights (morning + evening rotation of the same number).
+  const schedOf = (f: any) => (isDep ? f?.time?.scheduled?.departure : f?.time?.scheduled?.arrival) || 0;
+  const revisionKey = (f: any): string | null => {
+    const ident = String(f?.identification?.number?.default || '');
+    const real = isDep
+      ? (f?.time?.real?.departure || f?.time?.real?.arrival)
+      : (f?.time?.real?.arrival || f?.time?.real?.departure);
+    if (!ident || !real) return null;
+    return `${ident}:${real}`;
+  };
+  const revisionWinners = new Map<string, any>();
+  for (const f of flights) {
+    const key = revisionKey(f);
+    if (!key) continue;
+    const existing = revisionWinners.get(key);
+    // Earliest non-zero schedule wins; a row with no scheduled time at all never displaces one
+    // that carries the original baseline.
+    const candSched = schedOf(f);
+    const existingSched = existing ? schedOf(existing) : 0;
+    if (!existing || (candSched > 0 && (existingSched === 0 || candSched < existingSched))) {
+      revisionWinners.set(key, f);
+    }
+  }
+  const afterRevisions = flights.filter((f) => {
+    const key = revisionKey(f);
+    if (!key || revisionWinners.get(key) === f) return true;
+    dedupe.revisions++;
+    return false;
+  });
+
+  // (b)+(c) Non-UA idents: a row matching a UA row on route + time is the same physical flight
+  // listed under its operator/codeshare ident — keep the UA row. Real timestamps are the ground
+  // truth: when BOTH rows carry a real departure (arrival for arrivals boards), they are clones
+  // only if those real times match within ±120s — distinct real times are two physical aircraft
+  // even on the same route minutes apart (route + schedule ±5 min alone deleted legitimate
+  // United Express flights). A non-UA row that has a real time the UA row lacks is likewise a
+  // real flight; only a non-UA row with NO real times may match on schedule (±5 min). A
+  // non-matching row survives only if its carrier is a known United Express operator; anything
+  // else (NK/DL/AA/…) is a foreign leak and is dropped.
+  const uaRows = afterRevisions.filter((f) => boardCarrierCode(f) === 'UA');
+  const result = afterRevisions.filter((f) => {
+    const carrier = boardCarrierCode(f);
+    if (carrier === 'UA' || carrier === '') return true; // '' = unparseable ident, already UA-vetted upstream
+    const route = boardRoute(f);
+    const realT = isDep ? f?.time?.real?.departure : f?.time?.real?.arrival;
+    const schedT = isDep ? f?.time?.scheduled?.departure : f?.time?.scheduled?.arrival;
+    const clone = uaRows.some((u) => {
+      if (boardRoute(u) !== route) return false;
+      const uReal = isDep ? u?.time?.real?.departure : u?.time?.real?.arrival;
+      const uSched = isDep ? u?.time?.scheduled?.departure : u?.time?.scheduled?.arrival;
+      if (realT && uReal) return timesMatch(realT, uReal, OPERATOR_CLONE_REAL_TOLERANCE_S);
+      if (realT) return false; // this row physically moved at a time the UA row doesn't corroborate
+      return timesMatch(schedT, uSched, OPERATOR_CLONE_TOLERANCE_S);
+    });
+    if (clone) {
+      dedupe.operatorClones++;
+      return false;
+    }
+    if (UNITED_EXPRESS_CARRIERS.has(carrier)) return true;
+    dedupe.foreign++;
+    return false;
+  });
+
+  return { flights: result, dedupe };
 }
 
 async function fetchWindow(
@@ -412,7 +553,7 @@ export async function fetchViaAeroDataBox(
   }
 
   const seen = new Set<string>();
-  const flights: any[] = [];
+  const exactDeduped: any[] = [];
   for (const raw of rawFlights) {
     const normalized = normalizeFlight(raw, hub, dir);
     if (!normalized) continue;
@@ -422,7 +563,16 @@ export async function fetchViaAeroDataBox(
     const key = `${normalized.identification?.number?.default || ''}:${scheduleKey || ''}:${normalized.airport?.origin?.code?.iata || ''}:${normalized.airport?.destination?.code?.iata || ''}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    flights.push(normalized);
+    exactDeduped.push(normalized);
+  }
+
+  // The exact key above intentionally includes the scheduled time, so schedule revisions,
+  // operator-code clones and foreign codeshare leaks survive it — collapse those here.
+  const { flights, dedupe } = dedupeBoardFlights(exactDeduped, dir);
+  if (dedupe.revisions > 0 || dedupe.operatorClones > 0 || dedupe.foreign > 0) {
+    console.log(
+      `AeroDataBox dedupe for ${hub} ${dir}: collapsed ${dedupe.revisions} schedule-revision dupes, ${dedupe.operatorClones} operator-code clones; dropped ${dedupe.foreign} foreign rows`
+    );
   }
 
   const partial = failedWindows.length > 0;
@@ -449,6 +599,7 @@ export async function fetchViaAeroDataBox(
       completeness: pagesRequested > 0 ? Math.round((pagesSucceeded / pagesRequested) * 100) / 100 : 1,
       elapsedMs: Date.now() - startTime,
       source: 'aerodatabox',
+      dedupe,
     },
   };
 }

--- a/api/_schedule-snapshots.ts
+++ b/api/_schedule-snapshots.ts
@@ -38,6 +38,22 @@ export function shouldPersistPartialSnapshot(data: any): boolean {
   return total > 0 && getSnapshotCompleteness(data) >= MIN_PARTIAL_SNAPSHOT_COMPLETENESS;
 }
 
+// Dedupe-adjusted ranking total. dedupeBoardFlights lowers a board's `total` BECAUSE duplicate
+// revision rows, operator clones and foreign leaks were removed — not because coverage shrank.
+// Ranking on the raw total let a stale pre-dedupe snapshot (e.g. 717 rows, 17 of them dupes)
+// permanently outrank every fresh deduped board (700 rows) and refuse overwrite. A candidate
+// carrying meta.dedupe therefore ranks on total + rows it dropped; a snapshot without
+// meta.dedupe keeps its raw total, so equal underlying coverage ranks equal.
+function getRankingTotal(data: any): number {
+  const total = Number(data?.total || 0);
+  const dedupe = data?.meta?.dedupe;
+  if (!dedupe) return total;
+  return total
+    + (Number(dedupe.revisions) || 0)
+    + (Number(dedupe.operatorClones) || 0)
+    + (Number(dedupe.foreign) || 0);
+}
+
 export function isSnapshotCandidateBetter(candidate: any, existing: any): boolean {
   if (!existing) return true;
   if (!candidate?.partial) return true;
@@ -48,9 +64,14 @@ export function isSnapshotCandidateBetter(candidate: any, existing: any): boolea
   if (candidateCompleteness > existingCompleteness + 0.01) return true;
   if (candidateCompleteness + 0.01 < existingCompleteness) return false;
 
-  const candidateTotal = Number(candidate?.total || 0);
-  const existingTotal = Number(existing?.total || 0);
+  const candidateTotal = getRankingTotal(candidate);
+  const existingTotal = getRankingTotal(existing);
   if (candidateTotal !== existingTotal) return candidateTotal > existingTotal;
+
+  // Equal dedupe-adjusted totals: a deduped candidate REPLACES an un-deduped existing snapshot —
+  // same underlying coverage, but the fresh board is hygienic (and fresher) while the stale
+  // dup-laden one would otherwise pin until its 72h TTL.
+  if (candidate?.meta?.dedupe && !existing?.meta?.dedupe) return true;
 
   const candidatePages = Number(candidate?.meta?.pagesSucceeded || 0);
   const existingPages = Number(existing?.meta?.pagesSucceeded || 0);

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -13,6 +13,7 @@ import { UNITED_HUBS } from '../_hubs.js';
 import { isAuthorizedCronRequest } from '../_cron-auth.js';
 import { sendAlert } from '../_alert.js';
 import { hydrateAdbSpend, getAdbUnitsToday, getAdbDailyUnitBudget } from '../_cost-state.js';
+import { getDisruptedAirportsMap } from '../faa.js';
 import { getStartOfHubDay } from '../../src/lib/hubTz.js';
 
 const HUBS = UNITED_HUBS;
@@ -81,22 +82,105 @@ function buildWarmRing(): WarmTask[] {
   return ring;
 }
 
+// One slot per cron fire. SLOT_MS MUST match the cron interval in vercel.json (currently
+// hourly): a 15-min slot here while the cron fires hourly would stride 4× per fire and skip
+// most windows. Update both together. The same slot number seeds applyIropsPriority's
+// disrupted-hub rotation so priority fairness advances in lockstep with the ring.
+const SLOT_MS = 60 * 60 * 1000; // = vercel.json cron interval (0 * * * *)
+export function getWarmSlot(nowMs = Date.now()): number {
+  return Math.floor(nowMs / SLOT_MS);
+}
+
 export function buildWarmPlan(nowMs = Date.now()): WarmTask[] {
   const tasks = buildWarmRing();
 
   // Advance exactly one WARM_TASKS_PER_RUN stride per cron fire so consecutive fires cover the
-  // ring sequentially with no gaps. SLOT_MS MUST match the cron interval in vercel.json
-  // (currently hourly): a 15-min slot here while the cron fires hourly would stride 4× per fire
-  // and skip most windows. Update both together.
-  const SLOT_MS = 60 * 60 * 1000; // = vercel.json cron interval (0 * * * *)
+  // ring sequentially with no gaps.
   const tasksPerRun = getWarmTasksPerRun();
-  const slot = Math.floor(nowMs / SLOT_MS);
+  const slot = getWarmSlot(nowMs);
   const start = (slot * tasksPerRun) % tasks.length;
   const plan: WarmTask[] = [];
   for (let i = 0; i < Math.min(tasksPerRun, tasks.length); i++) {
     plan.push(tasks[(start + i) % tasks.length]);
   }
   return plan;
+}
+
+// ── IROPS-aware priority (pure) ──
+// During an active FAA program (GDP/ground stop/closure) a hub's TODAY board changes minute to
+// minute, but the stride-4 ring only revisits it ~every 6h. While hubs are disrupted, their
+// today windows ROTATE FAIRLY into the front of each run's stride: priority injections are
+// capped at stride-1 slots per run (at least one base ring slot always survives, so the ring
+// never fully stalls behind a long disruption), and the disrupted-hub order is rotated by the
+// same clock-derived slot pointer buildWarmPlan strides with — across consecutive runs every
+// disrupted hub's boards cycle through the capped priority slots instead of the first two hubs
+// in HUBS order winning every run and starving the rest. Injections replace the lowest-priority
+// slots of the stride (tomorrow slots first, then today slots of undisrupted hubs, from the
+// back), so the run's task count — and therefore the 300s budget and unit spend — is unchanged.
+// Priority tasks run first within the stride. Pure function; the handler feeds it the cached FAA
+// disruption map (api/faa.ts — one cached fetch per run, no per-task upstream call) plus the
+// current warm slot as the rotation seed.
+export function applyIropsPriority(
+  plan: WarmTask[],
+  disruptedHubs: Iterable<string>,
+  rotationSeed = 0
+): { plan: WarmTask[]; injected: string[]; displaced: string[] } {
+  const hubSet: ReadonlySet<string> = new Set(HUBS);
+  const disrupted: string[] = [];
+  for (const raw of Array.from(disruptedHubs)) {
+    const hub = String(raw || '').toUpperCase();
+    if (hubSet.has(hub) && !disrupted.includes(hub)) disrupted.push(hub);
+  }
+  if (disrupted.length === 0 || plan.length === 0) return { plan, injected: [], displaced: [] };
+
+  // Fair rotation: start the disrupted-hub order at the seed-derived offset so consecutive runs
+  // hand the capped priority slots to different hubs.
+  const offset = ((rotationSeed % disrupted.length) + disrupted.length) % disrupted.length;
+  const rotated = disrupted.map((_, i) => disrupted[(i + offset) % disrupted.length]);
+
+  const keyOf = (t: WarmTask) => `${t.hub}-${t.dir}-${t.dayOffset}`;
+  const isPriority = (t: WarmTask) => t.dayOffset === 0 && disrupted.includes(t.hub);
+
+  // Priority candidates in rotated hub order, departures before arrivals within a hub. The
+  // candidate rank also orders the priority tasks at the front of the returned plan.
+  const candidates: WarmTask[] = [];
+  for (const hub of rotated) {
+    for (const dir of ['departures', 'arrivals'] as const) {
+      candidates.push({ hub, dir, dayOffset: 0, label: 'today' });
+    }
+  }
+  const candidateRank = new Map(candidates.map((t, i) => [keyOf(t), i]));
+
+  const result = [...plan];
+  const injected: string[] = [];
+  const displaced: string[] = [];
+  // Cap injections at stride-1 so at least one base ring slot always survives (2 disrupted hubs
+  // used to consume the entire stride-4 run and starve the ring for the whole disruption).
+  const maxInjections = Math.max(0, plan.length - 1);
+
+  for (const task of candidates) {
+    if (injected.length >= maxInjections) break;
+    if (result.some((t) => keyOf(t) === keyOf(task))) continue; // stride already covers it
+    // Pick the lowest-priority victim: a tomorrow slot if any (scanning from the back), else
+    // the back-most today slot of an undisrupted hub. Never displace another priority task.
+    let victim = -1;
+    for (let i = result.length - 1; i >= 0; i--) {
+      if (isPriority(result[i])) continue;
+      if (result[i].dayOffset === 1) { victim = i; break; }
+      if (victim === -1) victim = i;
+    }
+    if (victim === -1) break; // every slot is already a disrupted-hub today task
+    displaced.push(`${result[victim].hub}-${result[victim].dir}-${result[victim].label}`);
+    result[victim] = task;
+    injected.push(`${task.hub}-${task.dir}-today`);
+  }
+
+  // Disrupted-hub today boards run first, in rotated candidate order; everything else keeps its
+  // ring order.
+  const rank = (t: WarmTask) => candidateRank.get(keyOf(t)) ?? Number.MAX_SAFE_INTEGER;
+  const priority = result.filter(isPriority).sort((a, b) => rank(a) - rank(b));
+  const rest = result.filter((t) => !isPriority(t));
+  return { plan: [...priority, ...rest], injected, displaced };
 }
 
 export function buildScheduleWarmUrl(hub: string, dir: string, timestamp: number): string {
@@ -190,7 +274,29 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   let warmed = 0;
   let failed = 0;
 
-  const warmPlan = buildWarmPlan();
+  let warmPlan = buildWarmPlan();
+
+  // IROPS priority: while hubs have active FAA programs, their today boards rotate fairly into
+  // the front of each run's stride (capped at stride-1 injections; same task count — lowest-
+  // priority ring slots are displaced, so the 300s budget holds). The warm slot seeds the
+  // rotation so consecutive runs prioritize different disrupted hubs.
+  try {
+    const disruptions = await getDisruptedAirportsMap();
+    const disruptedHubs = HUBS.filter((h) => (disruptions.get(h) || 0) > 0);
+    if (disruptedHubs.length > 0) {
+      const adjusted = applyIropsPriority(warmPlan, disruptedHubs, getWarmSlot());
+      console.log(
+        `IROPS warm priority engaged for ${disruptedHubs.map((h) => `${h}(${disruptions.get(h)}m)`).join(', ')}: ` +
+        (adjusted.injected.length
+          ? `injected [${adjusted.injected.join(', ')}] displacing [${adjusted.displaced.join(', ')}]`
+          : 'disrupted-hub boards already in this stride; reordered to run first')
+      );
+      warmPlan = adjusted.plan;
+    }
+  } catch (e: any) {
+    console.warn('IROPS warm priority lookup failed; using base ring plan:', e?.message || e);
+  }
+
   for (let i = 0; i < warmPlan.length; i++) {
     const task = warmPlan[i];
     // getStartOfHubDay (NOT irops' getStartOfDayForHub): the IROPS helper rolls back to YESTERDAY

--- a/api/faa.ts
+++ b/api/faa.ts
@@ -341,6 +341,123 @@ function parseXmlFallback(xml: string): FAAAirport[] {
   return results;
 }
 
+// --- Cached hub-disruption lookup (internal server consumers) ---
+// api/schedule.ts (board meta.hubDisruptionMinutes) and api/cron/warm-schedules.ts (IROPS-aware
+// warm priority) need "does hub X currently have an active FAA program, and how bad is it?"
+// WITHOUT adding an upstream FAA call per board request. This reuses the same nasstatus JSON
+// endpoint the handler above fetches, behind a small in-memory TTL cache with in-flight dedupe.
+
+// 10-minute TTL (positive AND negative): fresh enough for grace/warm decisions (FAA programs run
+// for hours), cheap enough that a board-serving lambda fetches FAA at most once per 10 minutes.
+// Deliberately generous so serve paths are effectively fetch-free after the first lookup.
+const FAA_DISRUPTION_CACHE_TTL_MS = 10 * 60 * 1000;
+const FAA_DISRUPTION_NEGATIVE_TTL_MS = 10 * 60 * 1000;
+const FAA_DISRUPTION_FETCH_TIMEOUT_MS = 5000;
+
+let disruptionCache: { byAirport: Map<string, number>; expires: number } | null = null;
+let disruptionInFlight: Promise<Map<string, number>> | null = null;
+
+/** Test-only: clear the disruption cache so tests control the fetch outcome. */
+export function __resetFaaDisruptionCacheForTests(): void {
+  disruptionCache = null;
+  disruptionInFlight = null;
+}
+
+/**
+ * Disruption magnitude for one FAA airport record, in minutes. 0 = no active program.
+ * Pure — exported for tests.
+ * - "Active" means a real traffic-management PROGRAM: ground stop, ground delay (GDP) or
+ *   closure. Routine departure/arrival delay advisories ("departure delays 31-45 min") are
+ *   normal-ops noise and deliberately do NOT count — they used to trigger IROPS warm priority
+ *   and the extended inference grace, contradicting the documented GDP/GS/closure contract.
+ * - Uses the worst published delay figure (avg preferred, then min) of the active programs.
+ * - A ground stop or closure with no published figure still means nothing is moving: floor 60.
+ * - Any other active program with no published figure gets a nominal 15 so it still reads as
+ *   "disrupted" (warm priority) without wildly inflating the departed-inference grace.
+ */
+export function computeHubDisruptionMinutes(airport: FAAAirport | null | undefined): number {
+  if (!airport) return 0;
+  const active = airport.groundStop || airport.groundDelay || airport.closure;
+  if (!active) return 0;
+  const worst = Math.max(airport.avgDelay ?? 0, airport.minDelay ?? 0);
+  if (worst > 0) return worst;
+  if (airport.groundStop || airport.closure) return 60;
+  return 15;
+}
+
+async function fetchDisruptionMap(): Promise<Map<string, number>> {
+  const byAirport = new Map<string, number>();
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FAA_DISRUPTION_FETCH_TIMEOUT_MS);
+    let upstream: Response;
+    try {
+      upstream = await fetch('https://nasstatus.faa.gov/api/airport-events', { signal: controller.signal });
+    } finally {
+      // finally, not the post-await pattern used elsewhere in this file: a rejected fetch would
+      // skip a trailing clearTimeout and leave the abort timer holding the controller up to 5s.
+      clearTimeout(timeout);
+    }
+    if (!upstream.ok) throw new Error(`HTTP ${upstream.status}`);
+    const json = await upstream.json();
+    if (!validateJsonResponse(json)) throw new Error('schema validation failed');
+    for (const airport of parseJsonResponse(json)) {
+      const minutes = computeHubDisruptionMinutes(airport);
+      if (minutes > 0) byAirport.set(airport.airportCode.toUpperCase(), minutes);
+    }
+    disruptionCache = { byAirport, expires: Date.now() + FAA_DISRUPTION_CACHE_TTL_MS };
+  } catch (e: any) {
+    console.warn('FAA disruption lookup failed (treating all hubs as undisrupted):', e?.message || e);
+    // Negative-cache the empty map briefly so a dead FAA endpoint doesn't add a fetch per board.
+    disruptionCache = { byAirport, expires: Date.now() + FAA_DISRUPTION_NEGATIVE_TTL_MS };
+  }
+  return byAirport;
+}
+
+/** Cached map of airportCode -> disruption minutes for every airport with an active program. */
+export async function getDisruptedAirportsMap(): Promise<Map<string, number>> {
+  if (disruptionCache && Date.now() < disruptionCache.expires) return disruptionCache.byAirport;
+  if (disruptionInFlight) return disruptionInFlight;
+  disruptionInFlight = fetchDisruptionMap().finally(() => { disruptionInFlight = null; });
+  return disruptionInFlight;
+}
+
+/**
+ * Synchronous, never-fetching peek at the cached disruption magnitude for one hub, in minutes.
+ * Returns the last-known cached value — even one past its TTL (a slightly stale magnitude beats
+ * a false 0 mid-GDP) — or 0 when nothing has been fetched yet. Serve paths use this instead of
+ * awaiting getHubDisruptionMinutes so a cache-hit board response never blocks up to 5s on a cold
+ * FAA fetch; pair with kickDisruptionRefresh() to warm a cold/expired cache in the background.
+ */
+export function peekHubDisruptionMinutes(hub: string): number {
+  if (!disruptionCache) return 0;
+  return disruptionCache.byAirport.get(String(hub || '').toUpperCase()) || 0;
+}
+
+/**
+ * Start (or join) a background refresh of the disruption map when the cache is cold or expired.
+ * Returns the in-flight promise — hand it to waitUntil so the lambda stays alive long enough —
+ * or null when the cache is fresh and nothing needs doing. Never rejects: fetchDisruptionMap
+ * catches internally and negative-caches failures.
+ */
+export function kickDisruptionRefresh(): Promise<Map<string, number>> | null {
+  if (disruptionCache && Date.now() < disruptionCache.expires) return null;
+  if (!disruptionInFlight) {
+    disruptionInFlight = fetchDisruptionMap().finally(() => { disruptionInFlight = null; });
+  }
+  return disruptionInFlight;
+}
+
+/** Current FAA disruption magnitude for one hub, in minutes (0 = none / lookup unavailable). */
+export async function getHubDisruptionMinutes(hub: string): Promise<number> {
+  try {
+    const map = await getDisruptedAirportsMap();
+    return map.get(String(hub || '').toUpperCase()) || 0;
+  } catch {
+    return 0;
+  }
+}
+
 // --- Handler ---
 
 // Track consecutive JSON failures for exponential backoff

--- a/api/flight-times.ts
+++ b/api/flight-times.ts
@@ -1,9 +1,23 @@
 // Flight Times API — scrapes FlightAware for departure/arrival times
 // Usage: /api/flight-times?flight=UA2221
 // Returns scheduled, estimated, and actual gate/takeoff/landing times
+//
+// Source chain (Jul 3 2026 audit: FlightAware's bot-wall serves a parseable trackpollBootstrap
+// with ZERO flights, which the old code treated as authoritative "No active flight found" —
+// killing the endpoint for every flight):
+//   1. FlightAware scrape (source: 'flightaware')
+//   2. FR24 Official API flight-summary (source: 'fr24') — HARD-GATED on isOfficialFr24Enabled():
+//      the kill switch is OFF in prod while credits are exhausted, so this tier must be skippable
+//   3. Schedule snapshot layer (source: 'schedule-cache') — the boards already hold sched/est/real
+//      times server-side; look the flight number up across the persisted hub board snapshots
+// Only when ALL tiers fail does the endpoint return success:false with a reason.
 
 import type { VercelRequest, VercelResponse } from './types.js';
 import { icaoToIata } from '../src/lib/airport-metadata.js';
+import { isOfficialFr24Enabled } from './_official-fr24.js';
+import { loadScheduleSnapshot } from './_schedule-snapshots.js';
+import { UNITED_HUBS } from './_hubs.js';
+import { getStartOfHubDay } from '../src/lib/hubTz.js';
 
 const CACHE_TTL_MS = 60_000; // 1 minute
 const cache = new Map<string, { data: any; ts: number }>();
@@ -71,10 +85,12 @@ export function epochToISO(epoch: number | undefined | null): string {
   return new Date(epoch * 1000).toISOString();
 }
 
-async function tryFR24Summary(req: VercelRequest, res: VercelResponse, flight: string, cacheKey: string) {
-  if (!process.env.FR24_API_TOKEN) {
-    return res.status(404).json({ success: false, error: 'No flight data available' });
-  }
+// FR24 Official API flight-summary tier. Returns a result payload or null — never writes the
+// response itself, so the caller can continue down the fallback chain.
+async function fetchFr24Summary(flight: string): Promise<any | null> {
+  if (!process.env.FR24_API_TOKEN) return null;
+  // Paid official API: honour the operator kill switch (credits exhausted → OFF in prod).
+  if (!isOfficialFr24Enabled()) return null;
   try {
     // Convert UAL2221 -> UA2221 for FR24
     const fr24Flight = flight.replace('UAL', 'UA');
@@ -96,7 +112,7 @@ async function tryFR24Summary(req: VercelRequest, res: VercelResponse, flight: s
     );
     clearTimeout(timeout);
     if (!resp.ok) {
-      return res.status(404).json({ success: false, error: 'No flight data available' });
+      return null;
     }
     const data = await resp.json();
     const flights = (data as any)?.data || [];
@@ -105,7 +121,7 @@ async function tryFR24Summary(req: VercelRequest, res: VercelResponse, flight: s
       || flights.find((fl: any) => !fl.flight_ended)
       || flights[0];
     if (!f) {
-      return res.status(404).json({ success: false, error: 'No flight data available' });
+      return null;
     }
     const result = {
       success: true,
@@ -132,17 +148,109 @@ async function tryFR24Summary(req: VercelRequest, res: VercelResponse, flight: s
       status: f.flight_ended ? 'landed' : 'en-route',
       cancelled: false,
       diverted: !!(f.dest_icao_actual && f.dest_icao && f.dest_icao !== f.dest_icao_actual),
-      source: 'fr24-summary',
+      source: 'fr24',
       cached: false,
     };
     if (f.orig_icao) result.origin.iata = icaoToIata(f.orig_icao);
     if (f.dest_icao_actual || f.dest_icao) result.destination.iata = icaoToIata(f.dest_icao_actual || f.dest_icao);
-    setCache(cacheKey, result);
-    res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
-    return res.status(200).json(result);
+    return result;
   } catch (e) {
-    return res.status(404).json({ success: false, error: 'No flight data available' });
+    return null;
   }
+}
+
+// Schedule snapshot tier: the hub boards already carry scheduled/estimated/real times server-side
+// (api/schedule.ts caches + api/_schedule-snapshots.ts persistence). Look the flight number up
+// across today's persisted hub boards — departures first (richer origin-side data), then
+// arrivals. Reads only the durable snapshot layer (shared across lambdas); no upstream calls.
+async function fetchScheduleCacheTimes(flight: string): Promise<any | null> {
+  const flightNum = flight.replace('UAL', 'UA');
+  try {
+    for (const dir of ['departures', 'arrivals'] as const) {
+      const snapshots = await Promise.all(
+        UNITED_HUBS.map(async (hub) => {
+          const ts = getStartOfHubDay(hub, 0);
+          return loadScheduleSnapshot(`agg:${hub}:${dir}:${ts}`);
+        })
+      );
+      for (const snapshot of snapshots) {
+        const flights = snapshot?.data?.flights;
+        if (!Array.isArray(flights)) continue;
+        const match = flights.find(
+          (f: any) => String(f?.identification?.number?.default || '').toUpperCase() === flightNum
+        );
+        if (!match) continue;
+
+        const time = match.time || {};
+        const generic = match.status?.generic?.status || {};
+        return {
+          success: true,
+          flight: flightNum,
+          origin: {
+            iata: match.airport?.origin?.code?.iata || '',
+            name: match.airport?.origin?.name || '',
+            terminal: match.airport?.origin?.info?.terminal || '',
+            gate: match.airport?.origin?.info?.gate || '',
+            tz: '',
+          },
+          destination: {
+            iata: match.airport?.destination?.code?.iata || '',
+            name: match.airport?.destination?.name || '',
+            terminal: match.airport?.destination?.info?.terminal || '',
+            gate: match.airport?.destination?.info?.gate || '',
+            tz: '',
+          },
+          departure: {
+            gate: {
+              scheduled: epochToISO(time.scheduled?.departure),
+              estimated: epochToISO(time.estimated?.departure),
+              actual: epochToISO(time.real?.departure),
+            },
+            takeoff: { scheduled: '', estimated: '', actual: '' },
+          },
+          arrival: {
+            landing: { scheduled: '', estimated: '', actual: '' },
+            gate: {
+              scheduled: epochToISO(time.scheduled?.arrival),
+              estimated: epochToISO(time.estimated?.arrival),
+              actual: epochToISO(time.real?.arrival),
+            },
+          },
+          aircraft: match.aircraft?.model?.text || match.aircraft?.model?.code || '',
+          status: generic.text || '',
+          cancelled: match.status?.generic?.type === 'canceled' || generic.text === 'canceled',
+          diverted: !!generic.diverted,
+          source: 'schedule-cache',
+          cached: false,
+        };
+      }
+    }
+  } catch (e: any) {
+    console.warn('flight-times schedule-cache lookup failed:', e?.message || e);
+  }
+  return null;
+}
+
+// Run the FR24 → schedule-cache fallback chain and write the response. `reason` records WHY the
+// primary (FlightAware) tier failed, and is only surfaced when every tier fails.
+async function respondViaFallbacks(res: VercelResponse, flight: string, cacheKey: string, reason: string) {
+  const fr24 = await fetchFr24Summary(flight);
+  if (fr24) {
+    setCache(cacheKey, fr24);
+    res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
+    return res.status(200).json(fr24);
+  }
+  const schedCache = await fetchScheduleCacheTimes(flight);
+  if (schedCache) {
+    setCache(cacheKey, schedCache);
+    res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
+    return res.status(200).json(schedCache);
+  }
+  return res.status(404).json({
+    success: false,
+    error: 'No flight data available',
+    reason: `${reason}; fr24 and schedule-cache fallbacks unavailable`,
+  });
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -185,7 +293,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     clearTimeout(timeout);
 
     if (!resp.ok) {
-      return await tryFR24Summary(req, res, flight, cacheKey);
+      return await respondViaFallbacks(res, flight, cacheKey, `flightaware HTTP ${resp.status}`);
     }
 
     // Cap response body size to prevent a misbehaving or malicious FlightAware
@@ -199,15 +307,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // catastrophic regex backtracking on unexpected input shapes.
     const match = html.match(/trackpollBootstrap\s*=\s*(\{[\s\S]{1,200000}?\});\s*(?:var|<\/script)/);
     if (!match) {
-      // FlightAware blocked — try FR24 summary as fallback
-      return await tryFR24Summary(req, res, flight, cacheKey);
+      // FlightAware blocked — fall down the chain
+      return await respondViaFallbacks(res, flight, cacheKey, 'flightaware blocked (no bootstrap)');
     }
 
     let bootstrap: any;
     try {
       bootstrap = JSON.parse(match[1]);
     } catch (e) {
-      return await tryFR24Summary(req, res, flight, cacheKey);
+      return await respondViaFallbacks(res, flight, cacheKey, 'flightaware bootstrap unparseable');
     }
 
     // Find the most relevant flight — scan ALL activity log entries, prefer in-air
@@ -230,7 +338,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const bestFlight = candidates[0]?.flight || null;
 
     if (!bestFlight) {
-      return res.status(404).json({ success: false, error: 'No active flight found' });
+      // A bootstrap that parses but contains ZERO flights is FlightAware's bot-wall, not a
+      // definitive "this flight does not exist" — treat it as a source failure and fall through
+      // to FR24 / the schedule snapshot layer instead of 404ing every flight. (Jul 3 2026 audit.)
+      return await respondViaFallbacks(res, flight, cacheKey, 'flightaware bootstrap empty (bot-wall)');
     }
 
     const f = bestFlight;
@@ -288,6 +399,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(200).json(result);
   } catch (e) {
     console.error('FlightAware scrape error:', e);
-    return await tryFR24Summary(req, res, flight, cacheKey);
+    return await respondViaFallbacks(res, flight, cacheKey, 'flightaware fetch error');
   }
 }

--- a/api/irops.ts
+++ b/api/irops.ts
@@ -71,6 +71,11 @@ interface WorstDelay {
   delay: number;
 }
 
+// 'canceled_uncertain' is AeroDataBox's soft-cancel state ("Likely Canceled"); it groups under
+// Canceled everywhere else in the UI, so the server-side metrics must count it too — otherwise
+// likely-canceled rows vanish from the IROPS index and the Delays tab cancellation counts.
+const CANCELED_STATUSES = new Set(['canceled', 'cancelled', 'canceled_uncertain']);
+
 export function computeMetrics(flightsByHub: Record<string, any[]>) {
   let allFlights: any[] = [];
   const hubMetrics: Record<string, HubMetric> = {};
@@ -81,7 +86,7 @@ export function computeMetrics(flightsByHub: Record<string, any[]>) {
 
     for (const fl of flights) {
       const status = fl.status?.generic?.status?.text?.toLowerCase() || '';
-      if (status === 'canceled' || status === 'cancelled') { hubMetrics[hub].cancellations++; continue; }
+      if (CANCELED_STATUSES.has(status)) { hubMetrics[hub].cancellations++; continue; }
       if (status === 'diverted') hubMetrics[hub].diversions++;
 
       const hasOperated = status === 'departed' || status === 'en-route' || status === 'landed' || status === 'diverted';
@@ -114,7 +119,7 @@ export function computeMetrics(flightsByHub: Record<string, any[]>) {
 
   for (const fl of allFlights) {
     const status = fl.status?.generic?.status?.text?.toLowerCase() || '';
-    if (status === 'canceled' || status === 'cancelled') cancellations++;
+    if (CANCELED_STATUSES.has(status)) cancellations++;
     if (status === 'diverted') diversions++;
 
     const schedT = fl.time?.scheduled?.departure || 0;

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -12,6 +12,7 @@ import {
   hasConfiguredFr24ScraperTransport,
 } from './_fr24-scraper-transport.js';
 import { getStartOfDayForHub } from './irops.js';
+import { peekHubDisruptionMinutes, kickDisruptionRefresh } from './faa.js';
 import { waitUntil } from '@vercel/functions';
 import { icaoToIata, isInternationalRoute } from '../src/lib/airport-metadata.js';
 import { getStartOfHubDay } from '../src/lib/hubTz.js';
@@ -1735,6 +1736,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const currentAggKey = `agg:${hub}:${dir}:${ts}`;
     aggKey = currentAggKey;
 
+    // Live FAA disruption magnitude for this hub (meta.hubDisruptionMinutes). The frontend feeds
+    // it into classifySchedStatus so a GDP hub stops time-inferring false "Departed" rows.
+    // NON-BLOCKING: every serve path below — including sub-millisecond cache hits — attaches the
+    // synchronously PEEKED cached value; a cold/expired FAA cache kicks a background refresh via
+    // waitUntil instead of making the serve await the (up to 5s) FAA fetch. The first request
+    // after a cold start reads 0 and the refresh warms the value for subsequent serves.
+    const disruptionRefresh = kickDisruptionRefresh();
+    if (disruptionRefresh) enqueueBackgroundTask(disruptionRefresh);
+    const withDisruption = (payload: any) => ({
+      ...payload,
+      meta: { ...(payload?.meta || {}), hubDisruptionMinutes: peekHubDisruptionMinutes(hub) },
+    });
+
     // Authorized cron warms bypass every serve-from-cache path below: a complete snapshot would
     // otherwise satisfy the warm request, report "ok", and never be refetched — freezing the board
     // for the rest of the day while it self-reports completeness 1.0.
@@ -1760,7 +1774,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       !!(getLastComplete(currentAggKey) || getLastCompleteByHubDir(hub, dir, ts));
     if (cached && !shouldBypassEmptyPartialCache && !shouldBypassPartialForComplete) {
       setAggregateCacheHeader(res, cached.data, cdnMaxAge, swr, wantsForce);
-      return res.status(200).json({ ...cached.data, cached: true });
+      return res.status(200).json(withDisruption({ ...cached.data, cached: true }));
     }
 
     const stale = forceRefresh ? null : cacheGetStale(currentAggKey);
@@ -1778,7 +1792,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         });
       }
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-      return res.status(200).json({ ...stale.data, cached: true, stale: !isFreshComplete(stale) });
+      return res.status(200).json(withDisruption({ ...stale.data, cached: true, stale: !isFreshComplete(stale) }));
     }
 
     const exactLastComplete = forceRefresh ? null : getLastComplete(currentAggKey);
@@ -1797,7 +1811,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         });
       }
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-      return res.status(200).json(buildDegradedResponse(fallbackComplete, exactLastComplete ? 'exact' : 'hub_dir'));
+      return res.status(200).json(withDisruption(buildDegradedResponse(fallbackComplete, exactLastComplete ? 'exact' : 'hub_dir')));
     }
 
     let partialPersistentFallback: Awaited<ReturnType<typeof getPersistentFallback>> | null = null;
@@ -1821,7 +1835,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           });
         }
         res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-        return res.status(200).json(buildDegradedResponse(persistentFallback, persistentFallback.fallbackScope));
+        return res.status(200).json(withDisruption(buildDegradedResponse(persistentFallback, persistentFallback.fallbackScope)));
       }
     }
 
@@ -1833,7 +1847,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       const result = await pendingAggs.get(currentAggKey);
       if (result) {
         setAggregateCacheHeader(res, result, cdnMaxAge, swr, wantsForce);
-        return res.status(200).json({ ...result, cached: true });
+        return res.status(200).json(withDisruption({ ...result, cached: true }));
       }
     }
 
@@ -1858,13 +1872,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const lc = exactLc || getLastCompleteByHubDir(hub, dir, ts);
         if (lc) {
           res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-          return res.status(200).json(buildDegradedResponse(lc, exactLc ? 'exact' : 'hub_dir'));
+          return res.status(200).json(withDisruption(buildDegradedResponse(lc, exactLc ? 'exact' : 'hub_dir')));
         }
 
         const persistentResult = await getPersistentFallback(currentAggKey);
         if (persistentResult && persistentResult.fallbackScope === 'persistent') {
           res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-          return res.status(200).json(buildDegradedResponse(persistentResult, 'persistent'));
+          return res.status(200).json(withDisruption(buildDegradedResponse(persistentResult, 'persistent')));
         }
         // Only prefer the stale persisted partial snapshot when it genuinely outranks the board we
         // just built. The fresh board may be an official+live-feed merge (richer, higher completeness
@@ -1872,14 +1886,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         // Reuses the exact ranking the snapshot writer uses, so serve-path and persist-path agree.
         if (partialPersistentFallback && !isSnapshotCandidateBetter(result, partialPersistentFallback.data)) {
           res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-          return res.status(200).json(buildDegradedResponse(partialPersistentFallback, 'persistent_partial'));
+          return res.status(200).json(withDisruption(buildDegradedResponse(partialPersistentFallback, 'persistent_partial')));
         }
       }
       // The cron's force URL is its own CDN object (forceRefresh=1 is part of the query string).
       // Never let it pin: a CDN HIT on the warm URL would silently skip the refresh next cycle.
       // (The partial branches above set s-maxage=60, which expires long before the next warm.)
       setAggregateCacheHeader(res, result, cdnMaxAge, swr, wantsForce);
-      return res.status(200).json(result);
+      return res.status(200).json(withDisruption(result));
     } finally {
       // Compare-and-delete (see triggerBackgroundRefresh): never evict an entry that a
       // concurrent forced warm registered over this one.
@@ -1890,8 +1904,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (aggKey) {
       const persistentFallback = await getPersistentFallback(aggKey);
       if (persistentFallback) {
+        // Error-path serve: still attach the disruption context — peeked synchronously (cached
+        // value or 0, never fetches, never throws), same non-blocking contract as the main path.
+        const hubFromKey = /^agg:([A-Z]{3,4}):/.exec(aggKey)?.[1] || '';
+        const hubDisruptionMinutes = hubFromKey ? peekHubDisruptionMinutes(hubFromKey) : 0;
+        const degraded = buildDegradedResponse(persistentFallback, persistentFallback.fallbackScope);
         res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-        return res.status(200).json(buildDegradedResponse(persistentFallback, persistentFallback.fallbackScope));
+        return res.status(200).json({ ...degraded, meta: { ...degraded.meta, hubDisruptionMinutes } });
       }
     }
     return res.status(502).json({ error: 'Upstream service unavailable' });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.25",
+  "version": "1.5.26",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1153,3 +1153,26 @@ table,thead th,tbody td,.stat-val,.metric-val,.big-number,.ticker,.ticker-item,.
   #tip-strip:not([style*="none"])~main .tab-content.active:not(#tab-live){top:140px}
   #news-banner[style*="flex"]~#tip-strip:not([style*="none"])~main .tab-content.active:not(#tab-live){top:178px}
 }
+
+/* ═══ DQ-JUL3: data-quality release (frontend) ═══ */
+/* Likely Canceled (canceled_uncertain) — warning yellow, distinct from confirmed-red */
+.sched-status.warn{background:rgba(234,179,8,.15);color:var(--ua-yellow)}
+/* "as of <board time>" sub-stamp under statuses rendered from stale/unknown provider data */
+.sched-asof{font-size:8px;color:var(--ua-dim);margin-top:2px;font-family:var(--font-ui)}
+/* Date chip on rows from a previous hub-local date (yesterday's stragglers) */
+.sched-date-chip{display:inline-block;margin-left:4px;padding:0 4px;border:1px solid var(--ua-border);border-radius:3px;font-size:8px;color:var(--ua-muted);font-family:var(--font-mono);letter-spacing:.3px;vertical-align:1px}
+/* DELAY / RISK column: real deltas right-aligned in tabular figures */
+.sched-delay-cell{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}
+.sched-delay-actual{font-family:var(--font-mono);font-size:10px;font-weight:600}
+.sched-delay-none{color:var(--ua-dim)}
+/* Sticky "── NOW ──" divider row inside the schedule scroll container */
+.sched-now-divider td{position:sticky;top:0;z-index:3;background:var(--ua-panel-elevated);color:var(--ua-amber);font-family:var(--font-mono);font-size:9px;font-weight:700;letter-spacing:1px;text-align:center;padding:4px 8px;border-top:1px solid var(--ua-amber);border-bottom:1px solid var(--ua-border)}
+/* "Jump to now" toolbar pill */
+.sched-jump-now{background:none;border:1px solid var(--ua-border);color:var(--ua-accent);padding:4px 10px;font-family:var(--font-mono);font-size:10px;border-radius:20px;cursor:pointer;transition:border-color .15s ease,color .15s ease}
+.sched-jump-now:hover{border-color:var(--ua-accent)}
+/* Sub-strip notes under the schedule stat cards (presumed count, FAA lag warning) */
+#sched-stats-note{display:flex;gap:12px;flex-wrap:wrap;align-items:center;margin:2px 0 6px}
+.sched-note-chip{color:var(--ua-muted);font-family:var(--font-mono);font-size:9px;letter-spacing:.3px}
+.sched-note-warn{color:var(--ua-yellow);font-family:var(--font-ui);font-size:10px}
+/* Compact disclaimer/attribution item in the ticker rotation */
+.ticker-item.disclaimer{color:var(--ua-dim)}

--- a/public/index.html
+++ b/public/index.html
@@ -192,7 +192,7 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
   <span class="cdiv"></span>
 
   <!-- HUB HEALTH BAR (inline hub cluster inside the canopy) -->
-  <div id="hub-health-bar" aria-live="polite" title="On-Time Performance: % of operated flights within 30 min of schedule (departures + arrivals). 🟢 >70% · 🟡 50-70% · 🔴 <50%"><span class="hh-label">Hub Health</span><span class="hh-explainer">ON-TIME %</span><span class="hh-info" tabindex="0" role="button" aria-label="Hub health explanation">?<span class="hh-tooltip" role="tooltip">% of operated flights within 30 min of schedule (departures &amp; arrivals). 🟢 &gt;70% · 🟡 50–70% · 🔴 &lt;50%</span></span><span style="color:var(--ua-muted)">Loading…</span></div>
+  <div id="hub-health-bar" aria-live="polite" title="On-Time Performance: % of operated departures within 30 min of schedule. 🟢 >70% · 🟡 50-70% · 🔴 <50%"><span class="hh-label">Hub Health</span><span class="hh-explainer">ON-TIME %</span><span class="hh-info" tabindex="0" role="button" aria-label="Hub health explanation">?<span class="hh-tooltip" role="tooltip">% of operated departures within 30 min of schedule. 🟢 &gt;70% · 🟡 50–70% · 🔴 &lt;50%</span></span><span style="color:var(--ua-muted)">Loading…</span></div>
   <span class="cdiv"></span>
 
   <!-- TICKER (alert zone, flex-grows to fill the middle) -->
@@ -205,6 +205,7 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
   <div id="global-search-wrap">
     <input type="text" id="global-search-input" aria-label="Global flight search" placeholder="Track a flight (UA 1234, N12345, ORD...)">
     <div id="global-search-results" aria-label="Search results" style="position:absolute;top:34px;left:0;right:0;background:rgba(17,24,39,.97);border:1px solid var(--ua-border);border-radius:4px;max-height:300px;overflow-y:auto;display:none;z-index:775"></div>
+    <div id="global-search-error" role="alert" style="display:none;position:absolute;top:34px;left:0;right:0;background:rgba(17,24,39,.97);border:1px solid rgba(239,68,68,.4);border-radius:4px;padding:6px 10px;font-size:10px;color:var(--ua-red);z-index:775"></div>
   </div>
   <span class="cdiv"></span>
 
@@ -397,6 +398,8 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
           <option value="departures">Departures</option>
           <option value="arrivals">Arrivals</option>
         </select>
+        <input type="text" id="sched-find" aria-label="Find in board" placeholder="Find in board…" style="background:var(--ua-panel);color:var(--ua-text);border:1px solid var(--ua-border);padding:4px 8px;font-family:var(--font-mono);font-size:10px;border-radius:3px;width:110px">
+        <button id="sched-jump-now" data-action="sched-jump-now" class="sched-jump-now" style="display:none" title="Scroll to the current time">⌖ Jump to now</button>
         <button id="sched-refresh-btn" data-action="schedule-refresh" style="background:var(--ua-blue);color:white;border:none;padding:4px 10px;font-family:var(--font-ui);font-size:10px;border-radius:3px;cursor:pointer">↻ Refresh</button>
         <button id="sched-more-filters-btn" data-action="schedule-more-filters" aria-expanded="false" aria-controls="sched-adv-filters" style="background:none;border:1px solid var(--ua-border);color:var(--ua-muted);padding:4px 10px;font-family:var(--font-ui);font-size:10px;border-radius:3px;cursor:pointer">Filter: Aircraft, Starlink, Delay… ▾</button>
         <div id="sched-adv-filters" style="display:none;align-items:center;gap:8px;flex-wrap:wrap">
@@ -453,6 +456,7 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
   </div>
   <div id="equip-change-summary"></div>
   <div id="sched-stats" class="metric-row" style="margin:4px 0"></div>
+  <div id="sched-stats-note" style="display:none"></div>
   <div class="card" style="padding:0;overflow:hidden">
     <div id="sched-loading" style="text-align:center;padding:10px;color:var(--ua-muted);font-size:11px">
       <div style="font-size:24px;margin-bottom:8px">📅</div>
@@ -467,9 +471,9 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
             <th scope="col" data-sort="route" style="cursor:pointer;min-width:140px">Route</th>
             <th scope="col" data-sort="aircraft" style="cursor:pointer">Aircraft</th>
             <th scope="col" data-sort="reg" style="cursor:pointer">Reg</th>
-            <th scope="col">Gate</th>
+            <th scope="col">Term / Gate</th>
             <th scope="col" data-sort="status" style="cursor:pointer;min-width:130px">Status ↕</th>
-            <th scope="col" style="width:45px">Delay</th>
+            <th scope="col" style="min-width:80px">Delay / Risk</th>
             <th scope="col">Fleet</th>
             <th scope="col"><span aria-hidden="true">👁️</span><span class="sr-only">Watch</span></th>
           </tr>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -11,6 +11,11 @@ import { classifySchedStatus } from '../lib/schedule-status.js';
 import { getStartOfHubDay, getHubDayLabel } from '../lib/hubTz.js';
 import { formatDataAge, dataAgeSeverity } from '../lib/data-age.js';
 import { parseFr24Feed, applyFeedResult, feedFreshness, nextFeedRetryDelay } from '../lib/feed-health.js';
+import { formatDelayMinutes, delayColorVar } from '../lib/delay-format.js';
+import { firstFutureIndex, nowDividerIndex } from '../lib/board-now.js';
+import { deriveOpsHealth } from '../lib/ops-health.js';
+import { displayScheduleStatus } from '../lib/status-display.js';
+import { computeScheduleStatCounts } from '../lib/board-stats.js';
 
 injectSpeedInsights();
 
@@ -1863,6 +1868,19 @@ function updateTicker() {
   const airborne = allFlights.filter(f=>!f.onGround).length;
   const items = [];
 
+  // Ops health first: derived from the SAME inputs the IROPS panel uses (hub OTP,
+  // FAA programs at UA hubs, IROPS index) so the ticker can never say "all systems
+  // normal" while the Delays tab shows a red IROPS night. (Audit Jul 3 2026.)
+  const opsHealth = deriveOpsHealth({
+    hubOtps: hubHealthData,
+    faaIndex: faaDelayIndex,
+    hubCodes: ['ORD','DEN','IAH','EWR','SFO','IAD','LAX','NRT','GUM'],
+    iropsScore: lastIropsScore,
+  });
+  if (opsHealth.level !== 'normal') {
+    items.push({ text: `⚠️ ${opsHealth.text}`, cls: 'advisory' });
+  }
+
   if (allFlights.length > 0) {
     items.push({ text: `${airborne} United flights airborne`, cls: 'info' });
     // Show fleet counts only after fleet data has loaded — avoids misleading "0 aircraft" on initial render
@@ -1880,11 +1898,16 @@ function updateTicker() {
     }
   });
 
-  // Default message when no alerts
+  // Default message only when nothing above is an advisory/critical item — an
+  // active disruption item suppresses the green "all systems normal" line.
   if (items.length === 0 || items.every(i => i.cls === 'info')) {
     const countStr = allFlights.length > 0 ? ` — tracking ${allFlights.length} United flights` : '';
     items.unshift({ text: `✅ All systems normal${countStr}`, cls: 'info' });
   }
+
+  // Compact disclaimer/attribution in the rotation so it is visible in the mobile
+  // first viewport (the footer is far below the fold on phones).
+  items.push({ text: 'Unofficial — not affiliated with United Airlines · Data: AeroDataBox · FR24 · AWC · FAA', cls: 'disclaimer' });
 
   const tickerHtml = items.map(i => `<span class="ticker-item ${escapeHtml(i.cls)}">${escapeHtml(i.text)}</span>`).join('');
   const tickerEl = document.getElementById('ticker');
@@ -2589,12 +2612,22 @@ function isRecentlyFound(dateFound) {
   return t <= now + 86400000 && (now - t) <= 7 * 86400000;
 }
 
-// Format an upstream departure timestamp (UNIX seconds) as a short local HH:MM hint.
-function formatFlightTime(ts) {
+// Format an upstream departure timestamp (UNIX seconds) as a short HH:MM hint.
+// Hub-local with the hub TZ abbreviation when the airport is a known hub — the
+// Schedule tab is hub-local, and the FIDS board showing unlabeled viewer-local
+// times next to it was silently inconsistent (audit Jul 3 2026). Non-hub airports
+// fall back to viewer-local but ALWAYS carry a TZ label so the time is never
+// ambiguous.
+function formatFlightTime(ts, airportIata) {
   if (!ts) return '';
   const d = new Date(ts * 1000);
   if (isNaN(d.getTime())) return '';
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const tz = SCHED_HUB_TZ[airportIata];
+  if (tz) {
+    return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: tz })
+      + ' ' + getHubTzAbbrev(airportIata);
+  }
+  return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false, timeZoneName: 'short' });
 }
 
 // Map of tail → live airborne flight from the LIVE OPS feed. One pass over allFlights; cheap enough
@@ -3066,7 +3099,7 @@ function renderSlRoutesBoard() {
 // airframe, and live status (📡 Track reuses the existing delegated sl-track → focusFlight action;
 // the callsign opens the existing aircraft-detail modal). All fields are escaped.
 function renderSlBoardRow(r, now) {
-  const t = formatFlightTime(r.departure_ts);
+  const t = formatFlightTime(r.departure_ts, r.origin);
   const mins = Math.round((r.departure_ts - now) / 60);
   let rel;
   if (mins < 0) rel = Math.abs(mins) + 'm ago';
@@ -3246,7 +3279,7 @@ function renderSlTable() {
         // Next UPCOMING departure (flights are chronological; 30-min grace for one that just left),
         // falling back to the latest known flight if all are in the past.
         const next = flights.find(f => (f.departure_ts || 0) >= nowSec - 1800) || flights[flights.length - 1];
-        const t = formatFlightTime(next.departure_ts);
+        const t = formatFlightTime(next.departure_ts, next.origin);
         nextHtml = `<td style="font-size:9px">${escapeHtml(next.flight_number || '')} ${escapeHtml((next.origin || '') + '→' + (next.destination || ''))}${t ? ` <span class="starlink-next-time">${escapeHtml(t)}</span>` : ''}</td>`;
       } else {
         nextHtml = '<td style="font-size:9px;color:var(--ua-muted)">—</td>';
@@ -3281,9 +3314,9 @@ function renderSlExpand(s, live, hasFlights, hasLive, nowSec) {
   let timelineHtml = '<div class="sl-timeline-label">Upcoming Flights</div>';
   if (upcoming.length > 0) {
     timelineHtml += upcoming.map(f => {
-      const dep = formatFlightTime(f.departure_ts);
+      const dep = formatFlightTime(f.departure_ts, f.origin);
       const arrMs = f.arrival_time ? Date.parse(f.arrival_time) : NaN;
-      const arr = isNaN(arrMs) ? '' : formatFlightTime(arrMs / 1000);
+      const arr = isNaN(arrMs) ? '' : formatFlightTime(arrMs / 1000, f.destination);
       return `<div class="sl-fl-row"><span class="sl-fl-num">${escapeHtml(f.flight_number || '')}</span>` +
         `<span class="sl-fl-route">${escapeHtml(f.origin || '')} <span class="sl-arrow">→</span> ${escapeHtml(f.destination || '')}</span>` +
         `<span class="sl-fl-time">${escapeHtml(dep)}${arr ? ' – ' + escapeHtml(arr) : ''}</span></div>`;
@@ -4336,6 +4369,28 @@ let schedInitialized = false;
 let schedSortCol = 'time';
 let schedSortAsc = true;
 let schedLoading = false;
+let schedBoardMeta = null;        // meta object from the last loaded board (may be null/partial on old cached payloads)
+let schedMetaByHub = {};          // key: "hub-dir-day" → that board's meta (disruption minutes are PER HUB)
+let schedBoardFetchedAtMs = 0;    // when the current board arrived on this client
+
+// Threads the board's live FAA disruption magnitude into classification so the
+// disruption-extended operated-inference grace (schedule-status.js) actually engages.
+// Without this opts plumbing at every classify call site, the GDP guard is dead code
+// and stale boards mint false "Departed" rows again (review Jul 3 2026).
+function classifyOptsFor(meta) {
+  const v = Number(meta?.hubDisruptionMinutes);
+  return { hubDisruptionMinutes: Number.isFinite(v) && v > 0 ? v : 0 };
+}
+// Per-hub variant for loops over schedRawByHub keys ("hub-dir-day").
+function classifyOptsForKey(hubKey) {
+  return classifyOptsFor(schedMetaByHub[hubKey]);
+}
+// Prefix lookup when only hub+dir are known (day defaults to today's board first).
+function metaForHubDir(hub, dir) {
+  return schedMetaByHub[`${hub}-${dir}-0`] || schedMetaByHub[`${hub}-${dir}-1`] || null;
+}
+let schedAutoScrollPending = false; // one-shot: scroll a freshly loaded TODAY board to "now"
+let schedLastFutureIdx = -1;      // row index of the first future row in the last render (-1 = none)
 
 // Client→server clock offset (seconds), learned from the schedule API's Date/Age headers on each
 // fetch. classifySchedStatus reclassifies a long-past "scheduled" flight as departed based on
@@ -4372,6 +4427,21 @@ function initScheduleTab() {
     document.getElementById('sched-timerange').addEventListener('change', schedFilterChanged);
     document.getElementById('sched-risk').addEventListener('change', schedFilterChanged);
     document.getElementById('sched-search').addEventListener('input', schedFilterChanged);
+    // "Find in board" lives directly on the toolbar and drives the SAME text
+    // predicate as the drawer's search input (two-way mirror, one filter).
+    const schedFind = document.getElementById('sched-find');
+    const schedDrawerSearch = document.getElementById('sched-search');
+    if (schedFind && schedDrawerSearch) {
+      schedFind.addEventListener('input', () => {
+        if (schedDrawerSearch.value !== schedFind.value) {
+          schedDrawerSearch.value = schedFind.value;
+          schedFilterChanged();
+        }
+      });
+      schedDrawerSearch.addEventListener('input', () => {
+        if (schedFind.value !== schedDrawerSearch.value) schedFind.value = schedDrawerSearch.value;
+      });
+    }
     // Sort headers
     document.querySelectorAll('#sched-table th[data-sort]').forEach(th => {
       th.addEventListener('click', () => {
@@ -4434,6 +4504,7 @@ async function preloadScheduleData() {
       const hubKey = `${hub}-departures-0`;
       if (result.flights?.length && !schedRawByHub[hubKey]) {
         schedRawByHub[hubKey] = result.flights;
+        schedMetaByHub[hubKey] = result.meta || null;
         loaded++;
       }
     } catch (e) { /* preload is best-effort */ }
@@ -4538,6 +4609,10 @@ async function loadScheduleData() {
 
     schedAllFlights = allUAFlights;
     schedRawByHub[hubKey] = allUAFlights;
+    schedBoardMeta = result.meta || null;
+    schedMetaByHub[hubKey] = result.meta || null;
+    schedBoardFetchedAtMs = Date.now();
+    schedAutoScrollPending = schedCurrentDay === 0; // anchor Today at NOW on load (tomorrow/yesterday boards skip)
     preloadWeatherAndFAA();
     detectEquipmentSwaps(allUAFlights, schedCurrentHub, schedCurrentDir, schedCurrentDay);
     populateAircraftFilter();
@@ -4551,20 +4626,22 @@ async function loadScheduleData() {
       const meta = result.meta || {};
       let msg = '';
       if (result.degraded && meta.dataAge != null) {
-        // Humanized + honest: "1775m ago while refreshing" hid a 30h-frozen board behind a
-        // reassuring teal banner promising a refresh that never came. != null (not truthiness):
-        // a just-written snapshot has dataAge 0, which must still render with age context.
+        // Absolute time + consequence, not just a relative age: "from 2h ago" made users do
+        // clock math and never said what it MEANS. "Statuses as of 7:12 PM CDT — live updates
+        // paused" states both. != null (not truthiness): a just-written snapshot has dataAge 0,
+        // which must still render with age context.
         const age = formatDataAge(meta.dataAge);
+        const asOf = formatBoardAsOf();
         msg = result.partial
-          ? `Showing cached partial data from ${age} ago.`
-          : `Showing cached complete data from ${age} ago.`;
+          ? `Statuses as of ${asOf} (partial board, ${age} old) — live updates paused.`
+          : `Statuses as of ${asOf} (${age} old) — live updates paused.`;
       } else if (result.stale && !result.partial && meta.dataAge != null) {
         // Complete but aged out of the fresh window (degraded=false: nothing is missing). PR #207
         // made these boards degraded=false for honesty, but the banner gate never checked
         // result.stale — so hours-old complete boards rendered with NO warning. This branch (and
         // the gate above) restores the warning; without it the chain falls to the misleading
         // "Some flights may be missing." default, a lie for a complete board.
-        msg = `Showing complete data from ${formatDataAge(meta.dataAge)} ago.`;
+        msg = `Statuses as of ${formatBoardAsOf()} (${formatDataAge(meta.dataAge)} old) — live updates paused.`;
       } else if (meta.liveFeedFallbackAdded) {
         msg = `Added ${meta.liveFeedFallbackAdded} live active flight(s) while the full schedule feed recovers.`;
       } else if (meta.partialReason === 'live_feed_fallback') {
@@ -4644,6 +4721,36 @@ function formatSchedTime(utcTimestamp, hub) {
   return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: tz });
 }
 
+// Absolute timestamp (ms) the current board's statuses are valid "as of".
+// Prefers meta.generatedAt when the API provides it; falls back to fetch-time
+// minus meta.dataAge; finally the fetch time itself. All fields defensive —
+// old cached payloads may lack any of them.
+function schedBoardAsOfMs() {
+  const meta = schedBoardMeta;
+  if (meta && meta.generatedAt) {
+    const t = Date.parse(meta.generatedAt);
+    if (!isNaN(t)) return t;
+  }
+  const base = schedBoardFetchedAtMs || Date.now();
+  if (meta && meta.dataAge != null && Number.isFinite(Number(meta.dataAge))) {
+    return base - Number(meta.dataAge) * 1000;
+  }
+  return base;
+}
+
+// "7:12 PM CDT" in the current hub's timezone — the absolute stamp used by the
+// stale banner and by "Scheduled (as of …)" unknown-status rows.
+function formatBoardAsOf(hub = schedCurrentHub) {
+  const tz = SCHED_HUB_TZ[hub] || 'America/Chicago';
+  try {
+    return new Date(schedBoardAsOfMs()).toLocaleTimeString('en-US', {
+      hour: 'numeric', minute: '2-digit', timeZone: tz, timeZoneName: 'short',
+    });
+  } catch (e) {
+    return new Date(schedBoardAsOfMs()).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  }
+}
+
 function getFilteredScheduleFlights(nowSec = schedNow()) {
   const statusFilter = document.getElementById('sched-status').value;
   const aircraftFilter = document.getElementById('sched-aircraft').value;
@@ -4655,10 +4762,13 @@ function getFilteredScheduleFlights(nowSec = schedNow()) {
   const searchFilter = document.getElementById('sched-search').value.toLowerCase().trim();
 
   return schedAllFlights.filter(fl => {
-    // Status filter
+    // Status filter. canceled_uncertain ("Likely Canceled") groups under the
+    // Canceled filter per the dq-jul3 contract — it is a cancellation for
+    // filtering purposes, just an unconfirmed one.
     if (statusFilter) {
-      const s = classifySchedStatus(fl, schedCurrentDir, nowSec);
-      if (s.key !== statusFilter) return false;
+      const s = classifySchedStatus(fl, schedCurrentDir, nowSec, classifyOptsFor(schedBoardMeta));
+      const filterKey = s.key === 'canceled_uncertain' ? 'canceled' : s.key;
+      if (filterKey !== statusFilter) return false;
     }
     // Aircraft filter
     if (aircraftFilter && fl.aircraft?.model?.code !== aircraftFilter) return false;
@@ -4698,7 +4808,7 @@ function getFilteredScheduleFlights(nowSec = schedNow()) {
     }
     // Delay risk filter
     if (riskFilter) {
-      const status = classifySchedStatus(fl, schedCurrentDir, nowSec);
+      const status = classifySchedStatus(fl, schedCurrentDir, nowSec, classifyOptsFor(schedBoardMeta));
       if (['scheduled', 'estimated', 'delayed'].includes(status.key)) {
         const risk = computeDelayRiskForScheduleFlight(fl, schedCurrentHub, nowSec);
         const riskLabel = risk ? risk.label : 'LOW';
@@ -4744,8 +4854,8 @@ function sortScheduleFlights(flights, nowSec = schedNow()) {
       case 'aircraft': return ((a.aircraft?.model?.code || '').localeCompare(b.aircraft?.model?.code || '')) * dir;
       case 'reg': return ((a.aircraft?.registration || '').localeCompare(b.aircraft?.registration || '')) * dir;
       case 'status': {
-        const sA = classifySchedStatus(a, schedCurrentDir, nowSec).key;
-        const sB = classifySchedStatus(b, schedCurrentDir, nowSec).key;
+        const sA = classifySchedStatus(a, schedCurrentDir, nowSec, classifyOptsFor(schedBoardMeta)).key;
+        const sB = classifySchedStatus(b, schedCurrentDir, nowSec, classifyOptsFor(schedBoardMeta)).key;
         return sA.localeCompare(sB) * dir;
       }
       default: return 0;
@@ -4799,9 +4909,17 @@ function renderScheduleTable() {
 
   if (sorted.length === 0) {
     tbody.innerHTML = `<tr><td colspan="10" style="text-align:center;padding:40px;color:var(--ua-muted)"><div style="font-size:24px;margin-bottom:8px">🔍</div>No flights match your filters<br><span style="font-size:10px">Try adjusting hub, status, or search criteria</span></td></tr>`;
+    schedLastFutureIdx = -1;
+    updateJumpNowPill(false);
     renderScheduleStats(filtered, now);
     return;
   }
+
+  // Shared per-render context for date chips and "as of" stamps.
+  const hubTzName = SCHED_HUB_TZ[hub] || 'America/Chicago';
+  let boardDayStartSec = 0;
+  try { boardDayStartSec = getStartOfHubDay(hub, schedCurrentDay); } catch (e) { boardDayStartSec = 0; }
+  const boardAsOfStr = formatBoardAsOf(hub);
 
   const rows = sorted.map(fl => {
     const ident = fl.identification?.number?.default || '—';
@@ -4809,6 +4927,15 @@ function renderScheduleTable() {
     const actualTime = schedCurrentDir === 'departures' ? (fl.time?.real?.departure || fl.time?.estimated?.departure) : (fl.time?.real?.arrival || fl.time?.estimated?.arrival);
     const derivedScheduleTime = schedCurrentDir === 'departures' ? fl._source?.scheduleTimeDerivedFromActual?.departure : fl._source?.scheduleTimeDerivedFromActual?.arrival;
     const timeStr = formatSchedTime(schedTime, hub);
+    // Rows from a previous hub-local date (yesterday's stragglers on a time-ascending
+    // board) get a small date chip so "06:52" is never mistaken for today's 06:52.
+    let dateChip = '';
+    if (schedTime && boardDayStartSec && schedTime < boardDayStartSec) {
+      try {
+        const chipLabel = new Date(schedTime * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: hubTzName });
+        dateChip = ` <span class="sched-date-chip">${escapeHtml(chipLabel)}</span>`;
+      } catch (e) { /* chip is decorative — never break the row */ }
+    }
     let timeExtra = '';
     if (derivedScheduleTime) {
       timeExtra = `<div class="sched-time-actual">actual</div>`;
@@ -4837,16 +4964,23 @@ function renderScheduleTable() {
 
     const oIata = orig?.code?.iata || '';
     const dIata = dest?.code?.iata || '';
+    // Terminal first, gate second ("T1 · C18") — the header says Term / Gate, so a bare
+    // gate value must never sit where a terminal is expected (review Jul 3 2026).
     let gate;
-    if (schedCurrentDir === 'departures') {
-      const t = orig?.info?.terminal || getUnitedTerminal(oIata, oIata, dIata);
-      gate = orig?.info?.gate ? orig.info.gate : (t ? `T${t}` : '—');
-    } else {
-      const t = dest?.info?.terminal || getUnitedTerminal(dIata, oIata, dIata);
-      gate = dest?.info?.gate ? dest.info.gate : (t ? `T${t}` : '—');
+    {
+      const ap = schedCurrentDir === 'departures' ? orig : dest;
+      const t = ap?.info?.terminal || (schedCurrentDir === 'departures'
+        ? getUnitedTerminal(oIata, oIata, dIata)
+        : getUnitedTerminal(dIata, oIata, dIata));
+      const g = ap?.info?.gate;
+      gate = t && g ? `T${t} · ${g}` : t ? `T${t}` : g ? `Gate ${g}` : '—';
     }
 
-    const status = classifySchedStatus(fl, schedCurrentDir, now);
+    const status = classifySchedStatus(fl, schedCurrentDir, now, classifyOptsFor(schedBoardMeta));
+    // Display layer: 'unknown' renders as "Scheduled (as of …)", canceled_uncertain
+    // gets its "Likely Canceled" label, raw provider strings get title-cased, and
+    // presumed (time-inferred) departures get the asterisk treatment.
+    const statusDisp = displayScheduleStatus(status);
 
     // Fleet match + enrichment
     let fleetMatch = '';
@@ -4910,7 +5044,7 @@ function renderScheduleTable() {
     const isWatched = isFlightWatched(ident);
     const { origCode, destCode, depHub, arrHub } = getScheduleRiskContext(fl, hub, schedCurrentDir);
     const watchRoute = `${origCode}→${destCode}`;
-    const watchBtn = ident !== '—' ? `<button class="watch-btn${isWatched ? ' watching' : ''}" data-action="toggle-watch-flight" data-flight="${escapeHtml(ident)}" data-route="${escapeHtml(watchRoute)}" data-status="${escapeHtml(status.text)}" data-stop-prop="1" aria-label="${isWatched ? 'Unwatch flight' : 'Watch flight'}" title="${isWatched ? 'Unwatch' : 'Watch'} this flight">${isWatched ? ICO_WATCHING : ICO_WATCH}</button>` : '';
+    const watchBtn = ident !== '—' ? `<button class="watch-btn${isWatched ? ' watching' : ''}" data-action="toggle-watch-flight" data-flight="${escapeHtml(ident)}" data-route="${escapeHtml(watchRoute)}" data-status="${escapeHtml(statusDisp.text)}" data-stop-prop="1" aria-label="${isWatched ? 'Unwatch flight' : 'Watch flight'}" title="${isWatched ? 'Unwatch' : 'Watch'} this flight">${isWatched ? ICO_WATCHING : ICO_WATCH}</button>` : '';
 
     // Delay risk scoring
     const dRisk = computeDelayRiskForScheduleFlight(fl, hub, now);
@@ -4919,90 +5053,178 @@ function renderScheduleTable() {
     const schedRiskWxDest = weatherOpsByHub[arrHub];
     const schedRiskIrops = iropsHubData[depHub];
     const schedRiskFaa = formatDelayExplainFAAStatus(depHub, arrHub, faaDelayIndex);
-    const riskCell = dRisk ? `<span class="delay-risk-badge" data-action="explain-delay" data-flight="${escapeHtml(ident)}" data-route="${escapeHtml(origCode + '\u2192' + destCode)}" data-status="${escapeHtml(status.text)}" data-risk-label="${dRisk.label}" data-risk-score="${dRisk.score}" data-risk-factors="${escapeHtml(dRisk.factors.join('|'))}" data-hub="${escapeHtml(depHub)}"${schedRiskOtp !== undefined ? ' data-otp="' + schedRiskOtp + '"' : ''}${schedRiskWxOrig ? ' data-weather="' + escapeHtml(schedRiskWxOrig.level + (schedRiskWxOrig.reasons.length ? ': ' + schedRiskWxOrig.reasons.join(', ') : '')) + '"' : ''}${schedRiskWxDest ? ' data-dest-weather="' + escapeHtml(schedRiskWxDest.level + (schedRiskWxDest.reasons.length ? ': ' + schedRiskWxDest.reasons.join(', ') : '')) + '"' : ''}${schedRiskIrops ? ' data-irops="' + escapeHtml(schedRiskIrops.cancellationRate + '% cancelled, ' + (schedRiskIrops.delayed60Rate || 0) + '% delayed 60min+') + '"' : ''}${schedRiskFaa ? ' data-faa-status="' + escapeHtml(schedRiskFaa) + '"' : ''} style="background:${dRisk.color}20;color:${dRisk.color};cursor:pointer" title="Click for AI analysis">${dRisk.label}</span>` : '';
+    const riskCell = dRisk ? `<span class="delay-risk-badge" data-action="explain-delay" data-flight="${escapeHtml(ident)}" data-route="${escapeHtml(origCode + '\u2192' + destCode)}" data-status="${escapeHtml(statusDisp.text)}" data-risk-label="${dRisk.label}" data-risk-score="${dRisk.score}" data-risk-factors="${escapeHtml(dRisk.factors.join('|'))}" data-hub="${escapeHtml(depHub)}"${schedRiskOtp !== undefined ? ' data-otp="' + schedRiskOtp + '"' : ''}${schedRiskWxOrig ? ' data-weather="' + escapeHtml(schedRiskWxOrig.level + (schedRiskWxOrig.reasons.length ? ': ' + schedRiskWxOrig.reasons.join(', ') : '')) + '"' : ''}${schedRiskWxDest ? ' data-dest-weather="' + escapeHtml(schedRiskWxDest.level + (schedRiskWxDest.reasons.length ? ': ' + schedRiskWxDest.reasons.join(', ') : '')) + '"' : ''}${schedRiskIrops ? ' data-irops="' + escapeHtml(schedRiskIrops.cancellationRate + '% cancelled, ' + (schedRiskIrops.delayed60Rate || 0) + '% delayed 60min+') + '"' : ''}${schedRiskFaa ? ' data-faa-status="' + escapeHtml(schedRiskFaa) + '"' : ''} style="background:${dRisk.color}20;color:${dRisk.color};cursor:pointer" title="Click for AI analysis">RISK: ${dRisk.label}</span>` : '';
+
+    // DELAY / RISK cell (#2): facts beat predictions. A row with a known
+    // actual/estimated delta shows the REAL delay (right-aligned tabular figures,
+    // +Nm under 90 min, +XhYYm above); only future rows without a meaningful delta
+    // show the AI risk badge — worded "RISK: …" so a prediction can never read as a
+    // fact. (Audit Jul 3 2026: a flight with a known +140m delay displayed "V.HIGH".)
+    const hasOperatedRow = status.key === 'departed' || status.key === 'enroute' || status.key === 'landed';
+    const isTerminalRow = status.key === 'canceled' || status.key === 'canceled_uncertain' || status.key === 'diverted';
+    const deltaMin = (actualTime && schedTime) ? Math.round((actualTime - schedTime) / 60) : null;
+    let delayCell;
+    if (isTerminalRow) {
+      delayCell = '<span class="sched-delay-none">\u2014</span>';
+    } else if (deltaMin !== null && ((hasOperatedRow && !statusDisp.presumed) || deltaMin > 5)) {
+      const deltaSrc = (fl.time?.real?.departure || fl.time?.real?.arrival) ? 'Actual' : 'Estimated';
+      delayCell = `<span class="sched-delay-actual" style="color:${delayColorVar(deltaMin)}" title="${deltaSrc} vs scheduled ${schedCurrentDir === 'departures' ? 'departure' : 'arrival'}">${escapeHtml(formatDelayMinutes(deltaMin))}</span>`;
+    } else if (riskCell) {
+      delayCell = riskCell;
+    } else {
+      delayCell = '<span class="sched-delay-none">\u2014</span>';
+    }
+
+    // Status cell: presumed rows render "Departed*" with an explanatory tooltip;
+    // unknown rows render "Scheduled" plus an absolute "as of" sub-stamp (#5/#6).
+    const presumedTip = statusDisp.presumed
+      ? ` title="Presumed ${status.key === 'landed' ? 'landed' : 'departed'} \u2014 scheduled time passed without a live update"`
+      : '';
+    let statusCell = `<span class="sched-status ${escapeHtml(statusDisp.cls)}"${presumedTip}>${escapeHtml(statusDisp.text)}${statusDisp.presumed ? '*' : ''}</span>`;
+    if (statusDisp.asOf) statusCell += `<div class="sched-asof">as of ${escapeHtml(boardAsOfStr)}</div>`;
 
     return `<tr>
-      <td>${escapeHtml(timeStr)}${timeExtra}</td>
+      <td>${escapeHtml(timeStr)}${dateChip}${timeExtra}</td>
       <td style="font-weight:600;color:var(--ua-accent)">${escapeHtml(ident)}</td>
       <td>${routeStr}</td>
       <td title="${escapeHtml(acText)}">${escapeHtml(acCode)}${acShort ? `<div style="font-size:9px;color:var(--ua-muted)">${escapeHtml(acShort)}</div>` : ''}${equipBadge}</td>
       <td style="font-family:var(--font-mono);font-size:10px">${reg !== '—' ? `<span class="ac-reg-link" data-action="aircraft-detail" data-reg="${escapeHtml(reg)}">${escapeHtml(reg)}</span>` : '—'}${schedSpecial ? ' <span class="special-badge">⭐ ' + escapeHtml(schedSpecial.name) + '</span>' : ''}${fleetEnrich}</td>
       <td>${escapeHtml(gate)}</td>
-      <td><span class="sched-status ${escapeHtml(status.cls)}">${escapeHtml(status.text)}</span>${faaContext}</td>
-      <td>${riskCell}</td>
+      <td>${statusCell}${faaContext}</td>
+      <td class="sched-delay-cell">${delayCell}</td>
       <td>${fleetMatch}</td>
       <td>${watchBtn}</td>
     </tr>`;
   });
 
+  // ── NOW anchor (#3): today boards only, and only under the default time-ascending
+  // sort (a divider is meaningless mid-list when sorted by flight/route/status).
+  // Tomorrow boards and boards with no future rows skip all of this gracefully —
+  // firstFutureIndex returns -1 with no future rows, and nowDividerIndex additionally
+  // returns -1 when there are no past rows to divide from.
+  schedLastFutureIdx = -1;
+  if (schedCurrentDay === 0 && schedSortCol === 'time' && schedSortAsc) {
+    const rowTimes = sorted.map(f => (schedCurrentDir === 'departures' ? f.time?.scheduled?.departure : f.time?.scheduled?.arrival) || 0);
+    schedLastFutureIdx = firstFutureIndex(rowTimes, now);
+    const divIdx = nowDividerIndex(rowTimes, now);
+    if (divIdx >= 0) {
+      // Re-rendered with a fresh HH:MM on every refresh (renderScheduleTable is the
+      // single render path), so the stamp tracks the clock.
+      const nowLabel = `${formatSchedTime(now, hub)} ${getHubTzAbbrev(hub)}`;
+      rows.splice(divIdx, 0, `<tr class="sched-now-divider" id="sched-now-row" aria-label="Current time marker"><td colspan="10">── NOW · ${escapeHtml(nowLabel)} ──</td></tr>`);
+    }
+  }
+  updateJumpNowPill(schedCurrentDay === 0 && schedLastFutureIdx >= 0);
+
   tbody.innerHTML = rows.join('');
+
+  // One-shot auto-scroll to NOW after a fresh board load (never on filter re-renders,
+  // never when the user is on another tab).
+  if (schedAutoScrollPending) {
+    schedAutoScrollPending = false;
+    if (schedLastFutureIdx >= 0 && document.getElementById('tab-schedule')?.classList.contains('active')) {
+      scrollScheduleToNow(false);
+    }
+  }
   renderScheduleStats(filtered);
+}
+
+// Show/hide the "Jump to now" toolbar pill (today boards with at least one future row).
+function updateJumpNowPill(visible) {
+  const pill = document.getElementById('sched-jump-now');
+  if (pill) pill.style.display = visible ? '' : 'none';
+}
+
+// Scroll the schedule table's scroll container to the NOW divider (or the first
+// future row when the divider was skipped because there are no past rows).
+function scrollScheduleToNow(smooth = true) {
+  const wrap = document.getElementById('sched-table-wrap');
+  const tbody = document.getElementById('sched-tbody');
+  if (!wrap || !tbody) return;
+  const target = document.getElementById('sched-now-row')
+    || (schedLastFutureIdx >= 0 ? tbody.children[schedLastFutureIdx] : null);
+  if (!target) return;
+  const top = Math.max(0, target.offsetTop - 60);
+  requestAnimationFrame(() => {
+    if (typeof wrap.scrollTo === 'function') wrap.scrollTo({ top, behavior: smooth ? 'smooth' : 'auto' });
+    else wrap.scrollTop = top;
+  });
 }
 
 function renderScheduleStats(filtered, nowSec = schedNow()) {
   if (!filtered) filtered = getFilteredScheduleFlights(nowSec);
-  const showing = filtered.length;
-  const statuses = {};
-  filtered.forEach(fl => {
-    const s = classifySchedStatus(fl, schedCurrentDir, nowSec);
-    statuses[s.key] = (statuses[s.key] || 0) + 1;
-  });
 
-  // OTP: only count flights with real departure/arrival data (actually operated)
-  let depOnTime = 0;
-  let depDelayed = 0;
-  let scheduled = 0;
-  let canceled = statuses.canceled || 0;
-  filtered.forEach(fl => {
-    const status = classifySchedStatus(fl, schedCurrentDir, nowSec);
-    const hasOperated = status.key === 'departed' || status.key === 'enroute' || status.key === 'landed';
-    if (!hasOperated) {
-      if (status.key === 'scheduled' || status.key === 'estimated') scheduled++;
-      return;
-    }
-    // Time-inferred departures have no trustworthy actual-out time — exclude from OTP so a
-    // stale "expected" row that we reclassified can't be scored as on-time/late.
-    if (status.inferred) return;
-    const schedT = schedCurrentDir === 'departures' ? fl.time?.scheduled?.departure : fl.time?.scheduled?.arrival;
-    const derivedScheduleTime = schedCurrentDir === 'departures' ? fl._source?.scheduleTimeDerivedFromActual?.departure : fl._source?.scheduleTimeDerivedFromActual?.arrival;
-    if (fl._source?.liveFeedFallback) return; // live rescue rows have last-seen/ETA times, not true schedule baselines
-    const realT = fl.time?.real?.departure || fl.time?.real?.arrival;
-    const actT = realT || (schedCurrentDir === 'departures' ? fl.time?.estimated?.departure : fl.time?.estimated?.arrival);
-    if (!schedT || !actT || derivedScheduleTime) return; // skip flights without a real schedule baseline
-    if (actT > schedT + 1800) depDelayed++;
-    else depOnTime++;
+  // Bucketing lives in src/lib/board-stats.js so the reconciliation invariant
+  // (cards + catch-all === Total) is unit-tested. Audit Jul 3 2026: the strip
+  // computed `canceled` but never rendered it — ORD showed Total 717 while the
+  // visible cards summed 475, hiding 70 cancellations on an IROPS night.
+  const counts = computeScheduleStatCounts(filtered, {
+    dir: schedCurrentDir,
+    nowSec,
+    classify: (fl) => classifySchedStatus(fl, schedCurrentDir, nowSec, classifyOptsFor(schedBoardMeta)),
   });
+  const showing = counts.total;
 
-  const totalOperated = depOnTime + depDelayed;
-  const otp = totalOperated > 0 ? Math.round((depOnTime / totalOperated) * 100) : (showing > 0 ? '—' : 0);
+  const otp = counts.otp != null ? counts.otp : (showing > 0 ? '\u2014' : 0);
   const otpColor = typeof otp === 'number' ? (otp >= 70 ? '#22c55e' : otp >= 50 ? '#f59e0b' : '#ef4444') : 'var(--ua-muted)';
   const otpStr = typeof otp === 'number' ? otp + '%' : otp;
 
   const dayLabel = getSchedDayLabel(schedCurrentDay);
   const dirLabel = schedCurrentDir === 'departures' ? 'DEP' : 'ARR';
 
+  const canceledTitle = counts.canceledUncertain > 0
+    ? ` title="Includes ${counts.canceledUncertain} likely canceled (unconfirmed by provider)"`
+    : '';
+  // Muted catch-all so the visible cards always reconcile with Total instead of
+  // lying by omission (diverted, operated rows without usable timestamps, etc.).
+  const uncatCard = counts.uncategorized > 0 ? `
+    <div class="metric-card" title="Rows that fit no card: diverted, or operated without usable timestamps">
+      <span class="metric-val" style="color:var(--ua-dim)">${counts.uncategorized}</span>
+      <span class="metric-label">Uncategorized</span>
+    </div>` : '';
+
   document.getElementById('sched-stats').innerHTML = `
     <div class="metric-card">
       <span class="metric-val">${showing}</span>
-      <span class="metric-label">UA ${dirLabel} · ${dayLabel}</span>
+      <span class="metric-label">UA ${dirLabel} \u00b7 ${dayLabel}</span>
     </div>
     <div class="metric-card">
       <span class="metric-val" style="color:${otpColor}">${otpStr}</span>
-      <span class="metric-label">On-Time (${totalOperated} opr)</span>
+      <span class="metric-label">On-Time (${counts.operated} operated)</span>
     </div>
     <div class="metric-card">
-      <span class="metric-val" style="color:var(--ua-green)">${depOnTime}</span>
+      <span class="metric-val" style="color:var(--ua-green)">${counts.onTime}</span>
       <span class="metric-label">On Time</span>
     </div>
     <div class="metric-card">
-      <span class="metric-val" style="color:var(--ua-yellow)">${depDelayed}</span>
+      <span class="metric-val" style="color:var(--ua-yellow)">${counts.late}</span>
       <span class="metric-label">Late</span>
     </div>
-    <div class="metric-card">
-      <span class="metric-val" style="color:var(--ua-muted)">${scheduled}</span>
-      <span class="metric-label">Upcoming</span>
+    <div class="metric-card"${canceledTitle}>
+      <span class="metric-val" style="color:var(--ua-red)">${counts.canceled}</span>
+      <span class="metric-label">Canceled</span>
     </div>
+    <div class="metric-card">
+      <span class="metric-val" style="color:var(--ua-muted)">${counts.upcoming}</span>
+      <span class="metric-label">Upcoming</span>
+    </div>${uncatCard}
   `;
+
+  // Sub-strip notes: presumed-departed count (#6) + FAA hub-disruption lag warning.
+  const noteEl = document.getElementById('sched-stats-note');
+  if (noteEl) {
+    let notes = '';
+    if (counts.presumed > 0) {
+      const verb = schedCurrentDir === 'arrivals' ? 'landed' : 'departed';
+      notes += `<span class="sched-note-chip" title="Presumed ${verb} \u2014 scheduled time passed without a live update">\u2708 ${counts.presumed} presumed ${verb}</span>`;
+    }
+    const hdm = Number(schedBoardMeta?.hubDisruptionMinutes);
+    if (Number.isFinite(hdm) && hdm > 60 && schedCurrentHub) {
+      notes += `<span class="sched-note-warn">\u26a0 ${escapeHtml(schedCurrentHub)} under FAA delay program (avg ${Math.round(hdm)}min) \u2014 statuses may lag.</span>`;
+    }
+    noteEl.innerHTML = notes;
+    noteEl.style.display = notes ? '' : 'none';
+  }
 }
 
 // ═══ OFFLINE DETECTION ═══
@@ -5021,6 +5243,7 @@ window.addEventListener('offline', updateOnlineStatus);
 
 // ═══ GLOBAL SEARCH ═══
 document.getElementById('global-search-input').addEventListener('input', debounce(function() {
+  hideGlobalSearchError();
   const q = this.value.trim().toUpperCase();
   const results = document.getElementById('global-search-results');
   if (q.length < 2) { results.style.display = 'none'; return; }
@@ -5276,6 +5499,15 @@ function getEquipChangeForFlight(flightNum) {
 
 // ═══ HUB HEALTH ═══
 let hubHealthData = {};
+// Hubs whose OTP came from the server /api/irops response. Server values are
+// authoritative: the client-side computation may only FILL hubs the server
+// response lacks, never overwrite them (audit Jul 3 2026: the DEN 68→100 flap —
+// a thin client sample gated only by a ≥5-flight floor clobbered the server's
+// much larger sample).
+let hubHealthServerHubs = new Set();
+// Latest IROPS severity index (0-100) from either computation path — feeds the
+// header ticker so it can never say "normal" during a red IROPS night.
+let lastIropsScore = null;
 
 // Single renderer for the hub health bar — reads from hubHealthData (shared state).
 // Both IROPS and schedule paths write to hubHealthData, then call this.
@@ -5283,11 +5515,11 @@ function renderHubHealthBar() {
   const bar = document.getElementById('hub-health-bar');
   const hubs = ['ORD','DEN','IAH','EWR','SFO','IAD','LAX','NRT','GUM'];
   if (!Object.keys(hubHealthData).length) {
-    bar.innerHTML = '<span class="hh-label">Hub Health</span><span class="hh-explainer">ON-TIME %</span><span class="hh-info">?<span class="hh-tooltip">% of operated flights departing within 30 min of schedule. 🟢 &gt;70% · 🟡 50–70% · 🔴 &lt;50%</span></span><span style="color:var(--ua-muted)">Load schedule data for hub health</span>';
+    bar.innerHTML = '<span class="hh-label">Hub Health</span><span class="hh-explainer">ON-TIME %</span><span class="hh-info">?<span class="hh-tooltip">% of operated departures within 30 min of schedule. 🟢 &gt;70% · 🟡 50–70% · 🔴 &lt;50%</span></span><span style="color:var(--ua-muted)">Load schedule data for hub health</span>';
     return;
   }
   const homeHub = getHomeAirport();
-  let html = '<span class="hh-label">Hub Health</span><span class="hh-explainer">ON-TIME %</span><span class="hh-info">?<span class="hh-tooltip">% of operated flights departing within 30 min of schedule. 🟢 &gt;70% · 🟡 50–70% · 🔴 &lt;50%</span></span>';
+  let html = '<span class="hh-label">Hub Health</span><span class="hh-explainer">ON-TIME %</span><span class="hh-info">?<span class="hh-tooltip">% of operated departures within 30 min of schedule. 🟢 &gt;70% · 🟡 50–70% · 🔴 &lt;50%</span></span>';
   hubs.forEach((hub, i) => {
     const isHome = hub === homeHub;
     const homeStyle = isHome ? ';border:1px solid var(--ua-accent);border-radius:3px;padding:2px 6px' : '';
@@ -5325,12 +5557,15 @@ function updateHubHealth() {
   for (const key of Object.keys(schedRawByHub)) {
     const flights = schedRawByHub[key];
     if (!flights || !flights.length) continue;
-    const hub = key.split('-')[0];
+    const keyParts = key.split('-');
+    const hub = keyParts[0];
+    const boardDir = keyParts[1] === 'arrivals' ? 'arrivals' : 'departures';
     if (!totalsByHub[hub]) continue;
     flights.forEach(fl => {
-      // Default dir 'departures' is intentional: this loop aggregates BOTH arrivals and departures
-      // boards, so there is no single correct direction. Don't pass schedCurrentDir here.
-      const status = classifySchedStatus(fl, 'departures', schedNow());
+      // The key carries each board's true direction — use it (a hardcoded 'departures' misreads
+      // arrivals rows: direction picks which real timestamp resolves inference and
+      // canceled_uncertain). Disruption opts are per-hub too. (review Jul 3 2026)
+      const status = classifySchedStatus(fl, boardDir, schedNow(), classifyOptsForKey(key));
       const hasOp = status.key === 'departed' || status.key === 'enroute' || status.key === 'landed';
       if (!hasOp) return;
       // Time-inferred operated rows (a long-past "scheduled" the classifier reclassified, with no
@@ -5354,14 +5589,20 @@ function updateHubHealth() {
   }
 
   hubs.forEach(hub => {
+    // Server /api/irops OTP is authoritative when present — the client-side
+    // computation only fills hubs the server response lacks, and never writes
+    // from a thin sample (n < 25). Audit Jul 3 2026: DEN flapped 68→100 because
+    // a 5-flight client sample overwrote the server's reading.
+    if (hubHealthServerHubs.has(hub)) return;
     const { onTime, operated } = totalsByHub[hub];
-    if (operated >= 5) {
+    if (operated >= 25) {
       hubHealthData[hub] = Math.round((onTime / operated) * 100);
     }
     // Don't delete hubHealthData[hub] — IROPS may have set it
   });
 
   renderHubHealthBar();
+  updateTicker(); // ticker health derives from hub OTP — keep it in lockstep
 }
 
 // ═══ IROPS DASHBOARD ═══
@@ -5488,8 +5729,10 @@ function updateIrops() {
   const content = document.getElementById('irops-content');
   // Gather all schedule data
   let allSchedFlts = [];
-  for (const flights of Object.values(schedRawByHub)) {
-    if (Array.isArray(flights)) allSchedFlts = allSchedFlts.concat(flights);
+  for (const [key, flights] of Object.entries(schedRawByHub)) {
+    if (!Array.isArray(flights)) continue;
+    const dir = key.split('-')[1] === 'arrivals' ? 'arrivals' : 'departures';
+    for (const fl of flights) allSchedFlts.push({ fl, dir, key });
   }
 
   if (allSchedFlts.length === 0) {
@@ -5501,11 +5744,12 @@ function updateIrops() {
 
   const worstDelays = [];
 
-  allSchedFlts.forEach(fl => {
-    // Default dir 'departures' is intentional: this only reads 'canceled'/'diverted', which the
-    // time-aware reclassification never produces, so direction (and now) can't change the result.
-    const s = classifySchedStatus(fl, 'departures', schedNow());
-    if (s.key === 'canceled') cancellations++;
+  allSchedFlts.forEach(({ fl, dir, key }) => {
+    // Direction matters here: canceled_uncertain resolves via the direction-appropriate real
+    // timestamp (an arrivals row with real.arrival must clear the suspicion) — a hardcoded
+    // 'departures' miscounts arrivals boards' likely-canceled rows. (review Jul 3 2026)
+    const s = classifySchedStatus(fl, dir, schedNow(), classifyOptsForKey(key));
+    if (s.key === 'canceled' || s.key === 'canceled_uncertain') cancellations++; // Likely Canceled groups with cancellations
     if (s.key === 'diverted') diversions++;
     const schedT = fl.time?.scheduled?.departure || fl.time?.scheduled?.arrival || 0;
     const actT = fl.time?.real?.departure || fl.time?.real?.arrival || fl.time?.estimated?.departure || fl.time?.estimated?.arrival || 0;
@@ -5537,7 +5781,9 @@ function updateIrops() {
   // NOTE: All values here are computed numbers/strings from internal schedule data,
   // not user input. FAA alerts use escapeHtml() below.
   let html = '<div class="irops-bar">';
-  html += `<span class="irops-bar-item"><span class="irops-score ${scoreCls}" style="font-size:12px;padding:2px 8px">${score}</span><span class="irops-bar-label">${scoreLabel}</span></span>`;
+  // Bare "56.7" read as a mystery number — attach the scale/label and the same
+  // "?" tooltip pattern the OTP strip uses. (Audit Jul 3 2026, ticker coherence.)
+  html += `<span class="irops-bar-item"><span class="irops-score ${scoreCls}" style="font-size:12px;padding:2px 8px">IROPS ${score}/100</span><span class="irops-bar-label">${scoreLabel}</span><span class="hh-info">?<span class="hh-tooltip">IROPS severity index (0\u2013100): weighted cancellations, 60min+ delays and diversions per 100 flights. &lt;5 normal \u00b7 5\u201315 minor \u00b7 \u226515 significant</span></span></span>`;
   html += '<span class="irops-bar-sep">│</span>';
   html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:var(--ua-red)">${cancellations}</span><span class="irops-bar-label">Cancellations</span></span>`;
   html += '<span class="irops-bar-sep">│</span>';
@@ -5561,6 +5807,9 @@ function updateIrops() {
     html += `<div class="irops-bar-faa">${faaAlerts.map(a => escapeHtml(a)).join(' · ')}</div>`;
   }
   content.innerHTML = html;
+
+  lastIropsScore = Number(score);
+  updateTicker(); // ticker health derives from the IROPS index — keep it in lockstep
 }
 
 function autoLoadIrops() {
@@ -5613,8 +5862,10 @@ function renderIropsFromAPI(data) {
       const cancelRate = m.total > 10 ? Number(m.cancellations || 0) / m.total : 0;
       if (operated < 5 && cancelRate >= 0.5) {
         hubHealthData[hub] = 0; // mostly cancelled — show as critical
+        hubHealthServerHubs.add(hub); // server value is authoritative from here on
       } else if (operated >= 5) {
         hubHealthData[hub] = Math.round((onTime / operated) * 100);
+        hubHealthServerHubs.add(hub); // server value is authoritative from here on
       }
       // operated < 5 and low cancel rate: leave hub alone (no data yet)
     }
@@ -5628,7 +5879,8 @@ function renderIropsFromAPI(data) {
 
   // NOTE: All values here are from the IROPS API (internal, not user input).
   let html = '<div class="irops-bar">';
-  html += `<span class="irops-bar-item"><span class="irops-score ${scoreCls}" style="font-size:12px;padding:2px 8px">${score}</span><span class="irops-bar-label">${scoreLabel}</span></span>`;
+  // Same scale/label + tooltip treatment as the client-computed IROPS bar above.
+  html += `<span class="irops-bar-item"><span class="irops-score ${scoreCls}" style="font-size:12px;padding:2px 8px">IROPS ${score}/100</span><span class="irops-bar-label">${scoreLabel}</span><span class="hh-info">?<span class="hh-tooltip">IROPS severity index (0\u2013100): weighted cancellations, 60min+ delays and diversions per 100 flights. &lt;5 normal \u00b7 5\u201315 minor \u00b7 \u226515 significant</span></span></span>`;
   html += '<span class="irops-bar-sep">│</span>';
   html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:var(--ua-red)">${data.cancellations || '—'}</span><span class="irops-bar-label">Cancellations</span></span>`;
   html += '<span class="irops-bar-sep">│</span>';
@@ -5642,6 +5894,9 @@ function renderIropsFromAPI(data) {
   html += '</div>';
 
   content.innerHTML = html;
+
+  lastIropsScore = Number(score);
+  updateTicker(); // ticker health derives from the IROPS index — keep it in lockstep
 
   if (document.getElementById('tab-schedule')?.classList.contains('active') && schedAllFlights.length) {
     renderScheduleTable();
@@ -6190,9 +6445,22 @@ function buildMyFlightCard(watched, td) {
     }
   }
 
-  // Delay risk — pass timeData and liveFlight for multi-signal scoring
+  // Delay risk — pass timeData and liveFlight for multi-signal scoring.
+  // Never default to LOW on missing inputs (audit Jul 3 2026: card said LOW while
+  // the board said V.HIGH for the same flight, purely because the flight-times
+  // feed was dark). When the card lacks the inputs the board's risk had, reuse
+  // the board's computed score if the flight is on a loaded board; otherwise
+  // show an explicit "RISK N/A".
   let riskHtml = '';
-  const risk = computeDelayRisk(watched, origCode, destCode, td, liveFlight);
+  const hasRiskInputs = !!(td && td.success !== false && (td.departure?.gate?.scheduled || td.departure?.gate?.estimated));
+  let risk = null;
+  let riskNA = false;
+  if (hasRiskInputs) {
+    risk = computeDelayRisk(watched, origCode, destCode, td, liveFlight);
+  } else {
+    risk = findBoardRiskForFlight(watched.flight);
+    if (!risk) riskNA = true;
+  }
   const riskOtp = hubHealthData[origCode];
   const riskWx = weatherOpsByHub[origCode];
   const riskWxDest = weatherOpsByHub[destCode];
@@ -6204,6 +6472,8 @@ function buildMyFlightCard(watched, td) {
     : 'Connects to ' + riskConn.connFlight + ' ' + riskConn.hub + '\u2192' + (riskConn.dest || '?') + ', ' + riskConn.minutes + 'min layover (' + riskConn.risk + ')') : '';
   if (risk && (resolvedStatus === 'scheduled' || resolvedStatus === 'delayed' || resolvedStatus === '' || !resolvedStatus)) {
     riskHtml = `<span class="delay-risk-badge" data-action="explain-delay" data-flight="${flightNum}" data-route="${escapeHtml(origCode + '\u2192' + destCode)}" data-status="${escapeHtml(resolvedStatus || 'scheduled')}" data-risk-label="${risk.label}" data-risk-score="${risk.score}" data-risk-factors="${escapeHtml(risk.factors.join('|'))}" data-hub="${escapeHtml(origCode)}"${riskOtp !== undefined ? ' data-otp="' + riskOtp + '"' : ''}${riskWx ? ' data-weather="' + escapeHtml(riskWx.level + (riskWx.reasons.length ? ': ' + riskWx.reasons.join(', ') : '')) + '"' : ''}${riskWxDest ? ' data-dest-weather="' + escapeHtml(riskWxDest.level + (riskWxDest.reasons.length ? ': ' + riskWxDest.reasons.join(', ') : '')) + '"' : ''}${riskIrops ? ' data-irops="' + escapeHtml(riskIrops.cancellationRate + '% cancelled, ' + (riskIrops.delayed60Rate || 0) + '% delayed 60min+') + '"' : ''}${riskFaaStatus ? ' data-faa-status="' + escapeHtml(riskFaaStatus) + '"' : ''}${riskConnStr ? ' data-connection="' + escapeHtml(riskConnStr) + '"' : ''}${inboundStr ? ' data-inbound="' + escapeHtml(inboundStr) + '"' : ''} style="background:${risk.color}20;color:${risk.color};cursor:pointer" title="Click for AI analysis">${risk.label} RISK</span>`;
+  } else if (riskNA && (resolvedStatus === 'scheduled' || resolvedStatus === 'delayed' || resolvedStatus === '' || !resolvedStatus)) {
+    riskHtml = `<span class="delay-risk-badge" style="background:rgba(100,116,139,.15);color:var(--ua-muted);cursor:default" title="Not enough live data to score this flight">RISK N/A</span>`;
   }
 
   // Departure/arrival time data attributes for countdown timer
@@ -6351,9 +6621,9 @@ function computeDelayRisk(watched, origHub, destHub, timeData, liveFlight) {
   });
 }
 
-function computeDelayRiskForScheduleFlight(fl, hub, nowSec = schedNow()) {
-  const { depHub, arrHub } = getScheduleRiskContext(fl, hub, schedCurrentDir);
-  const status = classifySchedStatus(fl, schedCurrentDir, nowSec);
+function computeDelayRiskForScheduleFlight(fl, hub, nowSec = schedNow(), dir = schedCurrentDir) {
+  const { depHub, arrHub } = getScheduleRiskContext(fl, hub, dir);
+  const status = classifySchedStatus(fl, dir, nowSec, classifyOptsFor(metaForHubDir(hub, dir)));
   // Only score not-yet-departed flights
   if (status.key !== 'scheduled' && status.key !== 'estimated' && status.key !== 'delayed') return null;
 
@@ -6382,6 +6652,26 @@ function computeDelayRiskForScheduleFlight(fl, hub, nowSec = schedNow()) {
   });
 
   return result.score === 0 ? null : result;
+}
+
+// Reuse the schedule board's computed risk for a flight when the My Flights card
+// lacks the inputs the board had (flight-times feed dark → no scheduledTime →
+// the model degenerates to a default LOW that contradicts the board's V.HIGH,
+// same flight — audit Jul 3 2026). Scans every loaded board; returns null when
+// the flight is on no loaded board.
+function findBoardRiskForFlight(flightNum) {
+  if (!flightNum) return null;
+  for (const [key, flights] of Object.entries(schedRawByHub)) {
+    if (!Array.isArray(flights) || !flights.length) continue;
+    const parts = key.split('-');
+    const boardHub = parts[0];
+    const boardDir = parts[1] === 'arrivals' ? 'arrivals' : 'departures';
+    const fl = flights.find(f => f.identification?.number?.default === flightNum);
+    if (!fl) continue;
+    const risk = computeDelayRiskForScheduleFlight(fl, boardHub, schedNow(), boardDir);
+    if (risk) return risk;
+  }
+  return null;
 }
 
 // ═══ CONNECTION RISK CALCULATOR ═══
@@ -6548,13 +6838,18 @@ function checkWatchedFlightChanges(flights) {
     if (!ident) return;
     const wIdx = watched.findIndex(w => w.flight === ident);
     if (wIdx < 0) return;
-    const s = classifySchedStatus(fl, schedCurrentDir, schedNow());
+    const s = classifySchedStatus(fl, schedCurrentDir, schedNow(), classifyOptsFor(schedBoardMeta));
     // A time-inferred status (we guessed "Departed"/"Landed" because the clock crossed the grace
     // window, not because the provider confirmed it) must NOT fire a watch notification, a BMAC
     // landing toast, or overwrite the stored status. Skip until a real provider transition
     // arrives — otherwise watchers get speculative "your flight departed/landed" alerts and the
     // fabricated status masks the genuine change later. (adversarial review)
     if (s.inferred) return;
+    // Transitions INTO 'unknown' are pipeline noise, not flight events — tonight
+    // this fired "Unknown (was: Departed)" toasts. Skip entirely: don't notify and
+    // don't overwrite the stored status, so the next REAL transition still compares
+    // against the last meaningful state. (Audit Jul 3 2026.)
+    if (s.key === 'unknown') return;
     const newStatus = s.text;
     const oldStatus = watched[wIdx].status;
     if (oldStatus && newStatus !== oldStatus && isSignificantStatusChange(oldStatus, newStatus)) {
@@ -6605,6 +6900,20 @@ function showWatchNotification(msg) {
 function hideGlobalSearchResults() {
   const results = document.getElementById('global-search-results');
   if (results) results.style.display = 'none';
+}
+
+// Inline (non-blocking) error line under the header search field. A failed
+// lookup used to open a full-screen modal — a dead end for a quick search.
+function showGlobalSearchError(msg) {
+  const el = document.getElementById('global-search-error');
+  if (!el) return false;
+  el.textContent = msg;
+  el.style.display = 'block';
+  return true;
+}
+function hideGlobalSearchError() {
+  const el = document.getElementById('global-search-error');
+  if (el) el.style.display = 'none';
 }
 
 function toggleSidebarFilters() {
@@ -6704,6 +7013,9 @@ document.addEventListener('click', function(e) {
       break;
     case 'refresh-flights':
       refreshFlights();
+      break;
+    case 'sched-jump-now':
+      scrollScheduleToNow(true);
       break;
     case 'schedule-refresh':
       { const ts = getSchedDayTimestamp(schedCurrentDay);
@@ -7075,13 +7387,16 @@ async function initApp() {
       mfSearch.value = '';
     }
   });
+  // Connection-checker inputs submit on Enter (parity with the button)
+  ['conn-inbound', 'conn-outbound'].forEach(function(id) {
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('keydown', function(e) { if (e.key === 'Enter') checkManualConnection(); });
+  });
   // Rotating search placeholders
   (function() {
-    const hints = [
-      'Track a flight — try "UA 1234"',
-      'Look up an aircraft — try "N37502"',
-      'Search by airport — try "ORD"'
-    ];
+    // Header search keeps ONE flight-first placeholder everywhere (its static
+    // HTML placeholder) — the old rotation mutated it to "Look up an aircraft…"
+    // on whatever tab you were on, teaching users the wrong primary use.
     const mfHints = [
       'Add a flight (e.g. UA 1234)',
       'Try a tail number (N37502)'
@@ -7097,7 +7412,6 @@ async function initApp() {
       el.addEventListener('focus', () => { clearInterval(timer); timer = null; });
       el.addEventListener('blur', () => { if (!el.value && !timer) timer = setInterval(cycle, 4000); });
     }
-    rotator(document.getElementById('global-search-input'), hints);
     rotator(document.getElementById('myflight-search'), mfHints);
   })();
   // Init map immediately so the user sees something
@@ -7732,14 +8046,26 @@ function lookupFR24Flight(query) {
     .then(r => r.ok ? r.json() : r.json().catch(() => ({})).then(b => Promise.reject(new Error(b.error || 'HTTP ' + r.status))))
     .then(data => {
       if (!data.success || !data.flight) {
-        modal.innerHTML = '<div style="background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:10px;padding:24px;max-width:420px;width:90%;color:var(--ua-text);font-family:var(--font-mono);position:relative"><button data-action="close-fr24-modal" aria-label="Close" style="position:absolute;top:8px;right:12px;background:none;border:none;color:var(--ua-muted);cursor:pointer;font-size:16px">✕</button><div style="text-align:center;padding:20px"><div style="font-size:24px;margin-bottom:8px">✈️</div><div style="color:var(--ua-muted);font-size:11px">' + escapeHtml(data.error || 'No data found for ' + q) + '</div><div style="margin-top:12px;font-size:9px;color:var(--ua-muted)">The flight may not be active right now.<br>Check the Schedule tab for gate status.</div></div></div>';
+        // Failure is never a blocking modal (audit Jul 3 2026): close the loading
+        // modal and render inline error text under the header search field. Modal
+        // fallback only if the inline slot is missing from the DOM.
+        const msg = (data.error || 'No data found for ' + q) + ' — the flight may not be active right now. Check the Schedule tab for gate status.';
+        if (showGlobalSearchError(msg)) {
+          modal.style.display = 'none';
+        } else {
+          modal.innerHTML = '<div style="background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:10px;padding:24px;max-width:420px;width:90%;color:var(--ua-text);font-family:var(--font-mono);position:relative"><button data-action="close-fr24-modal" aria-label="Close" style="position:absolute;top:8px;right:12px;background:none;border:none;color:var(--ua-muted);cursor:pointer;font-size:16px">✕</button><div style="text-align:center;padding:20px"><div style="font-size:24px;margin-bottom:8px">✈️</div><div style="color:var(--ua-muted);font-size:11px">' + escapeHtml(data.error || 'No data found for ' + q) + '</div><div style="margin-top:12px;font-size:9px;color:var(--ua-muted)">The flight may not be active right now.<br>Check the Schedule tab for gate status.</div></div></div>';
+        }
         return;
       }
       renderFR24Modal(data.flight, data.source, data.cached);
     })
     .catch(err => {
       console.error('FR24 lookup error:', err);
-      modal.innerHTML = '<div style="background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:10px;padding:24px;max-width:420px;width:90%;color:var(--ua-text);font-family:var(--font-mono);position:relative"><button data-action="close-fr24-modal" aria-label="Close" style="position:absolute;top:8px;right:12px;background:none;border:none;color:var(--ua-muted);cursor:pointer;font-size:16px">✕</button><div style="text-align:center;padding:20px;color:var(--ua-muted)"><div style="font-size:24px;margin-bottom:8px">⚠️</div>Failed to look up flight. Try again later.</div></div>';
+      if (showGlobalSearchError('Lookup failed for ' + q + ' — try again in a moment.')) {
+        modal.style.display = 'none';
+      } else {
+        modal.innerHTML = '<div style="background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:10px;padding:24px;max-width:420px;width:90%;color:var(--ua-text);font-family:var(--font-mono);position:relative"><button data-action="close-fr24-modal" aria-label="Close" style="position:absolute;top:8px;right:12px;background:none;border:none;color:var(--ua-muted);cursor:pointer;font-size:16px">✕</button><div style="text-align:center;padding:20px;color:var(--ua-muted)"><div style="font-size:24px;margin-bottom:8px">⚠️</div>Failed to look up flight. Try again later.</div></div>';
+      }
     });
 }
 

--- a/src/lib/board-now.js
+++ b/src/lib/board-now.js
@@ -1,0 +1,36 @@
+// ═══ "NOW" ANCHOR FOR TIME-ASCENDING BOARDS ═══
+// The schedule board sorts time-ascending, so yesterday's stragglers lead the page
+// all day (audit Jul 3 2026). These helpers find where "now" falls in a sorted list
+// of departure timestamps so the UI can (a) auto-scroll to the first still-relevant
+// row and (b) insert a "── NOW ──" divider between past and future rows.
+//
+// A row counts as "future" from 30 minutes before now: a flight scheduled 20 minutes
+// ago may still be boarding, so anchoring strictly at now would scroll past it.
+
+export const NOW_GRACE_SECONDS = 1800; // 30 minutes
+
+/**
+ * Index of the first row whose timestamp is at or after (now - grace).
+ * @param {Array<number|null|undefined>} timesSec  sorted-ascending unix seconds (0/null = unknown).
+ * @param {number} nowSec  current unix time in seconds.
+ * @returns {number} index, or -1 when there are no future rows (skip all NOW anchoring).
+ */
+export function firstFutureIndex(timesSec, nowSec, graceSec = NOW_GRACE_SECONDS) {
+  if (!Array.isArray(timesSec) || !Number.isFinite(Number(nowSec))) return -1;
+  for (let i = 0; i < timesSec.length; i++) {
+    const t = Number(timesSec[i]);
+    if (Number.isFinite(t) && t > 0 && t >= nowSec - graceSec) return i;
+  }
+  return -1;
+}
+
+/**
+ * Where to insert the "── NOW ──" divider row, or -1 when a divider makes no sense:
+ *  - no future rows (whole board is in the past — e.g. late-night today board), or
+ *  - no past rows (divider would sit uselessly at the very top — e.g. tomorrow board
+ *    or early-morning today board).
+ */
+export function nowDividerIndex(timesSec, nowSec, graceSec = NOW_GRACE_SECONDS) {
+  const idx = firstFutureIndex(timesSec, nowSec, graceSec);
+  return idx > 0 ? idx : -1;
+}

--- a/src/lib/board-stats.js
+++ b/src/lib/board-stats.js
@@ -1,0 +1,78 @@
+// ═══ SCHEDULE STAT-STRIP RECONCILIATION ═══
+// Audit Jul 3 2026: renderScheduleStats computed `canceled` but never rendered it —
+// ORD showed Total 717 while the visible cards summed 475, hiding 70 cancellations
+// during an IROPS night. This helper buckets EVERY row exactly once so the cards
+// (+ a muted "uncategorized" catch-all) visibly reconcile with Total:
+//
+//   total = onTime + late + upcoming + canceled + presumed + uncategorized
+//
+// Buckets:
+//   onTime/late     operated rows with a trustworthy schedule baseline (30-min rule)
+//   upcoming        scheduled / estimated / delayed / unknown (unknown renders as
+//                   "Scheduled (as of …)" so it counts here, not as noise)
+//   canceled        canceled + canceled_uncertain ("Likely Canceled" groups here)
+//   presumed        time-inferred departures/landings (no live confirmation)
+//   uncategorized   everything else: diverted, operated rows without usable
+//                   timestamps, live-feed rescue rows, derived-schedule rows
+
+import { classifySchedStatus } from './schedule-status.js';
+
+/**
+ * @param {Array<object>} flights  normalized schedule flights (api/schedule shape).
+ * @param {object} [opts]
+ * @param {('departures'|'arrivals')} [opts.dir]
+ * @param {number} [opts.nowSec]
+ * @param {(fl:object)=>object} [opts.classify]  injectable for tests; defaults to
+ *        classifySchedStatus(fl, dir, nowSec, classifyOpts).
+ * @param {object} [opts.classifyOpts]  forwarded to classifySchedStatus (e.g.
+ *        {hubDisruptionMinutes}) so the disruption-extended inference grace engages
+ *        even when no custom classify is injected.
+ */
+export function computeScheduleStatCounts(flights, { dir = 'departures', nowSec = Math.floor(Date.now() / 1000), classify, classifyOpts } = {}) {
+  const cls = classify || ((fl) => classifySchedStatus(fl, dir, nowSec, classifyOpts));
+  const isArr = dir === 'arrivals';
+  const list = Array.isArray(flights) ? flights : [];
+
+  let onTime = 0, late = 0, upcoming = 0, canceled = 0, canceledUncertain = 0, presumed = 0;
+
+  for (const fl of list) {
+    const status = cls(fl) || {};
+    const key = status.key || 'unknown';
+
+    if (key === 'canceled' || key === 'canceled_uncertain') {
+      canceled++;
+      if (key === 'canceled_uncertain') canceledUncertain++;
+      continue;
+    }
+
+    const hasOperated = key === 'departed' || key === 'enroute' || key === 'landed';
+    if (!hasOperated) {
+      if (key === 'scheduled' || key === 'estimated' || key === 'delayed' || key === 'unknown') upcoming++;
+      // anything else (diverted, novel keys) falls into the uncategorized remainder
+      continue;
+    }
+
+    // Time-inferred rows have no trustworthy actual-out time: they are neither
+    // on-time nor late — they are "presumed departed" and get their own count.
+    if (status.presumed || status.inferred) { presumed++; continue; }
+
+    // OTP scoring — mirrors the long-standing rules (excludes synthetic baselines).
+    if (fl._source?.liveFeedFallback) continue;
+    const schedT = isArr ? fl.time?.scheduled?.arrival : fl.time?.scheduled?.departure;
+    const derived = isArr
+      ? fl._source?.scheduleTimeDerivedFromActual?.arrival
+      : fl._source?.scheduleTimeDerivedFromActual?.departure;
+    const realT = fl.time?.real?.departure || fl.time?.real?.arrival;
+    const actT = realT || (isArr ? fl.time?.estimated?.arrival : fl.time?.estimated?.departure);
+    if (!schedT || !actT || derived) continue;
+    if (actT > schedT + 1800) late++;
+    else onTime++;
+  }
+
+  const total = list.length;
+  const operated = onTime + late;
+  const otp = operated > 0 ? Math.round((onTime / operated) * 100) : null;
+  const uncategorized = Math.max(0, total - onTime - late - upcoming - canceled - presumed);
+
+  return { total, onTime, late, upcoming, canceled, canceledUncertain, presumed, operated, otp, uncategorized };
+}

--- a/src/lib/delay-format.js
+++ b/src/lib/delay-format.js
@@ -1,0 +1,35 @@
+// ═══ DELAY DELTA FORMATTING ═══
+// Formats a known departure/arrival delay (minutes vs schedule) for the schedule
+// board's DELAY / RISK column. Audit Jul 3 2026: the column was blank on departed
+// rows while the real delta hid as tiny sub-text in the TIME cell — a flight with a
+// known +140m delay displayed an AI prediction instead of the fact.
+//
+// Convention: "+Nm" under 90 minutes, "+XhYYm" at 90 minutes and above (a wall of
+// minutes like "+140m" is harder to read than "+2h20m"). Early departures render
+// with a proper minus sign ("−12m").
+
+/**
+ * @param {number} minutes  signed delay in minutes (positive = late).
+ * @returns {string} formatted delta, or '' when the input is not a finite number.
+ */
+export function formatDelayMinutes(minutes) {
+  if (minutes == null || !Number.isFinite(Number(minutes))) return '';
+  const rounded = Math.round(Number(minutes));
+  const sign = rounded < 0 ? '−' : '+';
+  const abs = Math.abs(rounded);
+  if (abs < 90) return `${sign}${abs}m`;
+  const h = Math.floor(abs / 60);
+  const m = abs % 60;
+  return `${sign}${h}h${String(m).padStart(2, '0')}m`;
+}
+
+/**
+ * Severity color token for a delay delta. Mirrors DESIGN.md status colors:
+ * green = on-time/early, yellow = moderate delay, red = severe delay.
+ */
+export function delayColorVar(minutes) {
+  const n = Number(minutes);
+  if (!Number.isFinite(n) || n <= 15) return 'var(--ua-green)';
+  if (n <= 60) return 'var(--ua-yellow)';
+  return 'var(--ua-red)';
+}

--- a/src/lib/ops-health.js
+++ b/src/lib/ops-health.js
@@ -1,0 +1,83 @@
+// ═══ OPERATIONAL HEALTH FOR THE HEADER TICKER ═══
+// Audit Jul 3 2026: the ticker said "✅ All systems normal" while the Delays tab
+// showed IROPS 56.7 red, 151 cancellations, and 17 ground stops — the ticker only
+// looked at emergency squawks in the live feed. This module derives the ticker's
+// health state from the SAME inputs the IROPS panel uses (hub OTP, FAA programs at
+// UA hubs, IROPS severity index) so the two surfaces can never contradict.
+//
+// Rules (from the info-design audit):
+//  - any hub OTP < 50%, or any active ground stop / ground delay program at a UA
+//    hub ⇒ amber "Disrupted: <worst hub> <fact>" — never green.
+//  - IROPS index red (≥ 15, "Significant IROPS") ⇒ never "normal", even when no
+//    single hub crosses a threshold.
+
+/**
+ * Extract active FAA traffic-management programs at UA hubs from the /api/faa
+ * index shape ({ [airportCode]: { groundStop, groundDelay, delays: [{type, avgDelay}] } }).
+ * Defensive: every field may be absent on old cached payloads.
+ * @returns {Array<{hub:string, kind:'GS'|'GDP', avgDelay:number|null}>}
+ */
+export function extractHubPrograms(faaIndex = {}, hubCodes = []) {
+  const programs = [];
+  if (!faaIndex || typeof faaIndex !== 'object') return programs;
+  for (const hub of hubCodes) {
+    const entry = faaIndex[hub];
+    if (!entry || typeof entry !== 'object') continue;
+    const delays = Array.isArray(entry.delays) ? entry.delays : [];
+    const typeOf = (d) => String(d?.type || d?.reason || '').toLowerCase();
+    const gsDelay = delays.find((d) => typeOf(d).includes('ground stop') || typeOf(d).includes('ground_stop'));
+    const gdpDelay = delays.find((d) => typeOf(d).includes('ground delay') || typeOf(d).includes('gdp'));
+    if (entry.groundStop || gsDelay) {
+      programs.push({ hub, kind: 'GS', avgDelay: numOrNull(gsDelay?.avgDelay) });
+    } else if (entry.groundDelay || gdpDelay) {
+      programs.push({ hub, kind: 'GDP', avgDelay: numOrNull(gdpDelay?.avgDelay) });
+    }
+  }
+  return programs;
+}
+
+function numOrNull(v) {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * Derive the ticker's health state.
+ * @param {object} opts
+ * @param {Record<string,number>} [opts.hubOtps]  on-time % per hub (hubHealthData).
+ * @param {object} [opts.faaIndex]  faaDelayIndex ({ code: airportEntry }).
+ * @param {string[]} [opts.hubCodes]  UA hub IATA codes to consider.
+ * @param {number|null} [opts.iropsScore]  latest IROPS severity index (0-100), null when unknown.
+ * @returns {{level:'normal'|'advisory', text:string}}
+ */
+export function deriveOpsHealth({ hubOtps = {}, faaIndex = {}, hubCodes = [], iropsScore = null } = {}) {
+  const programs = extractHubPrograms(faaIndex, hubCodes);
+
+  // Worst hub by OTP (only hubs with a numeric reading).
+  let worstHub = null;
+  let worstOtp = Infinity;
+  for (const hub of hubCodes) {
+    const v = Number(hubOtps?.[hub]);
+    if (Number.isFinite(v) && v < worstOtp) { worstOtp = v; worstHub = hub; }
+  }
+
+  const gs = programs.find((p) => p.kind === 'GS');
+  if (gs) return { level: 'advisory', text: `Disrupted: ${gs.hub} ground stop` };
+
+  if (worstHub && worstOtp < 50) {
+    return { level: 'advisory', text: `Disrupted: ${worstHub} on-time ${Math.round(worstOtp)}%` };
+  }
+
+  const gdp = programs.find((p) => p.kind === 'GDP');
+  if (gdp) {
+    const avg = gdp.avgDelay ? ` (avg ${Math.round(gdp.avgDelay)}m)` : '';
+    return { level: 'advisory', text: `Disrupted: ${gdp.hub} ground delay program${avg}` };
+  }
+
+  const score = Number(iropsScore);
+  if (Number.isFinite(score) && score >= 15) {
+    return { level: 'advisory', text: `Elevated irregular ops — IROPS ${score}/100` };
+  }
+
+  return { level: 'normal', text: '' };
+}

--- a/src/lib/schedule-status.js
+++ b/src/lib/schedule-status.js
@@ -24,6 +24,17 @@
 // best-known time is already well behind us.
 export const OPERATED_GRACE_SECONDS = 3600; // 60 minutes
 
+// During a hub-wide FAA program (GDP/ground stop), flights routinely sit hours past their
+// best-known time WITHOUT the provider ever publishing a revised estimate — the Jul 3 2026 ORD
+// GDP (293-min average delay) minted 162 false time-inferred "Departed" rows (UA2610/UA1967 were
+// physically parked). When the caller passes the hub's current disruption magnitude, extend the
+// inference grace to cover the program's average delay plus the normal 60-minute grace.
+export function operatedGraceSeconds(hubDisruptionMinutes) {
+  const mins = Number(hubDisruptionMinutes);
+  if (!Number.isFinite(mins) || mins <= 0) return OPERATED_GRACE_SECONDS;
+  return Math.max(OPERATED_GRACE_SECONDS, (mins + 60) * 60);
+}
+
 // How far past scheduled an estimated time must be before classifyBase labels it "delayed"
 // rather than "estimated". Faithfully carried over from the original inline classifier.
 const ESTIMATED_DELAY_SECONDS = 900; // 15 minutes
@@ -64,6 +75,14 @@ function classifyBase(flight) {
   if (diverted) return { text: 'Diverted', cls: 'diverted', key: 'diverted' };
   // FR24 uses various cancellation indicators: generic.status.text, status.text, status.icon
   const iconColor = s.icon || '';
+  // AeroDataBox "CanceledUncertain" is a SOFT signal — the provider suspects a cancellation but
+  // has not confirmed it. Surface it as its own warn-level state instead of hard red Canceled
+  // (the UI used to render the raw string "Canceleduncertain"). MUST be checked before the
+  // generic cancel branch below, whose includes('cancel') would swallow it. `label` mirrors
+  // `text` — it is the field name in the agreed frontend contract for this status.
+  if (statusText === 'canceled_uncertain' || generic?.type === 'canceled_uncertain' || txtLower.includes('canceleduncertain') || txtLower.includes('canceled uncertain')) {
+    return { text: 'Likely Canceled', label: 'Likely Canceled', cls: 'warn', key: 'canceled_uncertain' };
+  }
   if (statusText === 'canceled' || statusText === 'cancelled' || txtLower.includes('cancel') || (iconColor === 'red' && generic?.type === 'canceled')) return { text: txt || 'Canceled', cls: 'canceled', key: 'canceled' };
   if (statusText === 'landed' || txtLower.includes('landed')) return { text: txt || 'Landed', cls: 'landed', key: 'landed' };
   if (statusText === 'departed' || txtLower.startsWith('departed')) return { text: txt || 'Departed', cls: 'departed', key: 'departed' };
@@ -88,29 +107,48 @@ function classifyBase(flight) {
  * @param {('departures'|'arrivals')} [dir='departures']  board direction; decides which
  *        leg (departure vs arrival) drives the time-based "has it operated yet?" check.
  * @param {number} [nowSec]  current unix time in SECONDS (injectable for tests).
- * @returns {{text:string, cls:string, key:string, inferred?:boolean}}
- *        inferred:true marks a status derived from elapsed time rather than confirmed by
- *        the provider — callers exclude these from on-time stats (no trustworthy actual time).
+ * @param {{hubDisruptionMinutes?: number}} [opts]  hubDisruptionMinutes > 0 (from board
+ *        meta.hubDisruptionMinutes, derived from live FAA programs) extends the operated-
+ *        inference grace to max(3600, (hubDisruptionMinutes + 60) * 60) seconds so a GDP hub
+ *        stops minting false time-inferred Departed rows. 0/undefined = legacy behavior.
+ * @returns {{text:string, cls:string, key:string, inferred?:boolean, presumed?:boolean, label?:string}}
+ *        inferred:true / presumed:true both mark a status derived from elapsed time rather than
+ *        confirmed by the provider — callers exclude these from on-time stats (no trustworthy
+ *        actual time) and badge them as presumed in the UI.
  */
-export function classifySchedStatus(flight, dir = 'departures', nowSec = Math.floor(Date.now() / 1000)) {
+export function classifySchedStatus(flight, dir = 'departures', nowSec = Math.floor(Date.now() / 1000), opts = {}) {
   const base = classifyBase(flight);
+  const time = flight.time || {};
+  const isArr = dir === 'arrivals';
+
+  // A provider row can carry the soft CanceledUncertain status AND a real departure/arrival
+  // time (the suspicion was wrong — the flight operated). Confirmed real times win.
+  if (base.key === 'canceled_uncertain') {
+    const real = isArr ? time.real?.arrival : time.real?.departure;
+    if (real && real > 0) {
+      return isArr
+        ? { text: 'Landed', cls: 'landed', key: 'landed' }
+        : { text: 'Departed', cls: 'departed', key: 'departed' };
+    }
+    return base;
+  }
+
   if (!RECLASSIFIABLE_KEYS.has(base.key)) return base;
 
   // Reclassify purely on elapsed time. This path is only reached for not-yet-operated provider
   // statuses (scheduled / estimated / delayed); a confirmed real departure/arrival is already
   // handled by classifyBase (the departed / en-route / landed branches), so we do not re-read
   // time.real here.
-  const time = flight.time || {};
-  const isArr = dir === 'arrivals';
   const scheduled = isArr ? time.scheduled?.arrival : time.scheduled?.departure;
   const estimated = isArr ? time.estimated?.arrival : time.estimated?.departure;
   const eff = effectiveTime(scheduled, estimated);
   if (!eff) return base; // no time to reason about — leave provider status untouched
 
-  if (eff < nowSec - OPERATED_GRACE_SECONDS) {
+  const grace = operatedGraceSeconds(opts?.hubDisruptionMinutes);
+  if (eff < nowSec - grace) {
     return isArr
-      ? { text: 'Landed', cls: 'landed', key: 'landed', inferred: true }
-      : { text: 'Departed', cls: 'departed', key: 'departed', inferred: true };
+      ? { text: 'Landed', cls: 'landed', key: 'landed', inferred: true, presumed: true }
+      : { text: 'Departed', cls: 'departed', key: 'departed', inferred: true, presumed: true };
   }
   return base;
 }

--- a/src/lib/status-display.js
+++ b/src/lib/status-display.js
@@ -1,0 +1,70 @@
+// ═══ SCHEDULE STATUS DISPLAY LAYER ═══
+// Presentation on top of classifySchedStatus results (src/lib/schedule-status.js).
+// Audit Jul 3 2026: 168 rows rendered a literal "Unknown" status (pipeline leak),
+// and raw provider strings can leak as concatenations ("Canceleduncertain").
+// This module keeps the display honest without touching classification:
+//  - key 'unknown' renders as "Scheduled" with an "as of <board time>" sub-stamp
+//    (the caller supplies the stamp — we only flag that it is needed).
+//  - key 'canceled_uncertain' always gets its proper "Likely Canceled" label,
+//    even if the classifier's text field is missing on an old cached payload.
+//  - any remaining raw provider string (underscores, camelCase run-ons) is
+//    title-cased defensively.
+
+/** True when a status string looks like a raw machine token rather than display text. */
+export function looksRawStatusText(text) {
+  if (!text || typeof text !== 'string') return true;
+  if (/_/.test(text)) return true;
+  if (!/\s/.test(text) && /[a-z][A-Z]/.test(text)) return true; // camelCase run-on
+  if (!/\s/.test(text) && /^[a-z]/.test(text)) return true; // all-lowercase token ("canceleduncertain")
+  return false;
+}
+
+/** "canceled_uncertain" → "Canceled Uncertain"; "enRoute" → "En Route". */
+export function humanizeStatusText(text) {
+  if (!text || typeof text !== 'string') return '';
+  const spaced = text
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .trim();
+  if (!spaced) return '';
+  return spaced
+    .split(/\s+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/**
+ * Map a classification result to what the board should render.
+ * Defensive against old cached payloads: every new contract field (label,
+ * presumed, canceled_uncertain key) may be absent — degrades to prior behavior.
+ *
+ * @param {{text?:string, cls?:string, key?:string, inferred?:boolean, presumed?:boolean, label?:string}|null} status
+ * @returns {{text:string, cls:string, presumed:boolean, asOf:boolean}}
+ *   text     display label (without the presumed asterisk — caller appends "*")
+ *   cls      CSS class for .sched-status
+ *   presumed row is a time-inferred departure/landing (render "Departed*" + tooltip)
+ *   asOf     caller should append an "as of <absolute board time>" sub-stamp
+ */
+export function displayScheduleStatus(status) {
+  if (!status || typeof status !== 'object') {
+    return { text: 'Scheduled', cls: 'scheduled', presumed: false, asOf: true };
+  }
+  const key = status.key || 'unknown';
+  const presumed = !!(status.presumed ?? status.inferred);
+
+  if (key === 'unknown') {
+    // A provider gap, not a real state: the flight is on the schedule, we just have
+    // no live update. "Scheduled (as of <board time>)" is the honest rendering.
+    return { text: 'Scheduled', cls: 'scheduled', presumed: false, asOf: true };
+  }
+
+  if (key === 'canceled_uncertain') {
+    const label = status.label || (!looksRawStatusText(status.text) && status.text) || 'Likely Canceled';
+    return { text: label, cls: status.cls || 'warn', presumed: false, asOf: false };
+  }
+
+  let text = status.label || status.text || '';
+  if (!text) return { text: 'Scheduled', cls: status.cls || 'scheduled', presumed, asOf: true };
+  if (looksRawStatusText(text)) text = humanizeStatusText(text);
+  return { text, cls: status.cls || 'unknown', presumed, asOf: false };
+}

--- a/tests/aerodatabox-dq.test.js
+++ b/tests/aerodatabox-dq.test.js
@@ -1,0 +1,289 @@
+// Data-quality release (Jul 3 2026 ORD GDP audit) — AeroDataBox board hygiene:
+//   #4 dedupe (schedule revisions, operator-code clones, foreign rows) + meta.dedupe counters
+//   #5 registration field validation (model strings like "B737M9" must not pass as tails)
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  dedupeBoardFlights,
+  validateRegistration,
+  fetchViaAeroDataBox,
+} from '../api/_schedule-aerodatabox.js';
+import { __resetAdbSpendForTests } from '../api/_cost-state.js';
+
+function row({ ident, orig = 'ORD', dest = 'LHR', schedDep = null, realDep = null, estDep = null, schedArr = null, realArr = null }) {
+  return {
+    identification: { number: { default: ident } },
+    time: {
+      scheduled: { departure: schedDep, arrival: schedArr },
+      real: { departure: realDep, arrival: realArr },
+      estimated: { departure: estDep, arrival: null },
+    },
+    airport: {
+      origin: { code: { iata: orig } },
+      destination: { code: { iata: dest } },
+    },
+  };
+}
+
+const T = 1_780_000_000;
+
+describe('dedupeBoardFlights — schedule-revision collapse (#4a)', () => {
+  it('collapses two rows for one physical departure (same ident + same real dep), keeping the ORIGINAL schedule', () => {
+    // The UA5982 case: counted BOTH "+2h48 Late" (original schedule) AND "On Time" (revised).
+    // The EARLIEST scheduled time must win: the revised row's schedule ≈ the real time, so
+    // keeping it rendered the +2h48m delay as On Time. Both rows share the real timestamp, so
+    // keeping the original baseline preserves the true delay.
+    const late = row({ ident: 'UA5982', dest: 'MSP', schedDep: T, realDep: T + 10080 });
+    const revised = row({ ident: 'UA5982', dest: 'MSP', schedDep: T + 10080, realDep: T + 10080 });
+    const { flights, dedupe } = dedupeBoardFlights([late, revised], 'departures');
+    expect(flights).toHaveLength(1);
+    expect(flights[0].time.scheduled.departure).toBe(T); // original baseline wins — delay stays visible
+    expect(dedupe.revisions).toBe(1);
+  });
+
+  it('keeps the original baseline regardless of input order', () => {
+    const revised = row({ ident: 'UA5982', dest: 'MSP', schedDep: T + 10080, realDep: T + 10080 });
+    const late = row({ ident: 'UA5982', dest: 'MSP', schedDep: T, realDep: T + 10080 });
+    const { flights } = dedupeBoardFlights([revised, late], 'departures');
+    expect(flights).toHaveLength(1);
+    expect(flights[0].time.scheduled.departure).toBe(T);
+  });
+
+  it('collapses on same real ARRIVAL for arrivals boards', () => {
+    const a = row({ ident: 'UA100', orig: 'DEN', dest: 'ORD', schedArr: T, realArr: T + 3000 });
+    const b = row({ ident: 'UA100', orig: 'DEN', dest: 'ORD', schedArr: T + 3000, realArr: T + 3000 });
+    const { flights, dedupe } = dedupeBoardFlights([a, b], 'arrivals');
+    expect(flights).toHaveLength(1);
+    expect(dedupe.revisions).toBe(1);
+  });
+
+  it('does NOT collapse a legitimate same-number rotation (no real times, different schedules)', () => {
+    const morning = row({ ident: 'UA200', dest: 'SFO', schedDep: T });
+    const evening = row({ ident: 'UA200', dest: 'SFO', schedDep: T + 12 * 3600 });
+    const { flights, dedupe } = dedupeBoardFlights([morning, evening], 'departures');
+    expect(flights).toHaveLength(2);
+    expect(dedupe.revisions).toBe(0);
+  });
+
+  it('does NOT collapse same-number rows with DIFFERENT real departures (two physical flights)', () => {
+    const a = row({ ident: 'UA300', dest: 'EWR', schedDep: T, realDep: T + 600 });
+    const b = row({ ident: 'UA300', dest: 'EWR', schedDep: T + 10 * 3600, realDep: T + 10 * 3600 + 300 });
+    const { flights } = dedupeBoardFlights([a, b], 'departures');
+    expect(flights).toHaveLength(2);
+  });
+});
+
+describe('dedupeBoardFlights — operator-code clones (#4b)', () => {
+  it('drops a United Express operator clone (G7) matching a UA row on route + real time, keeping UA', () => {
+    // "G7929 to LHR" clone from tonight's ORD board.
+    const ua = row({ ident: 'UA929', dest: 'LHR', schedDep: T, realDep: T + 900 });
+    const clone = row({ ident: 'G7929', dest: 'LHR', schedDep: T + 60, realDep: T + 900 });
+    const { flights, dedupe } = dedupeBoardFlights([ua, clone], 'departures');
+    expect(flights.map((f) => f.identification.number.default)).toEqual(['UA929']);
+    expect(dedupe.operatorClones).toBe(1);
+  });
+
+  it('matches clones on scheduled time within a few minutes when no real times exist', () => {
+    const ua = row({ ident: 'UA5432', dest: 'CLE', schedDep: T });
+    const clone = row({ ident: 'OO5432', dest: 'CLE', schedDep: T + 120 });
+    const { flights, dedupe } = dedupeBoardFlights([ua, clone], 'departures');
+    expect(flights.map((f) => f.identification.number.default)).toEqual(['UA5432']);
+    expect(dedupe.operatorClones).toBe(1);
+  });
+
+  it('keeps a United Express row (OO/YV/G7...) with NO matching UA row — it is a real flight', () => {
+    const solo = row({ ident: 'G7500', dest: 'GRB', schedDep: T });
+    const { flights, dedupe } = dedupeBoardFlights([solo], 'departures');
+    expect(flights).toHaveLength(1);
+    expect(dedupe.operatorClones).toBe(0);
+    expect(dedupe.foreign).toBe(0);
+  });
+
+  it('does NOT drop a UX row on the same route at a clearly different time', () => {
+    const ua = row({ ident: 'UA700', dest: 'DSM', schedDep: T });
+    const uax = row({ ident: 'YV700', dest: 'DSM', schedDep: T + 4 * 3600 });
+    const { flights } = dedupeBoardFlights([ua, uax], 'departures');
+    expect(flights).toHaveLength(2);
+  });
+
+  it('keeps BOTH rows when sched times are close but the real departures are distinct physical movements', () => {
+    // OO row and UA row, same route, scheduled 3 min apart — but real departures 55 min apart
+    // (17:10 vs 18:05): two aircraft. Route + schedule ±5 min alone used to delete the OO flight.
+    const ua = row({ ident: 'UA800', dest: 'ATW', schedDep: T, realDep: T + 600 });        // dep 17:10
+    const oo = row({ ident: 'OO800', dest: 'ATW', schedDep: T + 180, realDep: T + 3900 }); // dep 18:05
+    const { flights, dedupe } = dedupeBoardFlights([ua, oo], 'departures');
+    expect(flights.map((f) => f.identification.number.default).sort()).toEqual(['OO800', 'UA800']);
+    expect(dedupe.operatorClones).toBe(0);
+  });
+
+  it('still collapses when both real times match within ±120s', () => {
+    const ua = row({ ident: 'UA801', dest: 'MKE', schedDep: T, realDep: T + 600 });
+    const oo = row({ ident: 'OO801', dest: 'MKE', schedDep: T + 180, realDep: T + 660 }); // 60s apart
+    const { flights, dedupe } = dedupeBoardFlights([ua, oo], 'departures');
+    expect(flights.map((f) => f.identification.number.default)).toEqual(['UA801']);
+    expect(dedupe.operatorClones).toBe(1);
+  });
+
+  it('keeps a non-UA row that physically departed when the sched-matching UA row has no real time', () => {
+    // The non-UA row moved at a time the UA row does not corroborate — cannot confirm the same
+    // physical flight, so it survives.
+    const ua = row({ ident: 'UA802', dest: 'FAR', schedDep: T });
+    const oo = row({ ident: 'OO802', dest: 'FAR', schedDep: T + 120, realDep: T + 3600 });
+    const { flights, dedupe } = dedupeBoardFlights([ua, oo], 'departures');
+    expect(flights).toHaveLength(2);
+    expect(dedupe.operatorClones).toBe(0);
+  });
+});
+
+describe('dedupeBoardFlights — foreign rows (#4c)', () => {
+  it('drops a clearly foreign row (Spirit NK3005 on the EWR board) with no matching UA row', () => {
+    const ua = row({ ident: 'UA1000', orig: 'EWR', dest: 'MCO', schedDep: T });
+    const nk = row({ ident: 'NK3005', orig: 'EWR', dest: 'MCO', schedDep: T + 7200 });
+    const { flights, dedupe } = dedupeBoardFlights([ua, nk], 'departures');
+    expect(flights.map((f) => f.identification.number.default)).toEqual(['UA1000']);
+    expect(dedupe.foreign).toBe(1);
+  });
+
+  it('counts a foreign row that shadows a UA row as an operator clone, not foreign', () => {
+    const ua = row({ ident: 'UA2000', orig: 'EWR', dest: 'LAX', schedDep: T, realDep: T + 300 });
+    const dl = row({ ident: 'DL2000', orig: 'EWR', dest: 'LAX', schedDep: T, realDep: T + 300 });
+    const { flights, dedupe } = dedupeBoardFlights([ua, dl], 'departures');
+    expect(flights).toHaveLength(1);
+    expect(dedupe.operatorClones).toBe(1);
+    expect(dedupe.foreign).toBe(0);
+  });
+
+  it('never drops UA rows and reports zeroed counters on a clean board', () => {
+    const a = row({ ident: 'UA1', dest: 'SFO', schedDep: T });
+    const b = row({ ident: 'UA2', dest: 'LAX', schedDep: T + 100 });
+    const { flights, dedupe } = dedupeBoardFlights([a, b], 'departures');
+    expect(flights).toHaveLength(2);
+    expect(dedupe).toEqual({ revisions: 0, operatorClones: 0, foreign: 0 });
+  });
+});
+
+describe('validateRegistration (#5)', () => {
+  it('rejects the observed model-string leak "B737M9"', () => {
+    expect(validateRegistration('B737M9')).toBeNull();
+  });
+
+  it('keeps valid US N-numbers', () => {
+    expect(validateRegistration('N37502')).toBe('N37502');
+    expect(validateRegistration('N12345')).toBe('N12345');
+    expect(validateRegistration('N1UA')).toBe('N1UA');
+    expect(validateRegistration('n37502')).toBe('N37502'); // normalized to uppercase
+  });
+
+  it('keeps common hyphenated international registrations', () => {
+    expect(validateRegistration('C-FABC')).toBe('C-FABC');
+    expect(validateRegistration('D-ABCD')).toBe('D-ABCD');
+    expect(validateRegistration('B-1234')).toBe('B-1234');
+    expect(validateRegistration('PH-BHA')).toBe('PH-BHA');
+  });
+
+  it('keeps common hyphenless forms (JA/HL/B####) but rejects model-shaped strings', () => {
+    expect(validateRegistration('JA801A')).toBe('JA801A');
+    expect(validateRegistration('HL8001')).toBe('HL8001');
+    expect(validateRegistration('B1234')).toBe('B1234');
+    // Aircraft model codes that must NOT pass:
+    expect(validateRegistration('B788')).toBeNull();
+    expect(validateRegistration('B38M')).toBeNull();
+    expect(validateRegistration('B77W')).toBeNull();
+    expect(validateRegistration('A321NEO')).toBeNull();
+  });
+
+  it('rejects garbage, empties and leading-zero N-numbers', () => {
+    expect(validateRegistration('')).toBeNull();
+    expect(validateRegistration(null)).toBeNull();
+    expect(validateRegistration(undefined)).toBeNull();
+    expect(validateRegistration('N037502')).toBeNull();
+    expect(validateRegistration('BOEING 737')).toBeNull();
+    expect(validateRegistration('N123456789')).toBeNull();
+  });
+});
+
+describe('fetchViaAeroDataBox end-to-end board hygiene', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __resetAdbSpendForTests();
+    process.env.AERODATABOX_API_KEY = 'adb-test-key';
+    process.env.AERODATABOX_INTER_WINDOW_DELAY_MS = '0';
+  });
+
+  afterEach(() => {
+    delete process.env.AERODATABOX_API_KEY;
+    delete process.env.AERODATABOX_INTER_WINDOW_DELAY_MS;
+    __resetAdbSpendForTests();
+  });
+
+  it('applies dedupe + registration validation + status mapping to the normalized board', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const iso = (offsetS) => new Date((nowSec + offsetS) * 1000).toISOString();
+    const departures = [
+      { // revision dupe pair — same real departure, two schedule revisions
+        number: 'UA 5982', status: 'Departed', airline: { iata: 'UA', name: 'United Airlines' },
+        departure: { scheduledTime: { utc: iso(-10080) }, runwayTime: { utc: iso(0) }, airport: { iata: 'ORD' } },
+        arrival: { scheduledTime: { utc: iso(7200) }, airport: { iata: 'MSP' } },
+        aircraft: { model: 'Embraer 175', reg: 'N12345' },
+      },
+      {
+        number: 'UA 5982', status: 'Departed', airline: { iata: 'UA', name: 'United Airlines' },
+        departure: { scheduledTime: { utc: iso(0) }, runwayTime: { utc: iso(0) }, airport: { iata: 'ORD' } },
+        arrival: { scheduledTime: { utc: iso(7200) }, airport: { iata: 'MSP' } },
+        aircraft: { model: 'Embraer 175', reg: 'B737M9' }, // model string in the reg field
+      },
+      { // UA row + its G7 operator clone
+        number: 'UA 929', status: 'Delayed', airline: { iata: 'UA', name: 'United Airlines' },
+        departure: { scheduledTime: { utc: iso(3600) }, revisedTime: { utc: iso(9000) }, airport: { iata: 'ORD' } },
+        arrival: { scheduledTime: { utc: iso(30000) }, airport: { iata: 'LHR' } },
+        aircraft: { model: 'Boeing 787-9', reg: 'N37502' },
+      },
+      {
+        number: 'G7 929', status: 'Delayed', airline: { iata: 'UA', name: 'United Airlines' },
+        departure: { scheduledTime: { utc: iso(3660) }, airport: { iata: 'ORD' } },
+        arrival: { scheduledTime: { utc: iso(30000) }, airport: { iata: 'LHR' } },
+        aircraft: {},
+      },
+      { // clearly foreign leak with no UA match
+        number: 'NK 3005', status: 'Expected', airline: { iata: 'UA' },
+        departure: { scheduledTime: { utc: iso(5400) }, airport: { iata: 'ORD' } },
+        arrival: { scheduledTime: { utc: iso(12000) }, airport: { iata: 'MCO' } },
+        aircraft: {},
+      },
+      { // soft-cancel state
+        number: 'UA 2610', status: 'CanceledUncertain', airline: { iata: 'UA' },
+        departure: { scheduledTime: { utc: iso(1800) }, airport: { iata: 'ORD' } },
+        arrival: { scheduledTime: { utc: iso(9000) }, airport: { iata: 'SFO' } },
+        aircraft: {},
+      },
+    ];
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      if (String(url).includes('aedbx/aerodatabox')) {
+        return { ok: true, status: 200, json: async () => ({ departures }) };
+      }
+      return { ok: false, status: 403, text: async () => 'blocked', headers: { get: () => null } };
+    });
+
+    const result = await fetchViaAeroDataBox('ORD', 'departures', nowSec, 8000);
+    expect(result).toBeTruthy();
+
+    const idents = result.flights.map((f) => f.identification.number.default).sort();
+    expect(idents).toEqual(['UA2610', 'UA5982', 'UA929']);
+    expect(result.meta.dedupe).toEqual({ revisions: 1, operatorClones: 1, foreign: 1 });
+
+    const ua5982 = result.flights.find((f) => f.identification.number.default === 'UA5982');
+    // ORIGINAL schedule kept (the true-delay row, sched 2h48m before the real departure) — the
+    // revised on-time-looking row (whose bogus model-string reg would have been dropped) loses.
+    expect(ua5982.time.scheduled.departure).toBe(nowSec - 10080);
+    expect(ua5982.aircraft.registration).toBe('N12345');
+
+    const ua929 = result.flights.find((f) => f.identification.number.default === 'UA929');
+    expect(ua929.aircraft.registration).toBe('N37502');
+    expect(ua929.status.generic.status.text).toBe('delayed'); // #6 Delayed mapping
+
+    const ua2610 = result.flights.find((f) => f.identification.number.default === 'UA2610');
+    expect(ua2610.status.generic.status.text).toBe('canceled_uncertain'); // #2 soft state
+    expect(ua2610.status.icon).toBe('yellow');
+  });
+});

--- a/tests/board-now.test.js
+++ b/tests/board-now.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { firstFutureIndex, nowDividerIndex, NOW_GRACE_SECONDS } from '../src/lib/board-now.js';
+
+const NOW = 1_800_000_000; // arbitrary anchor
+
+describe('firstFutureIndex', () => {
+  it('finds the first row at or after now', () => {
+    const times = [NOW - 7200, NOW - 3600, NOW + 600, NOW + 7200];
+    expect(firstFutureIndex(times, NOW)).toBe(2);
+  });
+
+  it('includes rows up to 30 minutes in the past (still boarding)', () => {
+    const times = [NOW - 7200, NOW - 1200, NOW + 600];
+    expect(firstFutureIndex(times, NOW)).toBe(1); // -20min row counts as "now"
+    expect(NOW_GRACE_SECONDS).toBe(1800);
+  });
+
+  it('returns -1 when every row is in the past (late-night board)', () => {
+    const times = [NOW - 86400, NOW - 7200, NOW - 3600];
+    expect(firstFutureIndex(times, NOW)).toBe(-1);
+  });
+
+  it('returns 0 when every row is in the future (tomorrow board)', () => {
+    const times = [NOW + 3600, NOW + 7200];
+    expect(firstFutureIndex(times, NOW)).toBe(0);
+  });
+
+  it('skips rows with missing/zero timestamps', () => {
+    const times = [0, null, undefined, NOW + 600];
+    expect(firstFutureIndex(times, NOW)).toBe(3);
+  });
+
+  it('is defensive against garbage input', () => {
+    expect(firstFutureIndex(null, NOW)).toBe(-1);
+    expect(firstFutureIndex([NOW + 1], NaN)).toBe(-1);
+    expect(firstFutureIndex([], NOW)).toBe(-1);
+  });
+});
+
+describe('nowDividerIndex', () => {
+  it('places the divider between past and future rows', () => {
+    const times = [NOW - 7200, NOW - 3600, NOW + 600, NOW + 7200];
+    expect(nowDividerIndex(times, NOW)).toBe(2);
+  });
+
+  it('skips the divider when there are no future rows', () => {
+    expect(nowDividerIndex([NOW - 7200, NOW - 3600], NOW)).toBe(-1);
+  });
+
+  it('skips the divider when there are no past rows (tomorrow board / early morning)', () => {
+    expect(nowDividerIndex([NOW + 600, NOW + 7200], NOW)).toBe(-1);
+  });
+
+  it('skips the divider on an empty board', () => {
+    expect(nowDividerIndex([], NOW)).toBe(-1);
+  });
+});

--- a/tests/board-stats.test.js
+++ b/tests/board-stats.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { computeScheduleStatCounts } from '../src/lib/board-stats.js';
+
+const NOW = 1_800_000_000;
+
+// Build a flight whose stubbed classification is carried on __status.
+function flight(statusKey, { sched, real, est, source, presumed, inferred } = {}) {
+  return {
+    __status: { key: statusKey, presumed, inferred },
+    time: {
+      scheduled: { departure: sched ?? null },
+      real: { departure: real ?? null },
+      estimated: { departure: est ?? null },
+    },
+    _source: source || undefined,
+  };
+}
+
+const classify = (fl) => fl.__status;
+
+describe('computeScheduleStatCounts', () => {
+  it('reconciles: total = onTime + late + upcoming + canceled + presumed + uncategorized', () => {
+    const flights = [
+      flight('departed', { sched: NOW - 7200, real: NOW - 7100 }),                    // on time
+      flight('departed', { sched: NOW - 7200, real: NOW - 3600 }),                    // late (+60m)
+      flight('scheduled'),                                                            // upcoming
+      flight('estimated'),                                                            // upcoming
+      flight('delayed'),                                                              // upcoming (hidden third fix)
+      flight('unknown'),                                                              // upcoming (renders as Scheduled)
+      flight('canceled'),                                                             // canceled
+      flight('canceled_uncertain'),                                                   // canceled (Likely Canceled)
+      flight('departed', { sched: NOW - 7200, presumed: true }),                      // presumed
+      flight('diverted'),                                                             // uncategorized
+      flight('departed', {}),                                                         // operated, no timestamps → uncategorized
+    ];
+    const c = computeScheduleStatCounts(flights, { dir: 'departures', nowSec: NOW, classify });
+    expect(c.total).toBe(11);
+    expect(c.onTime).toBe(1);
+    expect(c.late).toBe(1);
+    expect(c.upcoming).toBe(4);
+    expect(c.canceled).toBe(2);
+    expect(c.canceledUncertain).toBe(1);
+    expect(c.presumed).toBe(1);
+    expect(c.uncategorized).toBe(2);
+    expect(c.onTime + c.late + c.upcoming + c.canceled + c.presumed + c.uncategorized).toBe(c.total);
+  });
+
+  it('groups canceled_uncertain under canceled and still reports it separately', () => {
+    const c = computeScheduleStatCounts([flight('canceled_uncertain')], { nowSec: NOW, classify });
+    expect(c.canceled).toBe(1);
+    expect(c.canceledUncertain).toBe(1);
+  });
+
+  it('counts legacy inferred rows as presumed (old cached payloads without presumed:true)', () => {
+    const c = computeScheduleStatCounts([flight('departed', { sched: NOW - 9000, inferred: true })], { nowSec: NOW, classify });
+    expect(c.presumed).toBe(1);
+    expect(c.operated).toBe(0); // never scored into OTP
+  });
+
+  it('applies the 30-minute OTP rule and excludes synthetic baselines', () => {
+    const flights = [
+      flight('departed', { sched: NOW - 7200, real: NOW - 7200 + 1800 }),            // exactly +30m → on time
+      flight('departed', { sched: NOW - 7200, real: NOW - 7200 + 1801 }),            // +30m1s → late
+      flight('departed', { sched: NOW - 7200, real: NOW - 7100, source: { liveFeedFallback: true } }),
+      flight('departed', { sched: NOW - 7200, real: NOW - 7100, source: { scheduleTimeDerivedFromActual: { departure: true } } }),
+    ];
+    const c = computeScheduleStatCounts(flights, { dir: 'departures', nowSec: NOW, classify });
+    expect(c.onTime).toBe(1);
+    expect(c.late).toBe(1);
+    expect(c.operated).toBe(2);
+    expect(c.otp).toBe(50);
+    expect(c.uncategorized).toBe(2); // the two excluded synthetic rows are not hidden
+  });
+
+  it('returns otp null (not 0 or 100) when nothing has operated', () => {
+    const c = computeScheduleStatCounts([flight('scheduled')], { nowSec: NOW, classify });
+    expect(c.otp).toBeNull();
+  });
+
+  it('handles empty/garbage input', () => {
+    const c = computeScheduleStatCounts(null, { nowSec: NOW, classify });
+    expect(c.total).toBe(0);
+    expect(c.uncategorized).toBe(0);
+  });
+});

--- a/tests/delay-format.test.js
+++ b/tests/delay-format.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { formatDelayMinutes, delayColorVar } from '../src/lib/delay-format.js';
+
+describe('formatDelayMinutes', () => {
+  it('formats sub-90-minute delays as +Nm', () => {
+    expect(formatDelayMinutes(8)).toBe('+8m');
+    expect(formatDelayMinutes(45)).toBe('+45m');
+    expect(formatDelayMinutes(89)).toBe('+89m');
+  });
+
+  it('formats 90+ minute delays as +XhYYm with zero-padded minutes', () => {
+    expect(formatDelayMinutes(90)).toBe('+1h30m');
+    expect(formatDelayMinutes(140)).toBe('+2h20m'); // the live +140m case from the audit
+    expect(formatDelayMinutes(125)).toBe('+2h05m');
+    expect(formatDelayMinutes(180)).toBe('+3h00m');
+  });
+
+  it('formats early departures with a minus sign', () => {
+    expect(formatDelayMinutes(-12)).toBe('−12m');
+    expect(formatDelayMinutes(-95)).toBe('−1h35m');
+  });
+
+  it('handles zero and rounding', () => {
+    expect(formatDelayMinutes(0)).toBe('+0m');
+    expect(formatDelayMinutes(7.6)).toBe('+8m');
+  });
+
+  it('returns empty string for garbage input', () => {
+    expect(formatDelayMinutes(null)).toBe('');
+    expect(formatDelayMinutes(undefined)).toBe('');
+    expect(formatDelayMinutes(NaN)).toBe('');
+    expect(formatDelayMinutes('soon')).toBe('');
+  });
+});
+
+describe('delayColorVar', () => {
+  it('is green up to 15 minutes (and for early departures)', () => {
+    expect(delayColorVar(-20)).toBe('var(--ua-green)');
+    expect(delayColorVar(0)).toBe('var(--ua-green)');
+    expect(delayColorVar(15)).toBe('var(--ua-green)');
+  });
+
+  it('is yellow for moderate delays (16-60m)', () => {
+    expect(delayColorVar(16)).toBe('var(--ua-yellow)');
+    expect(delayColorVar(60)).toBe('var(--ua-yellow)');
+  });
+
+  it('is red past an hour', () => {
+    expect(delayColorVar(61)).toBe('var(--ua-red)');
+    expect(delayColorVar(140)).toBe('var(--ua-red)');
+  });
+
+  it('defaults to green for unknown values (no false alarms)', () => {
+    expect(delayColorVar(NaN)).toBe('var(--ua-green)');
+  });
+});

--- a/tests/faa-disruption.test.js
+++ b/tests/faa-disruption.test.js
@@ -1,0 +1,166 @@
+// Data-quality release (Jul 3 2026 audit) — cached FAA hub-disruption lookup used by
+// api/schedule.ts (meta.hubDisruptionMinutes, #3) and api/cron/warm-schedules.ts (IROPS warm
+// priority, #7).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  computeHubDisruptionMinutes,
+  getHubDisruptionMinutes,
+  getDisruptedAirportsMap,
+  peekHubDisruptionMinutes,
+  kickDisruptionRefresh,
+  __resetFaaDisruptionCacheForTests,
+} from '../api/faa.js';
+
+function faaAirport(overrides = {}) {
+  return {
+    airportCode: 'ORD',
+    programs: [],
+    groundStop: false,
+    groundDelay: false,
+    departureDelay: false,
+    arrivalDelay: false,
+    closure: false,
+    avgDelay: null,
+    minDelay: null,
+    maxDelay: null,
+    delays: [],
+    ...overrides,
+  };
+}
+
+describe('computeHubDisruptionMinutes (pure)', () => {
+  it('returns 0 for missing/undisrupted airports', () => {
+    expect(computeHubDisruptionMinutes(null)).toBe(0);
+    expect(computeHubDisruptionMinutes(undefined)).toBe(0);
+    expect(computeHubDisruptionMinutes(faaAirport())).toBe(0);
+  });
+
+  it('uses the worst published delay figure for a GDP (the 293-min ORD case)', () => {
+    expect(computeHubDisruptionMinutes(faaAirport({ groundDelay: true, avgDelay: 293, maxDelay: 353 }))).toBe(293);
+  });
+
+  it('falls back to minDelay when no average is published', () => {
+    expect(computeHubDisruptionMinutes(faaAirport({ groundDelay: true, minDelay: 45, maxDelay: 90 }))).toBe(45);
+  });
+
+  it('floors a ground stop / closure with no published figure at 60 minutes', () => {
+    expect(computeHubDisruptionMinutes(faaAirport({ groundStop: true }))).toBe(60);
+    expect(computeHubDisruptionMinutes(faaAirport({ closure: true }))).toBe(60);
+  });
+
+  it('gives a numberless GDP a nominal 15 minutes', () => {
+    expect(computeHubDisruptionMinutes(faaAirport({ groundDelay: true }))).toBe(15);
+  });
+
+  it('does NOT treat routine departure/arrival delay advisories as an active disruption', () => {
+    // The documented contract is GDP/GS/closure only: a plain "departure delays 31-45 min"
+    // advisory must not trigger IROPS warm priority or the extended inference grace.
+    expect(computeHubDisruptionMinutes(faaAirport({ departureDelay: true, minDelay: 31, maxDelay: 45 }))).toBe(0);
+    expect(computeHubDisruptionMinutes(faaAirport({ arrivalDelay: true, minDelay: 16, maxDelay: 30 }))).toBe(0);
+    expect(computeHubDisruptionMinutes(faaAirport({ departureDelay: true, arrivalDelay: true }))).toBe(0);
+  });
+});
+
+describe('getHubDisruptionMinutes / getDisruptedAirportsMap (cached fetch)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __resetFaaDisruptionCacheForTests();
+  });
+
+  afterEach(() => {
+    __resetFaaDisruptionCacheForTests();
+  });
+
+  function mockFaaEvents(payload) {
+    return vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      if (String(url).includes('nasstatus.faa.gov/api/airport-events')) {
+        return { ok: true, status: 200, json: async () => payload };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+  }
+
+  it('parses live airport-events into per-hub disruption minutes', async () => {
+    mockFaaEvents([
+      {
+        airportId: 'ORD',
+        groundDelay: { impactingCondition: 'thunderstorms', avgDelay: '4 hours and 53 minutes', maxDelay: 353 },
+      },
+      { airportId: 'SFO', groundStop: { impactingCondition: 'low ceilings' } },
+      { airportId: 'DEN' }, // no programs
+    ]);
+    expect(await getHubDisruptionMinutes('ORD')).toBe(293);
+    expect(await getHubDisruptionMinutes('SFO')).toBe(60);
+    expect(await getHubDisruptionMinutes('DEN')).toBe(0);
+    expect(await getHubDisruptionMinutes('ewr')).toBe(0); // case-insensitive, absent hub
+  });
+
+  it('caches the map — repeated lookups do not refetch', async () => {
+    const fetchSpy = mockFaaEvents([{ airportId: 'ORD', groundDelay: { avgDelay: 100 } }]);
+    await getHubDisruptionMinutes('ORD');
+    await getHubDisruptionMinutes('DEN');
+    await getDisruptedAirportsMap();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('degrades to 0 (all hubs undisrupted) when the FAA endpoint fails, and negative-caches', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('down'));
+    expect(await getHubDisruptionMinutes('ORD')).toBe(0);
+    expect(await getHubDisruptionMinutes('ORD')).toBe(0);
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // negative cache: no hammering
+  });
+
+  it('degrades to 0 on schema-invalid payloads (non-array)', async () => {
+    mockFaaEvents({ ok: true });
+    expect(await getHubDisruptionMinutes('ORD')).toBe(0);
+  });
+});
+
+describe('peekHubDisruptionMinutes / kickDisruptionRefresh (non-blocking serve path)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __resetFaaDisruptionCacheForTests();
+  });
+
+  afterEach(() => {
+    __resetFaaDisruptionCacheForTests();
+  });
+
+  it('peek on a cold cache returns 0 and NEVER fetches', () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      throw new Error('peek must not fetch');
+    });
+    expect(peekHubDisruptionMinutes('ORD')).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('kick warms the cache in the background; later peeks read the cached value synchronously', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      if (String(url).includes('nasstatus.faa.gov/api/airport-events')) {
+        return { ok: true, status: 200, json: async () => ([{ airportId: 'ORD', groundDelay: { avgDelay: 293 } }]) };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    const refresh = kickDisruptionRefresh();
+    expect(refresh).toBeTruthy(); // cold cache → refresh started
+    await refresh;
+    expect(peekHubDisruptionMinutes('ORD')).toBe(293);
+    expect(peekHubDisruptionMinutes('ord')).toBe(293); // case-insensitive
+    expect(peekHubDisruptionMinutes('DEN')).toBe(0);
+    expect(kickDisruptionRefresh()).toBeNull(); // fresh cache → nothing to do
+  });
+
+  it('kick joins the in-flight refresh instead of double-fetching', async () => {
+    let resolveFetch;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () => new Promise((resolve) => { resolveFetch = resolve; })
+    );
+    const a = kickDisruptionRefresh();
+    const b = kickDisruptionRefresh();
+    expect(b).toBe(a);
+    resolveFetch({ ok: true, status: 200, json: async () => [] });
+    await a;
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/flight-times-fallback.test.js
+++ b/tests/flight-times-fallback.test.js
@@ -1,0 +1,236 @@
+// Data-quality release (Jul 3 2026 audit) — #1 flight-times source chain:
+// FlightAware's bot-wall serves a PARSEABLE trackpollBootstrap with zero flights; that must be
+// treated as a source failure (→ FR24 → schedule-cache), never as "No active flight found".
+// The FR24 tier is a paid official-API call and must respect the isOfficialFr24Enabled() kill
+// switch (OFF in prod while credits are exhausted).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const snapshotMocks = vi.hoisted(() => ({
+  loadScheduleSnapshot: vi.fn(async () => null),
+  saveScheduleSnapshot: vi.fn(async () => {}),
+  getSupabaseAdmin: vi.fn(async () => null),
+}));
+
+vi.mock(process.cwd() + '/api/_schedule-snapshots.ts', () => snapshotMocks);
+
+import handler from '../api/flight-times.js';
+import { getStartOfHubDay } from '../src/lib/hubTz.js';
+
+function createRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    setHeader(name, value) { this.headers[name] = value; },
+    status(code) { this.statusCode = code; return this; },
+    end() { return this; },
+    json(payload) { this.body = payload; return this; },
+  };
+}
+
+// Distinct IPs keep each test clear of the 30 req/min per-IP limiter.
+let reqCounter = 0;
+function createReq(flight) {
+  reqCounter++;
+  return {
+    method: 'GET',
+    headers: { origin: 'http://localhost:3000', 'x-real-ip': `10.0.0.${reqCounter}` },
+    query: { flight },
+  };
+}
+
+function faHtml(bootstrap) {
+  return `<html><script>var trackpollBootstrap = ${JSON.stringify(bootstrap)};var other = 1;</script></html>`;
+}
+
+const EMPTY_BOOTSTRAP = { flights: {} }; // the bot-wall shape: parses fine, zero flights
+
+function populatedBootstrap(depEpoch) {
+  return {
+    flights: {
+      'UAL111-1751500000-airline-0500': {
+        activityLog: {
+          flights: [{
+            origin: { iata: 'ORD', friendlyName: "Chicago O'Hare Intl", TZ: ':America/Chicago', terminal: '1', gate: 'C18' },
+            destination: { iata: 'SFO', friendlyName: 'San Francisco Intl', TZ: ':America/Los_Angeles', terminal: '3', gate: 'F11' },
+            gateDepartureTimes: { scheduled: depEpoch, estimated: depEpoch + 300, actual: null },
+            takeoffTimes: { scheduled: depEpoch + 900, estimated: depEpoch + 1200, actual: null },
+            landingTimes: {}, gateArrivalTimes: {},
+            aircraftTypeFriendly: 'Boeing 737 MAX 9', flightStatus: 'scheduled', cancelled: false, diverted: false,
+          }],
+        },
+      },
+    },
+  };
+}
+
+const FR24_SUMMARY = {
+  data: [{
+    fr24_id: 'x', flight: 'UA9002', callsign: 'UAL9002', type: 'B39M', reg: 'N37502',
+    orig_icao: 'KORD', dest_icao: 'KSFO', dest_icao_actual: 'KSFO',
+    datetime_takeoff: '2026-07-03T02:10:00Z', datetime_landed: '', flight_ended: false,
+  }],
+};
+
+function scheduleSnapshotRow(flightNum, schedDep, estDep, realDep, schedArr) {
+  return {
+    data: {
+      flights: [{
+        identification: { number: { default: flightNum }, callsign: `UAL${flightNum.slice(2)}` },
+        airline: { code: { iata: 'UA' } },
+        status: { generic: { status: { text: 'delayed', diverted: false }, type: '' }, text: 'delayed', icon: 'yellow', live: false },
+        time: {
+          scheduled: { departure: schedDep, arrival: schedArr },
+          real: { departure: realDep, arrival: null },
+          estimated: { departure: estDep, arrival: null },
+        },
+        airport: {
+          origin: { code: { iata: 'ORD' }, name: "Chicago O'Hare", info: { gate: 'C18', terminal: '1' } },
+          destination: { code: { iata: 'SFO' }, name: 'San Francisco', info: { gate: 'F11', terminal: '3' } },
+        },
+        aircraft: { model: { code: '', text: 'Boeing 737 MAX 9' }, registration: 'N37502' },
+      }],
+      total: 1,
+    },
+    refreshedAt: Date.now() - 60_000,
+  };
+}
+
+describe('flight-times fallback chain (#1)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    snapshotMocks.loadScheduleSnapshot.mockReset();
+    snapshotMocks.loadScheduleSnapshot.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    delete process.env.FR24_API_TOKEN;
+    delete process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED;
+  });
+
+  it('still serves FlightAware when the bootstrap has flights (source: flightaware)', async () => {
+    const dep = Math.floor(Date.now() / 1000) + 3600;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      if (String(url).includes('flightaware.com')) {
+        return { ok: true, status: 200, text: async () => faHtml(populatedBootstrap(dep)) };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    const res = createRes();
+    await handler(createReq('UA9001'), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.source).toBe('flightaware');
+    expect(res.body.origin.iata).toBe('ORD');
+  });
+
+  it('empty bootstrap (bot-wall) → falls through to FR24 instead of "No active flight found"', async () => {
+    process.env.FR24_API_TOKEN = 'test-token';
+    const calls = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      calls.push(String(url));
+      if (String(url).includes('flightaware.com')) {
+        return { ok: true, status: 200, text: async () => faHtml(EMPTY_BOOTSTRAP) };
+      }
+      if (String(url).includes('fr24api.flightradar24.com')) {
+        return { ok: true, status: 200, json: async () => FR24_SUMMARY };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    const res = createRes();
+    await handler(createReq('UA9002'), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.source).toBe('fr24');
+    expect(res.body.origin.iata).toBe('ORD');
+    expect(calls.some((u) => u.includes('fr24api.flightradar24.com'))).toBe(true);
+  });
+
+  it('kill switch on (SCHEDULE_OFFICIAL_FALLBACK_ENABLED=false) → FR24 is NEVER called', async () => {
+    process.env.FR24_API_TOKEN = 'test-token';
+    process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED = 'false';
+    const calls = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      calls.push(String(url));
+      if (String(url).includes('flightaware.com')) {
+        return { ok: true, status: 200, text: async () => faHtml(EMPTY_BOOTSTRAP) };
+      }
+      return { ok: true, status: 200, json: async () => FR24_SUMMARY };
+    });
+    const res = createRes();
+    await handler(createReq('UA9003'), res);
+    // No snapshots either → honest all-sources-failed, but the paid API was never touched.
+    expect(calls.some((u) => u.includes('fr24api.flightradar24.com'))).toBe(false);
+    expect(res.statusCode).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('schedule-cache tier: serves sched/est/real times from a persisted hub board snapshot', async () => {
+    // No FR24 token → chain skips straight to the snapshot layer.
+    const schedDep = 1_751_500_000;
+    const estDep = schedDep + 10_000;
+    const realDep = schedDep + 10_060;
+    const schedArr = schedDep + 15_000;
+    const ordKey = `agg:ORD:departures:${getStartOfHubDay('ORD', 0)}`;
+    snapshotMocks.loadScheduleSnapshot.mockImplementation(async (key) =>
+      key === ordKey ? scheduleSnapshotRow('UA9004', schedDep, estDep, realDep, schedArr) : null
+    );
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      if (String(url).includes('flightaware.com')) {
+        return { ok: true, status: 200, text: async () => faHtml(EMPTY_BOOTSTRAP) };
+      }
+      throw new Error(`paid/upstream fetch must not happen: ${url}`);
+    });
+    const res = createRes();
+    await handler(createReq('UA9004'), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.source).toBe('schedule-cache');
+    expect(res.body.flight).toBe('UA9004');
+    expect(res.body.origin.iata).toBe('ORD');
+    expect(res.body.destination.iata).toBe('SFO');
+    expect(res.body.departure.gate.scheduled).toBe(new Date(schedDep * 1000).toISOString());
+    expect(res.body.departure.gate.estimated).toBe(new Date(estDep * 1000).toISOString());
+    expect(res.body.departure.gate.actual).toBe(new Date(realDep * 1000).toISOString());
+    expect(res.body.arrival.gate.scheduled).toBe(new Date(schedArr * 1000).toISOString());
+    expect(res.body.aircraft).toBe('Boeing 737 MAX 9');
+  });
+
+  it('all sources failed → success:false with a clear reason (and only then)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      if (String(url).includes('flightaware.com')) {
+        return { ok: true, status: 200, text: async () => faHtml(EMPTY_BOOTSTRAP) };
+      }
+      return { ok: false, status: 500, json: async () => ({}), text: async () => '' };
+    });
+    const res = createRes();
+    await handler(createReq('UA9005'), res);
+    expect(res.statusCode).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.reason).toMatch(/bot-wall/);
+    expect(res.body.reason).toMatch(/schedule-cache/);
+  });
+
+  it('FlightAware HTTP failure also runs the chain (FR24 disabled → schedule-cache)', async () => {
+    process.env.FR24_API_TOKEN = 'test-token';
+    process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED = '0';
+    const schedDep = 1_751_500_000;
+    const ordKey = `agg:ORD:departures:${getStartOfHubDay('ORD', 0)}`;
+    snapshotMocks.loadScheduleSnapshot.mockImplementation(async (key) =>
+      key === ordKey ? scheduleSnapshotRow('UA9006', schedDep, null, null, schedDep + 14400) : null
+    );
+    const calls = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      calls.push(String(url));
+      if (String(url).includes('flightaware.com')) {
+        return { ok: false, status: 403, text: async () => 'blocked' };
+      }
+      return { ok: true, status: 200, json: async () => FR24_SUMMARY };
+    });
+    const res = createRes();
+    await handler(createReq('UA9006'), res);
+    expect(calls.some((u) => u.includes('fr24api.flightradar24.com'))).toBe(false);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.source).toBe('schedule-cache');
+  });
+});

--- a/tests/irops.test.js
+++ b/tests/irops.test.js
@@ -81,6 +81,22 @@ describe('computeMetrics', () => {
     expect(result.cancellations).toBe(1);
   });
 
+  it('counts canceled_uncertain (AeroDataBox soft-cancel) as a cancellation, globally and per hub', () => {
+    // Likely-canceled rows group under Canceled everywhere else in the UI; the server metrics
+    // must agree or they vanish from the IROPS index and Delays tab cancellation counts.
+    const t = 1700000000;
+    const flights = [
+      makeFlight('ORD', { schedDep: t, realDep: t, status: 'landed' }),
+      makeFlight('ORD', { schedDep: t, status: 'canceled' }),
+      makeFlight('ORD', { schedDep: t, status: 'canceled_uncertain' }),
+    ];
+    const result = computeMetrics({ ORD: flights });
+    expect(result.cancellations).toBe(2);
+    expect(result.hubMetrics.ORD.cancellations).toBe(2);
+    // score = (2 cancels * 3 / 3 flights) * 100 = 200 — soft cancels move the index too.
+    expect(result.score).toBe(200);
+  });
+
   it('weights 60-min delays at 2x', () => {
     const t = 1700000000;
     const flights = [

--- a/tests/ops-health.test.js
+++ b/tests/ops-health.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { deriveOpsHealth, extractHubPrograms } from '../src/lib/ops-health.js';
+
+const HUBS = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM'];
+
+describe('extractHubPrograms', () => {
+  it('detects ground stops via the boolean flag and via delays[].type', () => {
+    const faa = {
+      EWR: { groundStop: true },
+      ORD: { delays: [{ type: 'Ground Stop', avgDelay: 45 }] },
+      DEN: { delays: [{ type: 'ground_stop' }] },
+    };
+    const programs = extractHubPrograms(faa, HUBS);
+    expect(programs.map((p) => `${p.hub}:${p.kind}`).sort()).toEqual(['DEN:GS', 'EWR:GS', 'ORD:GS']);
+  });
+
+  it('detects GDPs and carries avgDelay', () => {
+    const faa = { SFO: { delays: [{ type: 'Ground Delay Program', avgDelay: 72 }] } };
+    expect(extractHubPrograms(faa, HUBS)).toEqual([{ hub: 'SFO', kind: 'GDP', avgDelay: 72 }]);
+  });
+
+  it('ignores non-hub airports and malformed entries', () => {
+    const faa = { ATL: { groundStop: true }, ORD: null, DEN: 'nope' };
+    expect(extractHubPrograms(faa, HUBS)).toEqual([]);
+    expect(extractHubPrograms(undefined, HUBS)).toEqual([]);
+  });
+});
+
+describe('deriveOpsHealth', () => {
+  it('is normal when hubs are healthy, no programs, and IROPS is quiet', () => {
+    const h = deriveOpsHealth({ hubOtps: { ORD: 82, DEN: 91 }, faaIndex: {}, hubCodes: HUBS, iropsScore: 3.2 });
+    expect(h.level).toBe('normal');
+  });
+
+  it('goes amber with the worst hub fact when any hub OTP < 50%', () => {
+    const h = deriveOpsHealth({ hubOtps: { ORD: 42, DEN: 88, EWR: 61 }, faaIndex: {}, hubCodes: HUBS, iropsScore: 4 });
+    expect(h.level).toBe('advisory');
+    expect(h.text).toBe('Disrupted: ORD on-time 42%');
+  });
+
+  it('a ground stop at a UA hub always disrupts, even with healthy OTP', () => {
+    const h = deriveOpsHealth({
+      hubOtps: { ORD: 90 },
+      faaIndex: { EWR: { groundStop: true } },
+      hubCodes: HUBS,
+      iropsScore: 2,
+    });
+    expect(h.level).toBe('advisory');
+    expect(h.text).toBe('Disrupted: EWR ground stop');
+  });
+
+  it('a GDP at a UA hub disrupts with the avg delay fact', () => {
+    const h = deriveOpsHealth({
+      hubOtps: {},
+      faaIndex: { SFO: { delays: [{ type: 'Ground Delay Program', avgDelay: 72 }] } },
+      hubCodes: HUBS,
+      iropsScore: null,
+    });
+    expect(h.level).toBe('advisory');
+    expect(h.text).toBe('Disrupted: SFO ground delay program (avg 72m)');
+  });
+
+  it('never reports normal when the IROPS index is red (>= 15)', () => {
+    // The live contradiction: ticker green while IROPS showed 56.7 red.
+    const h = deriveOpsHealth({ hubOtps: { ORD: 75 }, faaIndex: {}, hubCodes: HUBS, iropsScore: 56.7 });
+    expect(h.level).toBe('advisory');
+    expect(h.text).toBe('Elevated irregular ops — IROPS 56.7/100');
+  });
+
+  it('prefers the ground-stop fact over the OTP fact when both apply', () => {
+    const h = deriveOpsHealth({
+      hubOtps: { DEN: 38 },
+      faaIndex: { ORD: { groundStop: true } },
+      hubCodes: HUBS,
+      iropsScore: 60,
+    });
+    expect(h.level).toBe('advisory');
+    expect(h.text).toContain('ground stop');
+  });
+
+  it('degrades gracefully with no inputs at all (old cached payloads)', () => {
+    expect(deriveOpsHealth({}).level).toBe('normal');
+    expect(deriveOpsHealth().level).toBe('normal');
+  });
+});

--- a/tests/schedule-meta-disruption.test.js
+++ b/tests/schedule-meta-disruption.test.js
@@ -1,0 +1,186 @@
+// Data-quality release (Jul 3 2026 audit) — #3 server side: every aggregation-mode board
+// response carries meta.hubDisruptionMinutes (live FAA program magnitude, 0 when none) so the
+// frontend can extend the Departed-inference grace during a GDP.
+// NON-BLOCKING contract: serve paths attach the synchronously PEEKED cached value and kick a
+// background refresh when the cache is cold — a cache-hit serve never awaits the FAA fetch
+// (the first request after a cold start may read 0; the refresh warms it for the next).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const scheduleSnapshotMocks = vi.hoisted(() => ({
+  loadScheduleSnapshot: vi.fn(async () => null),
+  saveScheduleSnapshot: vi.fn(async () => {}),
+  getSupabaseAdmin: vi.fn(async () => null),
+}));
+
+const vercelFunctionMocks = vi.hoisted(() => ({
+  waitUntil: vi.fn(),
+}));
+
+vi.mock(process.cwd() + '/api/_schedule-snapshots.ts', () => scheduleSnapshotMocks);
+vi.mock('@vercel/functions', () => vercelFunctionMocks);
+
+import handler, { resetFallbackBreaker, __resetScheduleCachesForTests } from '../api/schedule.js';
+import { __resetFaaDisruptionCacheForTests } from '../api/faa.js';
+import { __resetRateLimitersForTests } from '../api/_rate-limit.js';
+
+function createRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    setHeader(name, value) { this.headers[name] = value; },
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; },
+  };
+}
+
+function mockUpstreams({ ordDisruptionAvg = null, adbBoard = true } = {}) {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const iso = (offsetS) => new Date((nowSec + offsetS) * 1000).toISOString();
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+    const u = String(url);
+    if (u.includes('nasstatus.faa.gov/api/airport-events')) {
+      const events = ordDisruptionAvg
+        ? [{ airportId: 'ORD', groundDelay: { impactingCondition: 'thunderstorms', avgDelay: ordDisruptionAvg, maxDelay: ordDisruptionAvg + 60 } }]
+        : [];
+      return { ok: true, status: 200, headers: { get: () => null }, json: async () => events };
+    }
+    if (u.includes('aedbx/aerodatabox') && adbBoard) {
+      return {
+        ok: true, status: 200,
+        json: async () => ({
+          departures: [{
+            number: 'UA 123', callSign: 'UAL123', status: 'Scheduled',
+            airline: { iata: 'UA', icao: 'UAL', name: 'United Airlines' },
+            departure: { scheduledTime: { utc: iso(7200) }, terminal: '1', gate: 'C18', airport: { iata: 'ORD' } },
+            arrival: { scheduledTime: { utc: iso(18000) }, airport: { iata: 'SFO' } },
+            aircraft: { model: 'Boeing 737 MAX 9', reg: 'N37502' },
+          }],
+        }),
+      };
+    }
+    return { ok: false, status: 403, text: async () => 'blocked', headers: { get: () => null }, json: async () => ({}) };
+  });
+}
+
+describe('schedule board meta.hubDisruptionMinutes', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __resetRateLimitersForTests();
+    __resetScheduleCachesForTests();
+    __resetFaaDisruptionCacheForTests();
+    process.env.AERODATABOX_INTER_WINDOW_DELAY_MS = '0';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'provider';
+    process.env.AERODATABOX_API_KEY = 'adb-test-key';
+    scheduleSnapshotMocks.loadScheduleSnapshot.mockReset();
+    scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue(null);
+    scheduleSnapshotMocks.saveScheduleSnapshot.mockReset();
+    scheduleSnapshotMocks.saveScheduleSnapshot.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    delete process.env.AERODATABOX_INTER_WINDOW_DELAY_MS;
+    delete process.env.SCHEDULE_SOURCE_PRIORITY;
+    delete process.env.AERODATABOX_API_KEY;
+    __resetFaaDisruptionCacheForTests();
+    resetFallbackBreaker();
+  });
+
+  function boardReq(hub = 'ORD') {
+    return {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub, dir: 'departures', timestamp: String(Math.floor(Date.now() / 1000)) },
+    };
+  }
+
+  it('carries the live GDP magnitude on a fresh provider board (the ORD 293-min case)', async () => {
+    // The kick fires at request start; the FAA mock resolves in microtasks while the (much
+    // longer) provider board fetch runs, so the peek at serve time reads the warmed 293.
+    mockUpstreams({ ordDisruptionAvg: 293 });
+    const res = createRes();
+    await handler(boardReq('ORD'), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.meta.source).toBe('aerodatabox');
+    expect(res.body.meta.hubDisruptionMinutes).toBe(293);
+  });
+
+  it('reports 0 when the hub has no active FAA program', async () => {
+    mockUpstreams({ ordDisruptionAvg: null });
+    const res = createRes();
+    await handler(boardReq('ORD'), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.meta.hubDisruptionMinutes).toBe(0);
+  });
+
+  it('reports 0 (never throws) when the FAA lookup itself is down', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const iso = (offsetS) => new Date((nowSec + offsetS) * 1000).toISOString();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const u = String(url);
+      if (u.includes('nasstatus.faa.gov')) throw new Error('FAA down');
+      if (u.includes('aedbx/aerodatabox')) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({
+            departures: [{
+              number: 'UA 456', callSign: 'UAL456', status: 'Scheduled',
+              airline: { iata: 'UA' },
+              departure: { scheduledTime: { utc: iso(7200) }, airport: { iata: 'DEN' } },
+              arrival: { scheduledTime: { utc: iso(18000) }, airport: { iata: 'ORD' } },
+              aircraft: {},
+            }],
+          }),
+        };
+      }
+      return { ok: false, status: 403, text: async () => 'blocked', headers: { get: () => null } };
+    });
+    const res = createRes();
+    await handler(boardReq('DEN'), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.meta.hubDisruptionMinutes).toBe(0);
+  });
+
+  it('also attaches the field on cache-served boards (second request, same key)', async () => {
+    mockUpstreams({ ordDisruptionAvg: 293 });
+    const first = createRes();
+    await handler(boardReq('ORD'), first);
+    expect(first.body.cached).toBeFalsy();
+
+    const second = createRes();
+    await handler(boardReq('ORD'), second);
+    expect(second.statusCode).toBe(200);
+    expect(second.body.cached).toBe(true);
+    expect(second.body.meta.hubDisruptionMinutes).toBe(293);
+  });
+
+  it('a cache-hit serve does NOT await the FAA fetch: response returns while the FAA fetch hangs', async () => {
+    // Warm the board cache with the FAA endpoint healthy-but-empty (no disruption).
+    mockUpstreams({ ordDisruptionAvg: null });
+    const first = createRes();
+    await handler(boardReq('ORD'), first);
+    expect(first.statusCode).toBe(200);
+
+    // Expire the FAA disruption cache and make the FAA fetch HANG FOREVER. Under the old
+    // blocking contract every cache-hit serve awaited withDisruption → this handler call would
+    // never resolve (test timeout). The non-blocking contract peeks (0) and kicks the refresh
+    // into the background instead.
+    __resetFaaDisruptionCacheForTests();
+    const faaCalls = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      if (String(url).includes('nasstatus.faa.gov')) {
+        faaCalls.push(String(url));
+        return new Promise(() => {}); // hangs — never resolves
+      }
+      throw new Error(`cache-hit serve must not refetch the board: ${url}`);
+    });
+
+    const second = createRes();
+    await handler(boardReq('ORD'), second);
+    expect(second.statusCode).toBe(200);
+    expect(second.body.cached).toBe(true);
+    // The refresh WAS kicked (background), but the serve did not wait for it.
+    expect(faaCalls.length).toBe(1);
+    expect(second.body.meta.hubDisruptionMinutes).toBe(0);
+  });
+});

--- a/tests/schedule-snapshots.test.js
+++ b/tests/schedule-snapshots.test.js
@@ -112,6 +112,32 @@ describe('isSnapshotCandidateBetter', () => {
     )).toBe(false);
   });
 
+  it('ranks on dedupe-adjusted totals: a fresh 700-flight deduped board replaces a stale 717-row dup-laden snapshot', () => {
+    // Pre-dedupe persisted snapshot: 717 rows, 17 of them revision dupes / operator clones /
+    // foreign leaks. Fresh deduped board: 700 real flights + meta.dedupe accounting for the 17.
+    // Raw-total ranking let the stale snapshot outrank every fresh deduped board and refuse
+    // overwrite for its whole 72h TTL.
+    const staleDupLaden = { partial: true, total: 717, meta: { completeness: 0.5, pagesSucceeded: 1 } };
+    const freshDeduped = {
+      partial: true, total: 700,
+      meta: { completeness: 0.5, pagesSucceeded: 1, dedupe: { revisions: 16, operatorClones: 1, foreign: 0 } },
+    };
+    expect(isSnapshotCandidateBetter(freshDeduped, staleDupLaden)).toBe(true);
+    // And the reverse: the un-deduped 717 board must NOT beat the persisted deduped 700 board.
+    expect(isSnapshotCandidateBetter(staleDupLaden, freshDeduped)).toBe(false);
+  });
+
+  it('dedupe adjustment cannot manufacture a win over genuinely better coverage', () => {
+    // 690 + 17 dropped = 707 effective < 717 raw: the dup-laden snapshot still carries more
+    // underlying flights, so it stays.
+    const staleDupLaden = { partial: true, total: 717, meta: { completeness: 0.5, pagesSucceeded: 1 } };
+    const smallerDeduped = {
+      partial: true, total: 690,
+      meta: { completeness: 0.5, pagesSucceeded: 1, dedupe: { revisions: 16, operatorClones: 1, foreign: 0 } },
+    };
+    expect(isSnapshotCandidateBetter(smallerDeduped, staleDupLaden)).toBe(false);
+  });
+
   it('uses pagesSucceeded as final tiebreaker', () => {
     expect(isSnapshotCandidateBetter(
       { partial: true, total: 50, meta: { completeness: 0.5, pagesSucceeded: 5 } },

--- a/tests/schedule-status-dq.test.js
+++ b/tests/schedule-status-dq.test.js
@@ -1,0 +1,162 @@
+// Data-quality release (Jul 3 2026 ORD GDP audit) — schedule-status contract tests:
+//   #2 CanceledUncertain becomes its own soft state ('canceled_uncertain' / "Likely Canceled" / warn)
+//   #3 presumed flag on time-inferred statuses + hubDisruptionMinutes grace extension
+//   #6 provider 'Delayed' flows into the dedicated 'delayed' key (Delayed filter no longer empty)
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifySchedStatus,
+  operatedGraceSeconds,
+  OPERATED_GRACE_SECONDS,
+} from '../src/lib/schedule-status.js';
+import { mapAeroStatus } from '../api/_schedule-aerodatabox.js';
+
+const NOW = 2_000_000; // fixed "now" in unix seconds
+
+function flight({ status, schedDep, schedArr, realDep, realArr, estDep, estArr } = {}) {
+  return {
+    status,
+    time: {
+      scheduled: { departure: schedDep ?? null, arrival: schedArr ?? null },
+      real: { departure: realDep ?? null, arrival: realArr ?? null },
+      estimated: { departure: estDep ?? null, arrival: estArr ?? null },
+    },
+  };
+}
+
+describe('mapAeroStatus (AeroDataBox provider mapping)', () => {
+  it('maps CanceledUncertain to the soft canceled_uncertain state (yellow, not red)', () => {
+    const s = mapAeroStatus('CanceledUncertain');
+    expect(s.generic.status.text).toBe('canceled_uncertain');
+    expect(s.generic.type).toBe('canceled_uncertain');
+    expect(s.icon).toBe('yellow');
+    expect(s.live).toBe(false);
+  });
+
+  it('keeps plain Canceled as the hard red canceled state', () => {
+    const s = mapAeroStatus('Canceled');
+    expect(s.generic.status.text).toBe('canceled');
+    expect(s.generic.type).toBe('canceled');
+    expect(s.icon).toBe('red');
+  });
+
+  it("maps provider Delayed to the dedicated 'delayed' key instead of generic 'estimated'", () => {
+    const s = mapAeroStatus('Delayed');
+    expect(s.generic.status.text).toBe('delayed');
+    expect(s.icon).toBe('yellow');
+  });
+});
+
+describe('classifySchedStatus — canceled_uncertain soft state (#2)', () => {
+  it('classifies an ADB CanceledUncertain row as Likely Canceled / warn / canceled_uncertain', () => {
+    const fl = flight({ status: mapAeroStatus('CanceledUncertain'), schedDep: NOW + 3600 });
+    const s = classifySchedStatus(fl, 'departures', NOW);
+    expect(s.key).toBe('canceled_uncertain');
+    expect(s.label).toBe('Likely Canceled');
+    expect(s.text).toBe('Likely Canceled');
+    expect(s.cls).toBe('warn'); // NOT the red canceled cls
+  });
+
+  it('leaves plain Canceled classification completely unchanged', () => {
+    const fl = flight({ status: mapAeroStatus('Canceled'), schedDep: NOW + 3600 });
+    const s = classifySchedStatus(fl, 'departures', NOW);
+    expect(s.key).toBe('canceled');
+    expect(s.cls).toBe('canceled');
+  });
+
+  it('does NOT time-infer a canceled_uncertain flight into Departed, even long past', () => {
+    const fl = flight({ status: mapAeroStatus('CanceledUncertain'), schedDep: NOW - 8 * 3600 });
+    expect(classifySchedStatus(fl, 'departures', NOW).key).toBe('canceled_uncertain');
+  });
+
+  it('lets a confirmed real departure time win over the cancellation suspicion', () => {
+    const fl = flight({ status: mapAeroStatus('CanceledUncertain'), schedDep: NOW - 7200, realDep: NOW - 3600 });
+    const s = classifySchedStatus(fl, 'departures', NOW);
+    expect(s.key).toBe('departed');
+    expect(s.inferred).toBeUndefined(); // provider-confirmed, not time-inferred
+  });
+
+  it('lets a confirmed real arrival time win on the arrivals board', () => {
+    const fl = flight({ status: mapAeroStatus('CanceledUncertain'), schedArr: NOW - 7200, realArr: NOW - 3600 });
+    expect(classifySchedStatus(fl, 'arrivals', NOW).key).toBe('landed');
+  });
+});
+
+describe('classifySchedStatus — presumed flag + disruption-aware grace (#3)', () => {
+  it('grace extension math: max(3600, (hubDisruptionMinutes + 60) * 60)', () => {
+    expect(operatedGraceSeconds(0)).toBe(OPERATED_GRACE_SECONDS);
+    expect(operatedGraceSeconds(undefined)).toBe(OPERATED_GRACE_SECONDS);
+    expect(operatedGraceSeconds(null)).toBe(OPERATED_GRACE_SECONDS);
+    expect(operatedGraceSeconds(-10)).toBe(OPERATED_GRACE_SECONDS);
+    expect(operatedGraceSeconds('garbage')).toBe(OPERATED_GRACE_SECONDS);
+    // tiny disruption never SHRINKS the grace below the 60m default
+    expect(operatedGraceSeconds(5)).toBe(Math.max(3600, 65 * 60));
+    // the real ORD GDP: 293-min average → (293 + 60) * 60 = 21180s (~5.9h)
+    expect(operatedGraceSeconds(293)).toBe(21180);
+  });
+
+  it('sets presumed:true (alongside inferred:true) on every time-inferred departure', () => {
+    const fl = flight({ status: mapAeroStatus('Expected'), schedDep: NOW - 2 * 3600 });
+    const s = classifySchedStatus(fl, 'departures', NOW);
+    expect(s.key).toBe('departed');
+    expect(s.inferred).toBe(true);
+    expect(s.presumed).toBe(true);
+  });
+
+  it('sets presumed:true on time-inferred landings (arrivals board) too', () => {
+    const fl = flight({ status: mapAeroStatus('Expected'), schedArr: NOW - 2 * 3600 });
+    const s = classifySchedStatus(fl, 'arrivals', NOW);
+    expect(s.key).toBe('landed');
+    expect(s.presumed).toBe(true);
+  });
+
+  it('does NOT set presumed on provider-confirmed departures', () => {
+    const fl = flight({ status: mapAeroStatus('Departed'), schedDep: NOW - 2 * 3600, realDep: NOW - 3600 });
+    const s = classifySchedStatus(fl, 'departures', NOW);
+    expect(s.key).toBe('departed');
+    expect(s.presumed).toBeUndefined();
+    expect(s.inferred).toBeUndefined();
+  });
+
+  it('the UA2610 case: 2h past scheduled during a 293-min GDP stays Scheduled, not false Departed', () => {
+    const fl = flight({ status: mapAeroStatus('Expected'), schedDep: NOW - 2 * 3600 });
+    // Without disruption context the old behavior infers Departed...
+    expect(classifySchedStatus(fl, 'departures', NOW).key).toBe('departed');
+    // ...but with the hub's GDP magnitude the grace covers the program: still Scheduled.
+    const s = classifySchedStatus(fl, 'departures', NOW, { hubDisruptionMinutes: 293 });
+    expect(s.key).toBe('scheduled');
+    expect(s.presumed).toBeUndefined();
+  });
+
+  it('still infers Departed once past even the EXTENDED grace', () => {
+    const grace = operatedGraceSeconds(293); // 21180s
+    const fl = flight({ status: mapAeroStatus('Expected'), schedDep: NOW - grace - 1 });
+    const s = classifySchedStatus(fl, 'departures', NOW, { hubDisruptionMinutes: 293 });
+    expect(s.key).toBe('departed');
+    expect(s.presumed).toBe(true);
+  });
+
+  it('hubDisruptionMinutes: 0 / omitted opts preserve the exact legacy boundary', () => {
+    const atBoundary = flight({ status: mapAeroStatus('Expected'), schedDep: NOW - OPERATED_GRACE_SECONDS });
+    expect(classifySchedStatus(atBoundary, 'departures', NOW, { hubDisruptionMinutes: 0 }).key).toBe('scheduled');
+    const oneOver = flight({ status: mapAeroStatus('Expected'), schedDep: NOW - OPERATED_GRACE_SECONDS - 1 });
+    expect(classifySchedStatus(oneOver, 'departures', NOW, { hubDisruptionMinutes: 0 }).key).toBe('departed');
+    expect(classifySchedStatus(oneOver, 'departures', NOW).key).toBe('departed'); // no opts at all
+  });
+});
+
+describe('classifySchedStatus — provider Delayed key (#6)', () => {
+  it("an ADB Delayed row classifies to key 'delayed' (feeds the Delayed filter + Upcoming bucket)", () => {
+    const fl = flight({ status: mapAeroStatus('Delayed'), schedDep: NOW + 1800, estDep: NOW + 5400 });
+    const s = classifySchedStatus(fl, 'departures', NOW);
+    expect(s.key).toBe('delayed');
+    expect(s.cls).toBe('delayed');
+  });
+
+  it("a long-past Delayed row still time-infers Departed (key 'delayed' stays reclassifiable)", () => {
+    const fl = flight({ status: mapAeroStatus('Delayed'), schedDep: NOW - 6 * 3600 });
+    const s = classifySchedStatus(fl, 'departures', NOW);
+    expect(s.key).toBe('departed');
+    expect(s.presumed).toBe(true);
+  });
+});

--- a/tests/status-display.test.js
+++ b/tests/status-display.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { displayScheduleStatus, humanizeStatusText, looksRawStatusText } from '../src/lib/status-display.js';
+
+describe('displayScheduleStatus', () => {
+  it('renders key unknown as "Scheduled" with an as-of stamp flag', () => {
+    const d = displayScheduleStatus({ text: 'Unknown', cls: 'unknown', key: 'unknown' });
+    expect(d.text).toBe('Scheduled');
+    expect(d.cls).toBe('scheduled');
+    expect(d.asOf).toBe(true);
+  });
+
+  it('gives canceled_uncertain its proper Likely Canceled label + warn class', () => {
+    const d = displayScheduleStatus({ text: 'Likely Canceled', label: 'Likely Canceled', cls: 'warn', key: 'canceled_uncertain' });
+    expect(d.text).toBe('Likely Canceled');
+    expect(d.cls).toBe('warn');
+  });
+
+  it('defends canceled_uncertain when the label/cls fields are missing (old cached payload)', () => {
+    const d = displayScheduleStatus({ text: 'canceleduncertain', key: 'canceled_uncertain' });
+    expect(d.text).toBe('Likely Canceled');
+    expect(d.cls).toBe('warn');
+  });
+
+  it('flags presumed departures (from presumed OR legacy inferred)', () => {
+    expect(displayScheduleStatus({ text: 'Departed', cls: 'departed', key: 'departed', presumed: true }).presumed).toBe(true);
+    expect(displayScheduleStatus({ text: 'Departed', cls: 'departed', key: 'departed', inferred: true }).presumed).toBe(true);
+    expect(displayScheduleStatus({ text: 'Departed', cls: 'departed', key: 'departed' }).presumed).toBe(false);
+  });
+
+  it('title-cases raw provider strings that leak through', () => {
+    const d = displayScheduleStatus({ text: 'gate_hold', cls: 'delayed', key: 'delayed' });
+    expect(d.text).toBe('Gate Hold');
+  });
+
+  it('leaves normal display text untouched', () => {
+    const d = displayScheduleStatus({ text: 'En Route', cls: 'enroute', key: 'enroute' });
+    expect(d.text).toBe('En Route');
+  });
+
+  it('degrades a null/absent classification to Scheduled + as-of', () => {
+    const d = displayScheduleStatus(null);
+    expect(d.text).toBe('Scheduled');
+    expect(d.asOf).toBe(true);
+  });
+});
+
+describe('humanizeStatusText', () => {
+  it('splits underscores and camelCase and title-cases each word', () => {
+    expect(humanizeStatusText('canceled_uncertain')).toBe('Canceled Uncertain');
+    expect(humanizeStatusText('enRoute')).toBe('En Route');
+    expect(humanizeStatusText('DELAYED')).toBe('Delayed');
+  });
+});
+
+describe('looksRawStatusText', () => {
+  it('flags machine tokens and passes display text', () => {
+    expect(looksRawStatusText('canceled_uncertain')).toBe(true);
+    expect(looksRawStatusText('gateHold')).toBe(true);
+    expect(looksRawStatusText('Likely Canceled')).toBe(false);
+    expect(looksRawStatusText('Departed')).toBe(false);
+  });
+});

--- a/tests/warm-irops.test.js
+++ b/tests/warm-irops.test.js
@@ -1,0 +1,223 @@
+// Data-quality release (Jul 3 2026 audit) — #7 IROPS-aware warm cron: hubs with an active FAA
+// program rotate fairly into the front of each run's stride. Priority injections are capped at
+// stride-1 slots per run (≥1 base ring slot always survives) and the disrupted-hub order is
+// rotated by the clock-derived warm slot, so with 2+ disrupted hubs every hub's boards cycle
+// through the priority slots across consecutive runs instead of the first hubs in HUBS order
+// winning every run. Task count and 300s budget unchanged.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const snapshotMocks = vi.hoisted(() => ({
+  loadScheduleSnapshot: vi.fn(async () => null),
+  saveScheduleSnapshot: vi.fn(async () => {}),
+  getSupabaseAdmin: vi.fn(async () => null),
+}));
+
+vi.mock(process.cwd() + '/api/_schedule-snapshots.ts', () => snapshotMocks);
+
+import handler, { applyIropsPriority, buildWarmPlan } from '../api/cron/warm-schedules.js';
+import { __resetFaaDisruptionCacheForTests } from '../api/faa.js';
+import { __resetAlertThrottleForTests } from '../api/_alert.js';
+import { __resetAdbSpendForTests } from '../api/_cost-state.js';
+
+const t = (hub, dir, dayOffset) => ({ hub, dir, dayOffset, label: dayOffset === 0 ? 'today' : 'tomorrow' });
+const key = (task) => `${task.hub}-${task.dir}-${task.label}`;
+
+describe('applyIropsPriority (pure)', () => {
+  it('no disrupted hubs → plan unchanged', () => {
+    const plan = [t('DEN', 'departures', 0), t('GUM', 'arrivals', 1)];
+    const out = applyIropsPriority(plan, []);
+    expect(out.plan).toEqual(plan);
+    expect(out.injected).toEqual([]);
+    expect(out.displaced).toEqual([]);
+  });
+
+  it('injects the disrupted hub today boards, displacing tomorrow slots first', () => {
+    const plan = [t('DEN', 'departures', 0), t('IAH', 'departures', 1), t('GUM', 'arrivals', 1)];
+    const out = applyIropsPriority(plan, ['ORD']);
+    expect(out.plan).toHaveLength(3); // task count is the budget — never grows
+    const keys = out.plan.map(key);
+    expect(keys).toContain('ORD-departures-today');
+    expect(keys).toContain('ORD-arrivals-today');
+    // Priority tasks run FIRST; the surviving slot is the today board, tomorrow slots were displaced.
+    expect(out.plan[0].hub).toBe('ORD');
+    expect(out.plan[1].hub).toBe('ORD');
+    expect(keys).toContain('DEN-departures-today');
+    expect(out.injected).toHaveLength(2);
+    expect(out.displaced.sort()).toEqual(['GUM-arrivals-tomorrow', 'IAH-departures-tomorrow'].sort());
+  });
+
+  it('displaces undisrupted today slots only when no tomorrow slots remain', () => {
+    const plan = [t('DEN', 'departures', 0), t('IAH', 'arrivals', 0), t('SFO', 'departures', 0)];
+    const out = applyIropsPriority(plan, ['ORD']);
+    const keys = out.plan.map(key);
+    expect(out.plan).toHaveLength(3);
+    expect(keys).toContain('ORD-departures-today');
+    expect(keys).toContain('ORD-arrivals-today');
+    // Displaced from the BACK of the stride.
+    expect(out.displaced).toEqual(['SFO-departures-today', 'IAH-arrivals-today']);
+  });
+
+  it('reorders (no displacement) when the stride already covers the disrupted hub today boards', () => {
+    const plan = [t('DEN', 'departures', 0), t('ORD', 'departures', 0), t('ORD', 'arrivals', 0)];
+    const out = applyIropsPriority(plan, ['ORD']);
+    expect(out.injected).toEqual([]);
+    expect(out.displaced).toEqual([]);
+    expect(out.plan.map(key)).toEqual(['ORD-departures-today', 'ORD-arrivals-today', 'DEN-departures-today']);
+  });
+
+  it('never grows the plan; a stride of 1 allows zero injections (cap = stride-1)', () => {
+    const plan = [t('ORD', 'departures', 0)]; // stride of 1
+    const out = applyIropsPriority(plan, ['ORD', 'SFO']);
+    expect(out.plan).toHaveLength(1);
+    // Injection cap is stride-1 = 0: nothing can be displaced. The single slot happens to be an
+    // ORD-today priority task already, so it simply runs first.
+    expect(out.plan[0].hub).toBe('ORD');
+    expect(out.injected).toEqual([]);
+    expect(out.displaced).toEqual([]);
+  });
+
+  it('ignores non-hub airport codes (FAA programs at ATL/LGA are not our hubs)', () => {
+    const plan = [t('DEN', 'departures', 0), t('GUM', 'arrivals', 1)];
+    const out = applyIropsPriority(plan, ['ATL', 'LGA']);
+    expect(out.plan).toEqual(plan);
+  });
+
+  it('caps injections at stride-1 with multiple disrupted hubs — at least one ring slot survives', () => {
+    // 2 disrupted hubs used to consume the entire stride-4 run; now the cap (3) leaves the
+    // front-most surviving ring slot in place and the 4th priority board waits for rotation.
+    const plan = [t('DEN', 'departures', 1), t('IAH', 'departures', 1), t('GUM', 'arrivals', 1), t('NRT', 'arrivals', 1)];
+    const out = applyIropsPriority(plan, ['ORD', 'EWR'], 0);
+    expect(out.plan).toHaveLength(4);
+    expect(out.plan.map(key)).toEqual([
+      'ORD-departures-today', 'ORD-arrivals-today', 'EWR-departures-today', 'DEN-departures-tomorrow',
+    ]);
+    expect(out.injected).toHaveLength(3);
+    expect(out.displaced).toEqual([
+      'NRT-arrivals-tomorrow', 'GUM-arrivals-tomorrow', 'IAH-departures-tomorrow',
+    ]);
+  });
+
+  it('rotates which disrupted hub wins the capped slots across consecutive runs (seed)', () => {
+    const plan = [t('DEN', 'departures', 1), t('IAH', 'departures', 1), t('GUM', 'arrivals', 1), t('NRT', 'arrivals', 1)];
+    const run0 = applyIropsPriority(plan, ['ORD', 'EWR'], 0);
+    const run1 = applyIropsPriority(plan, ['ORD', 'EWR'], 1);
+    // Run 0 leads with ORD; run 1 leads with EWR — EWR-arrivals (left out of run 0) warms now.
+    expect(run0.injected).toEqual(['ORD-departures-today', 'ORD-arrivals-today', 'EWR-departures-today']);
+    expect(run1.injected).toEqual(['EWR-departures-today', 'EWR-arrivals-today', 'ORD-departures-today']);
+    // Across the two runs, ALL four disrupted-hub today boards were warmed.
+    const union = new Set([...run0.injected, ...run1.injected]);
+    expect(union.size).toBe(4);
+  });
+
+  it('with 3+ disrupted hubs, every hub board cycles through within a rotation period (no starvation)', () => {
+    // The old fixed HUBS-order victim scan let the SAME first two hubs win every run — hub 3's
+    // boards never warmed. Three consecutive slots must collectively cover all 6 boards.
+    const plan = [t('DEN', 'departures', 1), t('IAH', 'departures', 1), t('GUM', 'arrivals', 1), t('NRT', 'arrivals', 1)];
+    const hubs = ['ORD', 'EWR', 'SFO'];
+    const warmedAcrossRuns = new Set();
+    for (let seed = 0; seed < 3; seed++) {
+      const out = applyIropsPriority(plan, hubs, seed);
+      for (const k of out.plan.map(key)) {
+        if (k.endsWith('-today')) warmedAcrossRuns.add(k);
+      }
+      // Every individual run still leaves ≥1 ring slot.
+      expect(out.injected.length).toBeLessThanOrEqual(plan.length - 1);
+    }
+    expect(warmedAcrossRuns.size).toBe(6); // 3 hubs × 2 directions all cycled through
+  });
+
+  it('rotation seed is stable modulo the disrupted-hub count (negative/large seeds are safe)', () => {
+    const plan = [t('DEN', 'departures', 1), t('IAH', 'departures', 1), t('GUM', 'arrivals', 1), t('NRT', 'arrivals', 1)];
+    const a = applyIropsPriority(plan, ['ORD', 'EWR'], 2);
+    const b = applyIropsPriority(plan, ['ORD', 'EWR'], 0);
+    expect(a.plan.map(key)).toEqual(b.plan.map(key));
+    const c = applyIropsPriority(plan, ['ORD', 'EWR'], -1);
+    const d = applyIropsPriority(plan, ['ORD', 'EWR'], 1);
+    expect(c.plan.map(key)).toEqual(d.plan.map(key));
+  });
+});
+
+describe('warm-schedules handler IROPS integration', () => {
+  const SECRET = 'test-cron-secret-1234';
+
+  function createRes() {
+    return {
+      statusCode: 200,
+      body: null,
+      status(code) { this.statusCode = code; return this; },
+      json(payload) { this.body = payload; return this; },
+    };
+  }
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    process.env.SCHEDULE_WARM_DELAY_MS = '0';
+    process.env.SCHEDULE_WARM_TASKS_PER_RUN = '3';
+    __resetFaaDisruptionCacheForTests();
+    __resetAlertThrottleForTests();
+    __resetAdbSpendForTests();
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    delete process.env.SCHEDULE_WARM_DELAY_MS;
+    delete process.env.SCHEDULE_WARM_TASKS_PER_RUN;
+    __resetFaaDisruptionCacheForTests();
+    __resetAlertThrottleForTests();
+    __resetAdbSpendForTests();
+  });
+
+  it('warms the disrupted hub today boards every run while an FAA program is active', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const u = String(url);
+      if (u.includes('nasstatus.faa.gov/api/airport-events')) {
+        return {
+          ok: true, status: 200,
+          headers: { get: () => null },
+          json: async () => ([{ airportId: 'ORD', groundDelay: { impactingCondition: 'thunderstorms', avgDelay: 293, maxDelay: 353 } }]),
+        };
+      }
+      return {
+        ok: true, status: 200,
+        headers: { get: () => null },
+        json: async () => (u.includes('/api/schedule')
+          ? { cached: false, stale: false, partial: false, total: 300, meta: { completeness: 1 } }
+          : { ok: true }),
+      };
+    });
+    const res = createRes();
+    await handler({ method: 'GET', headers: { authorization: `Bearer ${SECRET}` } }, res);
+
+    expect(res.statusCode).toBe(200);
+    const scheduleKeys = Object.keys(res.body.results).filter((k) => k !== 'starlink-data');
+    // Task budget unchanged (3), and both ORD today boards are in this run.
+    expect(scheduleKeys).toHaveLength(3);
+    expect(scheduleKeys).toContain('ORD-departures-today');
+    expect(scheduleKeys).toContain('ORD-arrivals-today');
+    // Priority boards run FIRST.
+    expect(res.body.warmPlan[0].hub).toBe('ORD');
+    expect(res.body.warmPlan[0].label).toBe('today');
+  });
+
+  it('leaves the ring plan untouched when no hub has an active program', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const u = String(url);
+      if (u.includes('nasstatus.faa.gov/api/airport-events')) {
+        return { ok: true, status: 200, headers: { get: () => null }, json: async () => ([]) };
+      }
+      return {
+        ok: true, status: 200, headers: { get: () => null },
+        json: async () => (u.includes('/api/schedule')
+          ? { cached: false, stale: false, partial: false, total: 300, meta: { completeness: 1 } }
+          : { ok: true }),
+      };
+    });
+    const res = createRes();
+    await handler({ method: 'GET', headers: { authorization: `Bearer ${SECRET}` } }, res);
+    expect(res.statusCode).toBe(200);
+    const basePlan = buildWarmPlan().map((task) => `${task.hub}-${task.dir}-${task.label}`);
+    const executed = res.body.warmPlan.map((task) => `${task.hub}-${task.dir}-${task.label}`);
+    expect(executed).toEqual(basePlan);
+  });
+});


### PR DESCRIPTION
## Summary

Implements every actionable finding from the Jul 3 four-agent deep-dive (data accuracy vs ground truth, internal consistency, information design, task-based UX) — run live during the ORD GDP, the exact failure mode this release fixes — **plus all 10 confirmed defects from a 32-agent adversarial code review of the diff itself** (including catching that the headline GDP fix was initially dead code on the frontend, an over-aggressive dedupe that deleted real flights, and a revision-dedupe that masked the very delays it was built to surface).

### Data credibility (P1s from the audit)
- **Flight-time lookups work again**: FlightAware's parsed-but-empty bot-wall response now falls through to FR24 (kill-switch-gated) and then the schedule snapshot layer — reviving My Flights statuses, routes, and the Check-a-Connection tool.
- **Parked aircraft are no longer "Departed" during delay programs**: boards carry live FAA disruption magnitude (GDP/GS/closure only — advisories don't count), the 60-min inference grace stretches with it, threading verified into all 10 frontend classification sites, and inferred rows are badged "Departed*".
- **CanceledUncertain is a soft "Likely Canceled"** (amber), overridden by real times, counted in server IROPS — no more canceling flights that flew (UA4809), no more literal "Canceleduncertain".
- **One takeoff, one row**: revision dedupe keeps the ORIGINAL schedule baseline (review caught keep-latest masking +2h48m as On Time), operator-clone collapse requires real-time agreement (review caught it deleting legitimate Express flights), foreign airlines filtered, collapse counts in `meta.dedupe`, snapshot ranking dedupe-adjusted so fresh clean boards beat stale dup-laden snapshots.
- **OTP single-writer** (server authoritative; client fills gaps at n≥25 only — kills the DEN 68→100 flap) and **unified risk** (board score reused; "RISK N/A" instead of fabricated LOW).

### Status-layer information design
- Reconciling stat strip: CANCELED card, presumed chip, explicit uncategorized remainder — cards sum to Total by unit-tested invariant.
- DELAY/RISK split: real deltas in tabular figures on flown rows; predictions labeled "RISK: HIGH".
- Today boards anchor at NOW: sticky divider, auto-scroll, "Jul 3" date chips on rollover rows, jump-to-now pill.
- Ticker derives from the same inputs as the IROPS panel — never "✅ All systems normal" beside a red IROPS wall; IROPS index labeled ("IROPS 56.7/100").
- "Unknown" retired from passenger-facing UI (renders "Scheduled · as of 7:12 PM CDT"); stale banner states absolute time + consequence.
- Find-in-board search on the toolbar; static flight-first global-search placeholder; inline (non-blocking) search errors.

### Ops
- **IROPS-aware cache warming**: disrupted hubs' today boards jump the warm-cron queue with capped fair rotation (≥1 ring slot preserved; multi-hub disruptions rotate so no hub starves) — attacking the root cause: stale boards during disruptions.
- Non-blocking FAA disruption lookup (sync peek + background refresh) — cache-hit board serves never wait on nasstatus.faa.gov.

### Polish
Hub-local Starlink FIDS times with TZ labels, Term/Gate column honesty ("T1 · C18"), unified OTP tooltip definitions, per-direction classification in aggregation loops, Enter-submits connection checker, unknown-transition watch-notification suppression, mobile attribution/disclaimer, registration validation, revived Delayed filter.

## Verification
- `bun run test`: **904/904** (66 files; 121 tests added across the release, 8 assertions deliberately flipped where they pinned reviewed-defective behavior)
- `bun run typecheck` + `bun run build`: clean
- Review: 32-agent workflow (finders + independent adversarial verifiers) — all 10 confirmed defects fixed in this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)