### PR TITLE
v1.5.27: Jul 4 punch list — honest stale copy, violet Starlink, IROPS severity label, CONUS radar, reg backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-07-04
+
+### Added
+- Schedule: blank registrations backfill from live flight tracking (seen-today ledger; provider values never overwritten)
+
+### Fixed
+- Schedule: stale-board banner now says "showing the latest data we have" instead of "live updates paused"
+- Live Ops: Starlink aircraft render violet (#A78BFA) — glow halo removed
+- Delays: IROPS chip shows plain-language severity (Normal/Minor/Significant) instead of a 0–100 score; radar map opens framed to CONUS
+
 ## [1.5.26] - 2026-07-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-07-04
+## [1.5.27] - 2026-07-04
 
 ### Added
 - Schedule: blank registrations backfill from live flight tracking (seen-today ledger; provider values never overwritten)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -52,6 +52,7 @@ The Blue Board uses a dark NOC (Network Operations Center) aesthetic with cockpi
 | `--ua-accent` | `#6BAAED` | Links, interactive text, hover states. Slightly deeper than the old `#8ab4f8` — more intentional, less washed out. |
 | `--ua-amber` | `#C4A35A` | **NEW.** Cockpit instrument amber. Featured stat values, highlight borders, hover warmth, premium callouts. Use sparingly — this is the personality color. |
 | `--ua-amber-soft` | `rgba(196, 163, 90, 0.12)` | Amber background tint for badges and hover states. |
+| `--ua-violet` | `#A78BFA` | Starlink-equipped aircraft markers on maps. Owner-approved Jul 4 2026. Not for text or buttons. |
 | `--ua-blue-soft` | `rgba(0, 93, 170, 0.12)` | Blue background tint for active states. |
 | `--ua-green` | `#22C55E` | Live indicators, positive status, on-time. |
 | `--ua-yellow` | `#EAB308` | Warnings, moderate delays. |

--- a/docs/superpowers/plans/2026-07-04-punchlist.md
+++ b/docs/superpowers/plans/2026-07-04-punchlist.md
@@ -1,0 +1,525 @@
+# Jul 4 Punch List Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Honest stale-board copy, violet Starlink markers (no glow), IROPS severity label instead of 0–100 score, radar map framed to CONUS, and client-side registration backfill on the schedule board.
+
+**Architecture:** Four surgical edits in `src/dashboard/main.js` / `public/` plus one new pure-function module `src/lib/reg-ledger.js` (tested with vitest) that main.js wires to the live-feed poll and the schedule row renderer.
+
+**Tech Stack:** Vanilla JS dashboard (`src/dashboard/main.js`), Leaflet, vitest via `bun run test`, Vercel deploy.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-04-punchlist-design.md`
+- Tests: `bun run test` (vitest) — NEVER bare `bun test` (repo CLAUDE.md).
+- Gates before PR: `bun run test`, `bun run typecheck`, `bun run build`.
+- The numeric IROPS score must keep flowing to `lastIropsScore` → `updateTicker()` (ticker gating).
+- Starlink violet is `#A78BFA`; fill-priority: watched green → Starlink violet → long-haul amber → phase.
+- Reg backfill is client-side only; provider-supplied registrations are never overwritten.
+
+---
+
+### Task 1: Banner copy — retire "live updates paused"
+
+**Files:**
+- Modify: `src/dashboard/main.js:4628-4644` (three template strings + stale comment)
+
+**Interfaces:** none (display strings only).
+
+- [ ] **Step 1: Replace the three strings**
+
+In the schedule banner builder (search `live updates paused`), change:
+
+```js
+        // Absolute time + consequence, not just a relative age: "from 2h ago" made users do
+        // clock math and never said what it MEANS. "Statuses as of 7:12 PM CDT — showing the
+        // latest data we have" states both without implying an intentional, resumable stop
+        // (owner Jul 4 2026: "paused" read as dishonest). != null (not truthiness): a
+        // just-written snapshot has dataAge 0, which must still render with age context.
+        const age = formatDataAge(meta.dataAge);
+        const asOf = formatBoardAsOf();
+        msg = result.partial
+          ? `Statuses as of ${asOf} (partial board, ${age} old) — showing the latest data we have.`
+          : `Statuses as of ${asOf} (${age} old) — showing the latest data we have.`;
+```
+
+and in the `result.stale` branch:
+
+```js
+        msg = `Statuses as of ${formatBoardAsOf()} (${formatDataAge(meta.dataAge)} old) — showing the latest data we have.`;
+```
+
+- [ ] **Step 2: Verify no occurrence remains**
+
+Run: `grep -rn "live updates paused" src/ public/ api/ tests/`
+Expected: no matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/dashboard/main.js
+git commit -m "fix(schedule): stale-board banner says 'showing the latest data we have', not 'live updates paused'"
+```
+
+---
+
+### Task 2: Starlink markers — violet fill, no glow halo
+
+**Files:**
+- Modify: `src/dashboard/main.js:1198-1215` (`createPlaneIcon`)
+- Modify: `public/css/style.css:128` (`.map-legend-dot-starlink`)
+- Modify: `DESIGN.md` (add violet to color tokens)
+
+**Interfaces:**
+- `createPlaneIcon(hdg, isLonghaul, phase, isWatched, isStarlink)` signature unchanged; cache key already includes `isStarlink`.
+
+- [ ] **Step 1: Change fill priority and drop the halo**
+
+Replace the color/filter block in `createPlaneIcon`:
+
+```js
+  // Starlink marker treatment: distinct violet FILL, no glow halo (owner Jul 4 2026 — the
+  // stacked drop-shadow "orb" look is gone). Fill priority: watched green → Starlink violet
+  // → long-haul amber → phase color. Accepted trade-off: phase color is not visible on
+  // Starlink aircraft — the popup and the Starlink-only filter still carry it.
+  const color = isWatched ? '#22c55e'
+    : isStarlink ? '#A78BFA'
+    : isLonghaul ? '#fbbf24'
+    : (phase === 'Ground' ? '#64748B' : '#6BAAED');
+  const size = isWatched ? 16 : (isLonghaul ? 14 : 10);
+  const filter = `drop-shadow(0 0 2px ${color})`;
+```
+
+(The old `isStarlink ? drop-shadow(...)×3 : ...` ternary is deleted; every marker keeps the single 2px legibility shadow in its own color.)
+
+- [ ] **Step 2: Update the map legend dot**
+
+`public/css/style.css` line 128 — replace:
+
+```css
+.map-legend-dot-starlink{background:#A78BFA}
+```
+
+(was amber `#fbbf24` with a two-layer glow `box-shadow`).
+
+- [ ] **Step 3: Record the token in DESIGN.md**
+
+Add a row to the Color Tokens table after `--ua-amber-soft`:
+
+```markdown
+| `--ua-violet` | `#A78BFA` | Starlink-equipped aircraft markers on maps. Owner-approved Jul 4 2026. Not for text or buttons. |
+```
+
+- [ ] **Step 4: Verify no stale glow references**
+
+Run: `grep -n "fbbf24" src/dashboard/main.js public/css/style.css | grep -i starlink`
+Expected: no matches (long-haul amber `#fbbf24` elsewhere is fine).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dashboard/main.js public/css/style.css DESIGN.md
+git commit -m "feat(map): starlink aircraft render violet, glow halo removed"
+```
+
+---
+
+### Task 3: IROPS 0–100 score → severity label
+
+**Files:**
+- Modify: `src/dashboard/main.js:5775-5786` (client-computed bar in `updateIrops`)
+- Modify: `src/dashboard/main.js:5876-5884` (API-fed bar)
+
+**Interfaces:**
+- `lastIropsScore` assignments (`main.js:5811`, `main.js:5898`) and `updateTicker()` calls are UNTOUCHED.
+
+- [ ] **Step 1: Client-computed site**
+
+Replace label derivation + chip line (keep `score`/`scoreCls` computation):
+
+```js
+  const scoreLabel = score < 5 ? 'NORMAL OPERATIONS' : score < 15 ? 'MINOR DISRUPTION' : 'SIGNIFICANT DISRUPTION';
+```
+
+```js
+  // Plain-language severity instead of a bare 0-100 index (owner Jul 4 2026: the number
+  // wasn't helpful). The numeric score is still computed below for the ticker's gating.
+  html += `<span class="irops-bar-item"><span class="irops-score ${scoreCls}" style="font-size:12px;padding:2px 8px">${scoreLabel}</span><span class="hh-info">?<span class="hh-tooltip">Severity from weighted cancellations, 60min+ delays and diversions per 100 scheduled flights: Normal · Minor · Significant.</span></span></span>`;
+```
+
+(The adjacent `<span class="irops-bar-label">${scoreLabel}</span>` is removed — the chip IS the label now.)
+
+- [ ] **Step 2: API-fed site**
+
+Same two changes at the second render site (`const score = data.score;` block): same `scoreLabel` ternary, same chip HTML, drop the old bar-label span.
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -n "/100" src/dashboard/main.js`
+Expected: no IROPS chip matches. Run `grep -n "lastIropsScore = Number(score)" src/dashboard/main.js` — expected: still 2 matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/dashboard/main.js
+git commit -m "feat(delays): IROPS chip shows severity label instead of 0-100 score (ticker gating unchanged)"
+```
+
+---
+
+### Task 4: Radar map zoom 3 → 4
+
+**Files:**
+- Modify: `src/dashboard/main.js:3717`
+
+- [ ] **Step 1: Change zoom**
+
+```js
+  radarMap = L.map('radar-map', {center:[39,-97],zoom:4,zoomControl:false});
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/dashboard/main.js
+git commit -m "fix(delays): radar map opens at zoom 4 — CONUS framing, matches live ops map"
+```
+
+---
+
+### Task 5: `src/lib/reg-ledger.js` — pure functions + tests (TDD)
+
+**Files:**
+- Create: `src/lib/reg-ledger.js`
+- Test: `tests/reg-ledger.test.js`
+
+**Interfaces (Produces — Task 6 depends on these exact names):**
+- `normalizeFlightNum(raw: any): string | null` — `'UA 0123'`/`'UAL123'` → `'UA123'`; non-UA/garbage → `null`
+- `recordSightings(ledger: object, flights: Array<{flightIATA?, callsign?, reg?}>, nowMs: number): void` — mutates `ledger[key] = {reg, seenAt}`
+- `lookupReg(ledger: object, flightNumRaw: any, schedDepSec: number, schedArrSec: number|null|undefined, nowMs?: number): string | null`
+- `pruneLedger(ledger: object, nowMs: number): void` — drops entries older than 36h, caps at 1500 newest
+- `deserializeLedger(json: string|null): object` — `{}` on any garbage
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/reg-ledger.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeFlightNum, recordSightings, lookupReg, pruneLedger, deserializeLedger,
+} from '../src/lib/reg-ledger.js';
+
+const H = 3600e3;
+
+describe('normalizeFlightNum', () => {
+  it('normalizes UA/UAL variants with spaces and leading zeros', () => {
+    expect(normalizeFlightNum('UA123')).toBe('UA123');
+    expect(normalizeFlightNum('ua 123')).toBe('UA123');
+    expect(normalizeFlightNum('UAL0123')).toBe('UA123');
+    expect(normalizeFlightNum('UA 0042')).toBe('UA42');
+  });
+  it('rejects non-mainline and garbage', () => {
+    expect(normalizeFlightNum('G7929')).toBeNull();   // United Express operator ident
+    expect(normalizeFlightNum('NK3005')).toBeNull();
+    expect(normalizeFlightNum('UA')).toBeNull();
+    expect(normalizeFlightNum('')).toBeNull();
+    expect(normalizeFlightNum(null)).toBeNull();
+    expect(normalizeFlightNum('UA12345')).toBeNull(); // >4 digits
+  });
+});
+
+describe('recordSightings', () => {
+  it('records by flightIATA, falls back to callsign, skips reg-less flights', () => {
+    const ledger = {};
+    recordSightings(ledger, [
+      { flightIATA: 'UA123', callsign: 'UAL123', reg: 'N12345' },
+      { flightIATA: '', callsign: 'UAL456', reg: 'N45678' },
+      { flightIATA: 'UA789', callsign: 'UAL789', reg: '' },
+    ], 1000);
+    expect(ledger.UA123).toEqual({ reg: 'N12345', seenAt: 1000 });
+    expect(ledger.UA456).toEqual({ reg: 'N45678', seenAt: 1000 });
+    expect(ledger.UA789).toBeUndefined();
+  });
+  it('latest sighting wins', () => {
+    const ledger = { UA123: { reg: 'N11111', seenAt: 1000 } };
+    recordSightings(ledger, [{ flightIATA: 'UA123', reg: 'N22222' }], 2000);
+    expect(ledger.UA123).toEqual({ reg: 'N22222', seenAt: 2000 });
+  });
+});
+
+describe('lookupReg — sighting must fall inside this flight instance', () => {
+  const dep = 1_750_000_000;            // scheduled departure (unix seconds)
+  const arr = dep + 4 * 3600;           // scheduled arrival
+  const ledgerAt = (seenAt) => ({ UA123: { reg: 'N12345', seenAt } });
+
+  it('fills when seen between departure and arrival', () => {
+    expect(lookupReg(ledgerAt(dep * 1000 + H), 'UA 123', dep, arr)).toBe('N12345');
+  });
+  it('allows taxi-out (2h before dep) and post-arrival (3h after)', () => {
+    expect(lookupReg(ledgerAt(dep * 1000 - 1.9 * H), 'UA123', dep, arr)).toBe('N12345');
+    expect(lookupReg(ledgerAt(arr * 1000 + 2.9 * H), 'UA123', dep, arr)).toBe('N12345');
+  });
+  it("never pins another day's tail on this flight number", () => {
+    expect(lookupReg(ledgerAt(dep * 1000 - 24 * H), 'UA123', dep, arr)).toBeNull();
+    expect(lookupReg(ledgerAt(arr * 1000 + 24 * H), 'UA123', dep, arr)).toBeNull();
+  });
+  it('uses a 16h span when arrival is missing', () => {
+    expect(lookupReg(ledgerAt(dep * 1000 + 10 * H), 'UA123', dep, null)).toBe('N12345');
+    expect(lookupReg(ledgerAt(dep * 1000 + 20 * H), 'UA123', dep, null)).toBeNull();
+  });
+  it('returns null without a scheduled departure, unknown key, or malformed entry', () => {
+    expect(lookupReg(ledgerAt(dep * 1000), 'UA123', 0, arr)).toBeNull();
+    expect(lookupReg({}, 'UA123', dep, arr)).toBeNull();
+    expect(lookupReg({ UA123: { reg: 'N1', seenAt: 'nope' } }, 'UA123', dep, arr)).toBeNull();
+  });
+});
+
+describe('pruneLedger', () => {
+  it('drops entries older than 36h and caps at 1500 newest', () => {
+    const now = 100 * H;
+    const ledger = { OLD: { reg: 'N1', seenAt: now - 37 * H }, NEW: { reg: 'N2', seenAt: now - H } };
+    for (let i = 0; i < 1600; i++) ledger[`UA${i}`] = { reg: 'N3', seenAt: now - 2 * H - i };
+    pruneLedger(ledger, now);
+    expect(ledger.OLD).toBeUndefined();
+    expect(ledger.NEW).toBeDefined();
+    expect(Object.keys(ledger).length).toBe(1500);
+  });
+});
+
+describe('deserializeLedger', () => {
+  it('round-trips valid entries and rejects malformed ones', () => {
+    const json = JSON.stringify({
+      UA123: { reg: 'N12345', seenAt: 1000 },
+      BAD1: { reg: 42, seenAt: 1000 },
+      BAD2: { reg: 'N1' },
+    });
+    expect(deserializeLedger(json)).toEqual({ UA123: { reg: 'N12345', seenAt: 1000 } });
+  });
+  it('returns {} for garbage, arrays, null', () => {
+    expect(deserializeLedger('not json')).toEqual({});
+    expect(deserializeLedger('[1,2]')).toEqual({});
+    expect(deserializeLedger(null)).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun run test tests/reg-ledger.test.js`
+Expected: FAIL — cannot resolve `../src/lib/reg-ledger.js`.
+
+- [ ] **Step 3: Implement**
+
+`src/lib/reg-ledger.js`:
+
+```js
+// ═══ SEEN-TODAY REGISTRATION LEDGER ═══
+// The AeroDataBox schedule feed frequently omits tail numbers — including for flights the
+// live FR24 feed is tracking with a known registration in the SAME browser session (owner
+// Jul 4 2026: "missing so many registration numbers for planes that have already departed").
+// These pure helpers let the dashboard record flightNumber → {reg, seenAt} on every live
+// feed poll and backfill blank schedule rows, client-side, zero API spend.
+//
+// Guard model: a ledger entry only fills a schedule row when the sighting happened during
+// THAT flight instance's operation window (2h before scheduled departure, through 3h after
+// scheduled arrival; 16h assumed span when arrival is unknown). This ties the tail to the
+// specific instance instead of "same day" bookkeeping — red-eyes crossing midnight work,
+// and yesterday's tail can never pin to today's same flight number.
+
+export const SIGHTING_BEFORE_DEP_MS = 2 * 3600e3;   // taxi-out / early feed pickup
+export const SIGHTING_AFTER_ARR_MS = 3 * 3600e3;    // late feed dropout after landing
+export const DEFAULT_FLIGHT_SPAN_MS = 16 * 3600e3;  // when scheduled arrival is unknown
+export const LEDGER_MAX_AGE_MS = 36 * 3600e3;
+export const LEDGER_MAX_ENTRIES = 1500;
+
+/**
+ * 'UA 0123' / 'UAL123' / 'ua123' → 'UA123'. Mainline only: the live feed is queried as
+ * UAL, so regional operating idents (G7/OO/YX…) never appear in it — rejecting them here
+ * keeps a G7929 schedule row from matching nothing silently. Returns null when unmatched.
+ */
+export function normalizeFlightNum(raw) {
+  const s = String(raw || '').toUpperCase().replace(/[\s-]/g, '');
+  const m = s.match(/^(?:UA|UAL)0*(\d{1,4})$/);
+  return m ? `UA${m[1]}` : null;
+}
+
+/** Record every reg-carrying live flight. Mutates ledger; latest sighting wins. */
+export function recordSightings(ledger, flights, nowMs) {
+  if (!ledger || !Array.isArray(flights)) return;
+  for (const f of flights) {
+    if (!f || !f.reg) continue;
+    const key = normalizeFlightNum(f.flightIATA) || normalizeFlightNum(f.callsign);
+    if (!key) continue;
+    ledger[key] = { reg: f.reg, seenAt: nowMs };
+  }
+}
+
+/** Backfill lookup for one schedule row. Times in unix SECONDS (schedule feed shape). */
+export function lookupReg(ledger, flightNumRaw, schedDepSec, schedArrSec, nowMs = 0) {
+  const key = normalizeFlightNum(flightNumRaw);
+  if (!key) return null;
+  const entry = ledger ? ledger[key] : null;
+  const seen = entry ? Number(entry.seenAt) : NaN;
+  if (!entry || typeof entry.reg !== 'string' || !entry.reg || !Number.isFinite(seen)) return null;
+  const dep = Number(schedDepSec) * 1000;
+  if (!Number.isFinite(dep) || dep <= 0) return null; // can't tie a sighting to an unscheduled row
+  const arr = Number(schedArrSec) > 0 ? Number(schedArrSec) * 1000 : dep + DEFAULT_FLIGHT_SPAN_MS;
+  if (seen < dep - SIGHTING_BEFORE_DEP_MS || seen > arr + SIGHTING_AFTER_ARR_MS) return null;
+  return entry.reg;
+}
+
+/** Age out entries >36h and cap at the 1500 newest. Mutates ledger. */
+export function pruneLedger(ledger, nowMs) {
+  if (!ledger) return;
+  for (const [k, v] of Object.entries(ledger)) {
+    if (!v || !Number.isFinite(Number(v.seenAt)) || nowMs - Number(v.seenAt) > LEDGER_MAX_AGE_MS) delete ledger[k];
+  }
+  const keys = Object.keys(ledger);
+  if (keys.length > LEDGER_MAX_ENTRIES) {
+    keys.sort((a, b) => Number(ledger[b].seenAt) - Number(ledger[a].seenAt));
+    for (const k of keys.slice(LEDGER_MAX_ENTRIES)) delete ledger[k];
+  }
+}
+
+/** localStorage → ledger. Malformed JSON, arrays, or bad entries → {} / dropped. */
+export function deserializeLedger(json) {
+  try {
+    const obj = JSON.parse(json || '{}');
+    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return {};
+    const out = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (v && typeof v.reg === 'string' && v.reg && Number.isFinite(Number(v.seenAt))) {
+        out[k] = { reg: v.reg, seenAt: Number(v.seenAt) };
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `bun run test tests/reg-ledger.test.js`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/reg-ledger.js tests/reg-ledger.test.js
+git commit -m "feat(schedule): reg-ledger — pure helpers for live-feed tail backfill"
+```
+
+---
+
+### Task 6: Wire the ledger into main.js
+
+**Files:**
+- Modify: `src/dashboard/main.js` (imports ~line 12; feed commit ~line 1092; schedule row renderer ~line 4963)
+
+**Interfaces:**
+- Consumes: `recordSightings`, `lookupReg`, `pruneLedger`, `deserializeLedger` from Task 5.
+- Live flights shape: `{ flightIATA, callsign, reg }` (from `parseFr24Feed`).
+- Schedule row shape: `fl.identification.number.default`, `fl.time.scheduled.departure/arrival` (unix seconds), `fl.aircraft.registration`.
+
+- [ ] **Step 1: Import + module state**
+
+Next to the existing `../lib/` imports at the top of `src/dashboard/main.js`:
+
+```js
+import { recordSightings, lookupReg, pruneLedger, deserializeLedger } from '../lib/reg-ledger.js';
+```
+
+Below the other module-level state (near `let allFlights`):
+
+```js
+// Seen-today reg ledger: flightNumber → {reg, seenAt} harvested from every live-feed poll,
+// used to backfill blank schedule-board registrations (see src/lib/reg-ledger.js).
+const REG_LEDGER_KEY = 'bb_reg_ledger_v1';
+let regLedger = {};
+try { regLedger = deserializeLedger(localStorage.getItem(REG_LEDGER_KEY)); } catch (e) { regLedger = {}; }
+function recordRegSightings(flights) {
+  recordSightings(regLedger, flights, Date.now());
+  pruneLedger(regLedger, Date.now());
+  try { localStorage.setItem(REG_LEDGER_KEY, JSON.stringify(regLedger)); } catch (e) { /* private mode / quota */ }
+}
+```
+
+- [ ] **Step 2: Record on every successful feed commit**
+
+In `refreshFlights()`, immediately after `allFlights = result.flights;`:
+
+```js
+    allFlights = result.flights;
+    recordRegSightings(allFlights);
+```
+
+- [ ] **Step 3: Backfill in the schedule row renderer**
+
+Replace `const reg = fl.aircraft?.registration || '—';` (in `renderScheduleTable`'s row loop) with:
+
+```js
+    // Provider reg first, ALWAYS. When the schedule feed omitted the tail, fall back to the
+    // live-feed ledger — a currently-airborne flight fills from this poll's sighting, a
+    // departed one from whenever a session saw it airborne. A filled reg also unlocks the
+    // FLEET_BY_REG enrichment below (type, Starlink ⚡, special livery) for free.
+    let reg = fl.aircraft?.registration || '';
+    let regFromLive = false;
+    if (!reg) {
+      const filled = lookupReg(regLedger, fl.identification?.number?.default,
+        fl.time?.scheduled?.departure, fl.time?.scheduled?.arrival, Date.now());
+      if (filled) { reg = filled; regFromLive = true; }
+    }
+    if (!reg) reg = '—';
+```
+
+- [ ] **Step 4: Mark backfilled tails honestly**
+
+In the same row template, the registration cell (`<td style="font-family:var(--font-mono);font-size:10px">…`) gets a title on the link when backfilled — change the reg span to:
+
+```js
+${reg !== '—' ? `<span class="ac-reg-link" data-action="aircraft-detail" data-reg="${escapeHtml(reg)}"${regFromLive ? ' title="Tail from live flight tracking (not in the schedule feed)"' : ''}>${escapeHtml(reg)}</span>` : '—'}
+```
+
+- [ ] **Step 5: Gates**
+
+Run: `bun run test` → all pass. `bun run typecheck` → clean. `bun run build` → succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/dashboard/main.js
+git commit -m "feat(schedule): backfill missing registrations from the live-feed reg ledger"
+```
+
+---
+
+### Task 7: Full gates + CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md` (new entry, follow existing format)
+
+- [ ] **Step 1: Run all three gates**
+
+Run: `bun run test && bun run typecheck && bun run build`
+Expected: green / clean / success.
+
+- [ ] **Step 2: CHANGELOG entry**
+
+Follow the existing top-of-file format (see current entries for the version pattern; the version bump itself is handled at ship time):
+
+```markdown
+- Schedule: blank registrations backfill from live flight tracking (seen-today ledger; provider values never overwritten)
+- Schedule: stale-board banner now says "showing the latest data we have" instead of "live updates paused"
+- Live Ops: Starlink aircraft render violet (#A78BFA) — glow halo removed
+- Delays: IROPS chip shows plain-language severity (Normal/Minor/Significant) instead of a 0–100 score; radar map opens framed to CONUS
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog for Jul 4 punch list"
+```

--- a/docs/superpowers/specs/2026-07-04-punchlist-design.md
+++ b/docs/superpowers/specs/2026-07-04-punchlist-design.md
@@ -1,0 +1,102 @@
+# July 4 Punch List — Design
+
+Five items from owner feedback (Jul 4 2026): stale-board banner copy, Starlink map
+marker treatment, IROPS score display, radar map framing, and schedule registration
+backfill (Phase 1 of the schedule overhaul).
+
+## 1. Stale-board banner copy
+
+**Problem.** The schedule banner says "live updates paused" for degraded/stale boards.
+"Paused" implies an intentional, resumable stop; the truth is the feed is failing or the
+board is a cached snapshot. Owner: "doesn't feel very honest."
+
+**Change.** In `src/dashboard/main.js` (banner builder inside the schedule load path),
+replace the three "— live updates paused." strings with "— showing the latest data we
+have.":
+
+- degraded + partial: `Statuses as of {asOf} (partial board, {age} old) — showing the latest data we have.`
+- degraded, complete: `Statuses as of {asOf} ({age} old) — showing the latest data we have.`
+- stale, complete: same as degraded-complete.
+
+Everything else — age-based amber/red escalation, completeness percentage, Retry button —
+is unchanged.
+
+## 2. Starlink markers on the live ops map
+
+**Problem.** Starlink-equipped aircraft get a stacked triple `drop-shadow` amber halo
+(`createPlaneIcon`), which reads as a blurry "glowing orb," especially at low zoom.
+
+**Change.** Remove the halo. Starlink aircraft are drawn with a violet fill `#A78BFA`;
+all aircraft keep the standard single 2px legibility drop-shadow in their own fill color.
+
+Fill-color priority: **watched green → Starlink violet → long-haul amber → phase color.**
+A watched Starlink aircraft stays green (watchlist beats equipment).
+
+Accepted trade-off (owner decision): phase color is no longer visible on Starlink planes.
+The flight popup and the Starlink-only filter still carry that information. Any legend /
+tooltip / help text describing the amber glow is updated to describe the violet fill.
+The icon cache key already includes `isStarlink`; no cache-shape change needed.
+
+## 3. IROPS score → severity label
+
+**Problem.** The Delays tab shows `IROPS 56/100`. Owner: the 0–100 rating isn't helpful.
+
+**Change.** At both render sites of the IROPS bar, replace the numeric chip with a
+plain-language severity label using the existing score→class mapping and colors:
+
+- score < 5 → `NORMAL OPERATIONS` (green)
+- 5–15 → `MINOR DISRUPTION` (yellow)
+- ≥ 15 → `SIGNIFICANT DISRUPTION` (red)
+
+The concrete counts beside it (cancellations, >30m, >60m, diversions, total flights) are
+unchanged. The tooltip is reworded to explain the label thresholds in terms of weighted
+events per 100 flights, without presenting a user-facing 0–100 score.
+
+**Constraint.** The numeric score continues to be computed and written to
+`lastIropsScore` — the header ticker's ops-health gating (`src/lib/ops-health.js`,
+"never say normal on a red IROPS night") depends on it. Display-only change.
+
+## 4. Radar map framing (Delays tab)
+
+**Change.** `L.map('radar-map', {center:[39,-97], zoom:3})` → `zoom: 4`. Same center.
+Frames CONUS like the live ops map instead of hemisphere-plus-oceans.
+
+## 5. Schedule Phase 1 — registration & aircraft backfill (client-side)
+
+**Problem.** Schedule boards get registrations only from the AeroDataBox schedule feed,
+which frequently omits them — including for flights currently airborne whose tail is
+already known to the live FR24 feed in the same browser session. No cross-fill exists.
+
+**Change.** Client-side, zero new API spend:
+
+1. **Seen-today reg ledger.** On every live-feed poll, record
+   `normalizedFlightNumber → { reg, seenAt }` for every flight with both fields.
+   Kept in a module-level map and mirrored to `localStorage` so a tail seen airborne
+   earlier survives page reloads. Entries expire on a same-service-day TTL — a ledger
+   entry never fills a row whose scheduled departure is on a different local day than
+   `seenAt` (prevents pinning yesterday's tail on today's same flight number).
+2. **Backfill order in the schedule row renderer.** When `fl.aircraft.registration` is
+   empty: (a) match the live feed (`allFlights`) by normalized flight number — flight is
+   airborne now; (b) else consult the ledger — flight departed while a session was
+   watching. If neither hits, the row keeps `—`.
+3. **Free enrichment.** A backfilled reg flows into the existing `FLEET_BY_REG`
+   enrichment (aircraft type, Starlink ⚡, special-livery badge) with no further work.
+4. **Normalization.** One shared helper normalizes both sides of the match:
+   `UA123` / `UAL123` / `UA 0123` → `UA123`. Regional operating idents (e.g. `G7929`)
+   are not matched — mainline only, since the live feed is queried as UAL.
+
+**Honest limit (recorded, deliberate).** Flights that departed before any browser
+session saw them airborne remain blank. Closing that gap needs a server-side reg ledger
+(cron snapshots the live feed into Supabase) — deferred to schedule-overhaul Phase 2
+alongside caching/freshness. Phase 3 is the visual redesign.
+
+## Testing
+
+Unit tests (vitest) for: flight-number normalization, ledger TTL / service-day guard,
+and backfill precedence (live feed beats ledger; existing provider reg never overwritten).
+Repo gates before PR: `bun run test`, `bun run typecheck`, `bun run build`.
+
+## Out of scope
+
+Server-side reg ledger, schedule caching rework, schedule visual redesign (Phases 2–3),
+any change to the IROPS score computation or ticker logic.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.26",
+  "version": "1.5.27",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -121,8 +121,8 @@ main{display:contents}
 /* Degraded tier: Starlink toggle disabled (no tails loaded) — greyed, no hover affordance */
 .ctrl-btn:disabled,.ctrl-btn.ctrl-btn-disabled{opacity:.4;cursor:not-allowed}
 .ctrl-btn:disabled:hover,.ctrl-btn.ctrl-btn-disabled:hover{background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.96) 100%);border-color:var(--ua-border);color:var(--ua-muted)}
-/* Map marker legend — one amber Starlink key, grouped under the control ladder. The dot
-   mirrors the marker's amber glow halo; the "Starlink" text means color is not the sole signal. */
+/* Map marker legend — one violet Starlink key, grouped under the control ladder. The dot
+   mirrors the marker's violet fill; the "Starlink" text means color is not the sole signal. */
 #map-legend{display:flex;align-items:center;gap:6px;margin-top:5px;padding:5px 10px;background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.96) 100%);border:1px solid var(--ua-border);border-radius:6px;font-size:10px;font-family:var(--font-mono);color:var(--ua-muted);text-transform:uppercase;letter-spacing:.5px;white-space:nowrap;pointer-events:none}
 .map-legend-dot{width:9px;height:9px;border-radius:50%;display:inline-block;flex-shrink:0}
 .map-legend-dot-starlink{background:#A78BFA}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -125,7 +125,7 @@ main{display:contents}
    mirrors the marker's amber glow halo; the "Starlink" text means color is not the sole signal. */
 #map-legend{display:flex;align-items:center;gap:6px;margin-top:5px;padding:5px 10px;background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.96) 100%);border:1px solid var(--ua-border);border-radius:6px;font-size:10px;font-family:var(--font-mono);color:var(--ua-muted);text-transform:uppercase;letter-spacing:.5px;white-space:nowrap;pointer-events:none}
 .map-legend-dot{width:9px;height:9px;border-radius:50%;display:inline-block;flex-shrink:0}
-.map-legend-dot-starlink{background:#fbbf24;box-shadow:0 0 4px #fbbf24,0 0 7px rgba(251,191,36,.7)}
+.map-legend-dot-starlink{background:#A78BFA}
 #search-box{position:absolute;top:10px;left:10px;z-index:712}
 #search-input{background:rgba(10,14,20,.9);border:1px solid var(--ua-border);color:var(--ua-text);padding:7px 12px;border-radius:4px;font-family:var(--font-mono);font-size:11px;width:220px}
 #search-input:focus{border-color:var(--ua-accent)}

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -5775,7 +5775,7 @@ function updateIrops() {
 
   const score = totalFlights > 0 ? ((cancellations * 3 + delayed60 * 2 + delayed30 + diversions * 2) / totalFlights * 100).toFixed(1) : 0;
   const scoreCls = score < 5 ? 'low' : score < 15 ? 'med' : 'high';
-  const scoreLabel = score < 5 ? 'Normal Ops' : score < 15 ? 'Minor Disruptions' : 'Significant IROPS';
+  const scoreLabel = score < 5 ? 'NORMAL OPERATIONS' : score < 15 ? 'MINOR DISRUPTION' : 'SIGNIFICANT DISRUPTION';
 
   worstDelays.sort((a, b) => b.delay - a.delay);
   const top5 = worstDelays.slice(0, 5);
@@ -5783,9 +5783,9 @@ function updateIrops() {
   // NOTE: All values here are computed numbers/strings from internal schedule data,
   // not user input. FAA alerts use escapeHtml() below.
   let html = '<div class="irops-bar">';
-  // Bare "56.7" read as a mystery number — attach the scale/label and the same
-  // "?" tooltip pattern the OTP strip uses. (Audit Jul 3 2026, ticker coherence.)
-  html += `<span class="irops-bar-item"><span class="irops-score ${scoreCls}" style="font-size:12px;padding:2px 8px">IROPS ${score}/100</span><span class="irops-bar-label">${scoreLabel}</span><span class="hh-info">?<span class="hh-tooltip">IROPS severity index (0\u2013100): weighted cancellations, 60min+ delays and diversions per 100 flights. &lt;5 normal \u00b7 5\u201315 minor \u00b7 \u226515 significant</span></span></span>`;
+  // Plain-language severity instead of a bare 0-100 index (owner Jul 4 2026: the number
+  // wasn't helpful). The numeric score is still computed below for the ticker's gating.
+  html += `<span class="irops-bar-item"><span class="irops-score ${scoreCls}" style="font-size:12px;padding:2px 8px">${scoreLabel}</span><span class="hh-info">?<span class="hh-tooltip">Severity from weighted cancellations, 60min+ delays and diversions per 100 scheduled flights: Normal \u00b7 Minor \u00b7 Significant.</span></span></span>`;
   html += '<span class="irops-bar-sep">│</span>';
   html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:var(--ua-red)">${cancellations}</span><span class="irops-bar-label">Cancellations</span></span>`;
   html += '<span class="irops-bar-sep">│</span>';
@@ -5877,12 +5877,12 @@ function renderIropsFromAPI(data) {
   const content = document.getElementById('irops-content');
   const score = data.score;
   const scoreCls = score < 5 ? 'low' : score < 15 ? 'med' : 'high';
-  const scoreLabel = score < 5 ? 'Normal Ops' : score < 15 ? 'Minor Disruptions' : 'Significant IROPS';
+  const scoreLabel = score < 5 ? 'NORMAL OPERATIONS' : score < 15 ? 'MINOR DISRUPTION' : 'SIGNIFICANT DISRUPTION';
 
   // NOTE: All values here are from the IROPS API (internal, not user input).
   let html = '<div class="irops-bar">';
   // Same scale/label + tooltip treatment as the client-computed IROPS bar above.
-  html += `<span class="irops-bar-item"><span class="irops-score ${scoreCls}" style="font-size:12px;padding:2px 8px">IROPS ${score}/100</span><span class="irops-bar-label">${scoreLabel}</span><span class="hh-info">?<span class="hh-tooltip">IROPS severity index (0\u2013100): weighted cancellations, 60min+ delays and diversions per 100 flights. &lt;5 normal \u00b7 5\u201315 minor \u00b7 \u226515 significant</span></span></span>`;
+  html += `<span class="irops-bar-item"><span class="irops-score ${scoreCls}" style="font-size:12px;padding:2px 8px">${scoreLabel}</span><span class="hh-info">?<span class="hh-tooltip">Severity from weighted cancellations, 60min+ delays and diversions per 100 scheduled flights: Normal \u00b7 Minor \u00b7 Significant.</span></span></span>`;
   html += '<span class="irops-bar-sep">│</span>';
   html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:var(--ua-red)">${data.cancellations || '—'}</span><span class="irops-bar-label">Cancellations</span></span>`;
   html += '<span class="irops-bar-sep">│</span>';

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -16,6 +16,7 @@ import { firstFutureIndex, nowDividerIndex } from '../lib/board-now.js';
 import { deriveOpsHealth } from '../lib/ops-health.js';
 import { displayScheduleStatus } from '../lib/status-display.js';
 import { computeScheduleStatCounts } from '../lib/board-stats.js';
+import { recordSightings, lookupReg, pruneLedger, deserializeLedger } from '../lib/reg-ledger.js';
 
 injectSpeedInsights();
 
@@ -376,6 +377,16 @@ const IATA_CITIES = {
 // ═══ GLOBALS ═══
 let map, flightMarkers = {}, routeLine = null, routeGroup = null, hubMarkers = [], wxLayer = null;
 let allFlights = [], showHubs = true, showLonghaul = false, showWeather = false, showStarlinkOnly = false;
+// Seen-today reg ledger: flightNumber → {reg, seenAt} harvested from every live-feed poll,
+// used to backfill blank schedule-board registrations (see src/lib/reg-ledger.js).
+const REG_LEDGER_KEY = 'bb_reg_ledger_v1';
+let regLedger = {};
+try { regLedger = deserializeLedger(localStorage.getItem(REG_LEDGER_KEY)); } catch (e) { regLedger = {}; }
+function recordRegSightings(flights) {
+  recordSightings(regLedger, flights, Date.now());
+  pruneLedger(regLedger, Date.now());
+  try { localStorage.setItem(REG_LEDGER_KEY, JSON.stringify(regLedger)); } catch (e) { /* private mode / quota */ }
+}
 let activeHubFilter = null, activePhaseFilter = null;
 let refreshTimer = null, countdown = 30;
 let deepLinkHandled = false;
@@ -1090,6 +1101,7 @@ async function refreshFlights() {
 
     // Healthy live feed: commit the new flights and show LIVE.
     allFlights = result.flights;
+    recordRegSightings(allFlights);
     lastGoodFeedTs = Date.now();
     feedRetryAttempt = 0;
     const dot = document.getElementById('status-dot');
@@ -4962,7 +4974,18 @@ function renderScheduleTable() {
     const acCode = fl.aircraft?.model?.code || '—';
     const acText = fl.aircraft?.model?.text || '';
     const acShort = acText ? acText.replace(/Boeing |Airbus |Embraer /g, '').substring(0, 20) : '';
-    const reg = fl.aircraft?.registration || '—';
+    // Provider reg first, ALWAYS. When the schedule feed omitted the tail, fall back to the
+    // live-feed ledger — a currently-airborne flight fills from this poll's sighting, a
+    // departed one from whenever a session saw it airborne. A filled reg also unlocks the
+    // FLEET_BY_REG enrichment below (type, Starlink ⚡, special livery) for free.
+    let reg = fl.aircraft?.registration || '';
+    let regFromLive = false;
+    if (!reg) {
+      const filled = lookupReg(regLedger, fl.identification?.number?.default,
+        fl.time?.scheduled?.departure, fl.time?.scheduled?.arrival, Date.now());
+      if (filled) { reg = filled; regFromLive = true; }
+    }
+    if (!reg) reg = '—';
 
     const oIata = orig?.code?.iata || '';
     const dIata = dest?.code?.iata || '';
@@ -5090,7 +5113,7 @@ function renderScheduleTable() {
       <td style="font-weight:600;color:var(--ua-accent)">${escapeHtml(ident)}</td>
       <td>${routeStr}</td>
       <td title="${escapeHtml(acText)}">${escapeHtml(acCode)}${acShort ? `<div style="font-size:9px;color:var(--ua-muted)">${escapeHtml(acShort)}</div>` : ''}${equipBadge}</td>
-      <td style="font-family:var(--font-mono);font-size:10px">${reg !== '—' ? `<span class="ac-reg-link" data-action="aircraft-detail" data-reg="${escapeHtml(reg)}">${escapeHtml(reg)}</span>` : '—'}${schedSpecial ? ' <span class="special-badge">⭐ ' + escapeHtml(schedSpecial.name) + '</span>' : ''}${fleetEnrich}</td>
+      <td style="font-family:var(--font-mono);font-size:10px">${reg !== '—' ? `<span class="ac-reg-link" data-action="aircraft-detail" data-reg="${escapeHtml(reg)}"${regFromLive ? ' title="Tail from live flight tracking (not in the schedule feed)"' : ''}>${escapeHtml(reg)}</span>` : '—'}${schedSpecial ? ' <span class="special-badge">⭐ ' + escapeHtml(schedSpecial.name) + '</span>' : ''}${fleetEnrich}</td>
       <td>${escapeHtml(gate)}</td>
       <td>${statusCell}${faaContext}</td>
       <td class="sched-delay-cell">${delayCell}</td>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -1202,15 +1202,16 @@ function createPlaneIcon(hdg, isLonghaul, phase, isWatched, isStarlink) {
   const hdgRounded = Math.round((hdg || 0) / 5) * 5;
   const cacheKey = `${hdgRounded}|${isLonghaul?1:0}|${phase}|${isWatched?1:0}|${isStarlink?1:0}`;
   if (_iconCache[cacheKey]) return _iconCache[cacheKey];
-  const color = isWatched ? '#22c55e' : (isLonghaul ? '#fbbf24' : (phase === 'Ground' ? '#64748B' : '#6BAAED'));
+  // Starlink marker treatment: distinct violet FILL, no glow halo (owner Jul 4 2026 — the
+  // stacked drop-shadow "orb" look is gone). Fill priority: watched green → Starlink violet
+  // → long-haul amber → phase color. Accepted trade-off: phase color is not visible on
+  // Starlink aircraft — the popup and the Starlink-only filter still carry it.
+  const color = isWatched ? '#22c55e'
+    : isStarlink ? '#A78BFA'
+    : isLonghaul ? '#fbbf24'
+    : (phase === 'Ground' ? '#64748B' : '#6BAAED');
   const size = isWatched ? 16 : (isLonghaul ? 14 : 10);
-  // Starlink marker treatment: an amber glow HALO that STACKS on top of the existing
-  // phase/long-haul/watched fill (we keep the fill so phase info is never lost — a recolor
-  // would collide with long-haul's amber). Pairs the amber color with an enlarged glow shape
-  // so color is not the sole signal (DESIGN.md). #fbbf24 is the map's existing amber.
-  const filter = isStarlink
-    ? `drop-shadow(0 0 2px ${color}) drop-shadow(0 0 4px #fbbf24) drop-shadow(0 0 7px #fbbf24)`
-    : `drop-shadow(0 0 2px ${color})`;
+  const filter = `drop-shadow(0 0 2px ${color})`;
   // SVG plane pointing north (0°) — classic top-down aircraft silhouette, cross-platform consistent
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 256 256" fill="${color}" style="filter:${filter}"><path d="M128 16c-4 0-8 3-9 7l-15 72-88 34c-3 1-4 4-4 7s2 5 5 6l87 20 4 52-28 18c-2 1-3 3-3 5v8c0 2 1 4 3 4l20-6h28l20 6c2 0 3-2 3-4v-8c0-2-1-4-3-5l-28-18 4-52 87-20c3-1 5-3 5-6s-1-6-4-7l-88-34-15-72c-1-4-5-7-9-7z"/></svg>`;
   const icon = L.divIcon({

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -4627,21 +4627,22 @@ async function loadScheduleData() {
       let msg = '';
       if (result.degraded && meta.dataAge != null) {
         // Absolute time + consequence, not just a relative age: "from 2h ago" made users do
-        // clock math and never said what it MEANS. "Statuses as of 7:12 PM CDT — live updates
-        // paused" states both. != null (not truthiness): a just-written snapshot has dataAge 0,
-        // which must still render with age context.
+        // clock math and never said what it MEANS. "Statuses as of 7:12 PM CDT — showing the
+        // latest data we have" states both without implying an intentional, resumable stop
+        // (owner Jul 4 2026: "paused" read as dishonest). != null (not truthiness): a
+        // just-written snapshot has dataAge 0, which must still render with age context.
         const age = formatDataAge(meta.dataAge);
         const asOf = formatBoardAsOf();
         msg = result.partial
-          ? `Statuses as of ${asOf} (partial board, ${age} old) — live updates paused.`
-          : `Statuses as of ${asOf} (${age} old) — live updates paused.`;
+          ? `Statuses as of ${asOf} (partial board, ${age} old) — showing the latest data we have.`
+          : `Statuses as of ${asOf} (${age} old) — showing the latest data we have.`;
       } else if (result.stale && !result.partial && meta.dataAge != null) {
         // Complete but aged out of the fresh window (degraded=false: nothing is missing). PR #207
         // made these boards degraded=false for honesty, but the banner gate never checked
         // result.stale — so hours-old complete boards rendered with NO warning. This branch (and
         // the gate above) restores the warning; without it the chain falls to the misleading
         // "Some flights may be missing." default, a lie for a complete board.
-        msg = `Statuses as of ${formatBoardAsOf()} (${formatDataAge(meta.dataAge)} old) — live updates paused.`;
+        msg = `Statuses as of ${formatBoardAsOf()} (${formatDataAge(meta.dataAge)} old) — showing the latest data we have.`;
       } else if (meta.liveFeedFallbackAdded) {
         msg = `Added ${meta.liveFeedFallbackAdded} live active flight(s) while the full schedule feed recovers.`;
       } else if (meta.partialReason === 'live_feed_fallback') {

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -387,6 +387,16 @@ function recordRegSightings(flights) {
   pruneLedger(regLedger, Date.now());
   try { localStorage.setItem(REG_LEDGER_KEY, JSON.stringify(regLedger)); } catch (e) { /* private mode / quota */ }
 }
+// Single source of truth for a schedule row's registration: provider value first, ledger
+// backfill second. EVERY schedule consumer (row render, Starlink filter, tail search, reg
+// sort) must go through this — a row that shows a backfilled ⚡ tail but doesn't match the
+// Starlink filter or a search for that tail is a lie of inconsistency.
+function schedRegFor(fl) {
+  return fl.aircraft?.registration
+    || lookupReg(regLedger, fl.identification?.number?.default,
+         fl.time?.scheduled?.departure, fl.time?.scheduled?.arrival, Date.now())
+    || '';
+}
 let activeHubFilter = null, activePhaseFilter = null;
 let refreshTimer = null, countdown = 30;
 let deepLinkHandled = false;
@@ -4800,9 +4810,9 @@ function getFilteredScheduleFlights(nowSec = schedNow()) {
       if (routeTypeFilter === 'domestic' && isIntl) return false;
       if (routeTypeFilter === 'international' && !isIntl) return false;
     }
-    // Starlink filter
+    // Starlink filter (schedRegFor: backfilled tails must match the filter their ⚡ badge implies)
     if (starlinkFilter) {
-      const reg = fl.aircraft?.registration;
+      const reg = schedRegFor(fl);
       const hasSL = reg && STARLINK_TAILS.has(reg);
       if (starlinkFilter === 'starlink' && !hasSL) return false;
       if (starlinkFilter === 'no-starlink' && hasSL) return false;
@@ -4837,7 +4847,7 @@ function getFilteredScheduleFlights(nowSec = schedNow()) {
     if (searchFilter) {
       const flNum = fl.identification?.number?.default?.toLowerCase() || '';
       const callsign = fl.identification?.callsign?.toLowerCase() || '';
-      const reg = fl.aircraft?.registration?.toLowerCase() || '';
+      const reg = schedRegFor(fl).toLowerCase(); // incl. backfilled tails — searching a visible reg must hit
       const destName = (fl.airport?.destination?.name || '').toLowerCase();
       const destCode = (fl.airport?.destination?.code?.iata || '').toLowerCase();
       const origName = (fl.airport?.origin?.name || '').toLowerCase();
@@ -4866,7 +4876,7 @@ function sortScheduleFlights(flights, nowSec = schedNow()) {
         return rA.localeCompare(rB) * dir;
       }
       case 'aircraft': return ((a.aircraft?.model?.code || '').localeCompare(b.aircraft?.model?.code || '')) * dir;
-      case 'reg': return ((a.aircraft?.registration || '').localeCompare(b.aircraft?.registration || '')) * dir;
+      case 'reg': return (schedRegFor(a).localeCompare(schedRegFor(b))) * dir;
       case 'status': {
         const sA = classifySchedStatus(a, schedCurrentDir, nowSec, classifyOptsFor(schedBoardMeta)).key;
         const sB = classifySchedStatus(b, schedCurrentDir, nowSec, classifyOptsFor(schedBoardMeta)).key;
@@ -4978,14 +4988,8 @@ function renderScheduleTable() {
     // live-feed ledger — a currently-airborne flight fills from this poll's sighting, a
     // departed one from whenever a session saw it airborne. A filled reg also unlocks the
     // FLEET_BY_REG enrichment below (type, Starlink ⚡, special livery) for free.
-    let reg = fl.aircraft?.registration || '';
-    let regFromLive = false;
-    if (!reg) {
-      const filled = lookupReg(regLedger, fl.identification?.number?.default,
-        fl.time?.scheduled?.departure, fl.time?.scheduled?.arrival, Date.now());
-      if (filled) { reg = filled; regFromLive = true; }
-    }
-    if (!reg) reg = '—';
+    const reg = schedRegFor(fl) || '—';
+    const regFromLive = reg !== '—' && !fl.aircraft?.registration;
 
     const oIata = orig?.code?.iata || '';
     const dIata = dest?.code?.iata || '';

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -3715,7 +3715,7 @@ async function initWeatherTab() {
   // weather-retry action (which resets weatherInitialized), and L.map() on an already-initialized
   // container throws "Map container is already initialized." (Audit P1: weather-retry-double-map-init.)
   if (radarMap) { try { radarMap.remove(); } catch (e) { /* already removed */ } radarMap = null; }
-  radarMap = L.map('radar-map', {center:[39,-97],zoom:3,zoomControl:false});
+  radarMap = L.map('radar-map', {center:[39,-97],zoom:4,zoomControl:false});
   radarMap.attributionControl.setPrefix(''); // OSM/CARTO credit from tile options (ODbL)
   L.control.zoom({ position: 'bottomleft' }).addTo(radarMap);
   L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', basemapTileOptions).addTo(radarMap);

--- a/src/lib/reg-ledger.js
+++ b/src/lib/reg-ledger.js
@@ -1,0 +1,84 @@
+// ═══ SEEN-TODAY REGISTRATION LEDGER ═══
+// The AeroDataBox schedule feed frequently omits tail numbers — including for flights the
+// live FR24 feed is tracking with a known registration in the SAME browser session (owner
+// Jul 4 2026: "missing so many registration numbers for planes that have already departed").
+// These pure helpers let the dashboard record flightNumber → {reg, seenAt} on every live
+// feed poll and backfill blank schedule rows, client-side, zero API spend.
+//
+// Guard model: a ledger entry only fills a schedule row when the sighting happened during
+// THAT flight instance's operation window (2h before scheduled departure, through 3h after
+// scheduled arrival; 16h assumed span when arrival is unknown). This ties the tail to the
+// specific instance instead of "same day" bookkeeping — red-eyes crossing midnight work,
+// and yesterday's tail can never pin to today's same flight number.
+
+export const SIGHTING_BEFORE_DEP_MS = 2 * 3600e3;   // taxi-out / early feed pickup
+export const SIGHTING_AFTER_ARR_MS = 3 * 3600e3;    // late feed dropout after landing
+export const DEFAULT_FLIGHT_SPAN_MS = 16 * 3600e3;  // when scheduled arrival is unknown
+export const LEDGER_MAX_AGE_MS = 36 * 3600e3;
+export const LEDGER_MAX_ENTRIES = 1500;
+
+/**
+ * 'UA 0123' / 'UAL123' / 'ua123' → 'UA123'. Mainline only: the live feed is queried as
+ * UAL, so regional operating idents (G7/OO/YX…) never appear in it — rejecting them here
+ * keeps a G7929 schedule row from matching nothing silently. Returns null when unmatched.
+ */
+export function normalizeFlightNum(raw) {
+  const s = String(raw || '').toUpperCase().replace(/[\s-]/g, '');
+  const m = s.match(/^(?:UA|UAL)0*(\d{1,4})$/);
+  return m ? `UA${m[1]}` : null;
+}
+
+/** Record every reg-carrying live flight. Mutates ledger; latest sighting wins. */
+export function recordSightings(ledger, flights, nowMs) {
+  if (!ledger || !Array.isArray(flights)) return;
+  for (const f of flights) {
+    if (!f || !f.reg) continue;
+    const key = normalizeFlightNum(f.flightIATA) || normalizeFlightNum(f.callsign);
+    if (!key) continue;
+    ledger[key] = { reg: f.reg, seenAt: nowMs };
+  }
+}
+
+/** Backfill lookup for one schedule row. Times in unix SECONDS (schedule feed shape). */
+export function lookupReg(ledger, flightNumRaw, schedDepSec, schedArrSec, nowMs = 0) {
+  const key = normalizeFlightNum(flightNumRaw);
+  if (!key) return null;
+  const entry = ledger ? ledger[key] : null;
+  const seen = entry ? Number(entry.seenAt) : NaN;
+  if (!entry || typeof entry.reg !== 'string' || !entry.reg || !Number.isFinite(seen)) return null;
+  const dep = Number(schedDepSec) * 1000;
+  if (!Number.isFinite(dep) || dep <= 0) return null; // can't tie a sighting to an unscheduled row
+  const arr = Number(schedArrSec) > 0 ? Number(schedArrSec) * 1000 : dep + DEFAULT_FLIGHT_SPAN_MS;
+  if (seen < dep - SIGHTING_BEFORE_DEP_MS || seen > arr + SIGHTING_AFTER_ARR_MS) return null;
+  return entry.reg;
+}
+
+/** Age out entries >36h and cap at the 1500 newest. Mutates ledger. */
+export function pruneLedger(ledger, nowMs) {
+  if (!ledger) return;
+  for (const [k, v] of Object.entries(ledger)) {
+    if (!v || !Number.isFinite(Number(v.seenAt)) || nowMs - Number(v.seenAt) > LEDGER_MAX_AGE_MS) delete ledger[k];
+  }
+  const keys = Object.keys(ledger);
+  if (keys.length > LEDGER_MAX_ENTRIES) {
+    keys.sort((a, b) => Number(ledger[b].seenAt) - Number(ledger[a].seenAt));
+    for (const k of keys.slice(LEDGER_MAX_ENTRIES)) delete ledger[k];
+  }
+}
+
+/** localStorage → ledger. Malformed JSON, arrays, or bad entries → {} / dropped. */
+export function deserializeLedger(json) {
+  try {
+    const obj = JSON.parse(json || '{}');
+    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return {};
+    const out = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (v && typeof v.reg === 'string' && v.reg && Number.isFinite(Number(v.seenAt))) {
+        out[k] = { reg: v.reg, seenAt: Number(v.seenAt) };
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}

--- a/tests/reg-ledger.test.js
+++ b/tests/reg-ledger.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeFlightNum, recordSightings, lookupReg, pruneLedger, deserializeLedger,
+} from '../src/lib/reg-ledger.js';
+
+const H = 3600e3;
+
+describe('normalizeFlightNum', () => {
+  it('normalizes UA/UAL variants with spaces and leading zeros', () => {
+    expect(normalizeFlightNum('UA123')).toBe('UA123');
+    expect(normalizeFlightNum('ua 123')).toBe('UA123');
+    expect(normalizeFlightNum('UAL0123')).toBe('UA123');
+    expect(normalizeFlightNum('UA 0042')).toBe('UA42');
+  });
+  it('rejects non-mainline and garbage', () => {
+    expect(normalizeFlightNum('G7929')).toBeNull();   // United Express operator ident
+    expect(normalizeFlightNum('NK3005')).toBeNull();
+    expect(normalizeFlightNum('UA')).toBeNull();
+    expect(normalizeFlightNum('')).toBeNull();
+    expect(normalizeFlightNum(null)).toBeNull();
+    expect(normalizeFlightNum('UA12345')).toBeNull(); // >4 digits
+  });
+});
+
+describe('recordSightings', () => {
+  it('records by flightIATA, falls back to callsign, skips reg-less flights', () => {
+    const ledger = {};
+    recordSightings(ledger, [
+      { flightIATA: 'UA123', callsign: 'UAL123', reg: 'N12345' },
+      { flightIATA: '', callsign: 'UAL456', reg: 'N45678' },
+      { flightIATA: 'UA789', callsign: 'UAL789', reg: '' },
+    ], 1000);
+    expect(ledger.UA123).toEqual({ reg: 'N12345', seenAt: 1000 });
+    expect(ledger.UA456).toEqual({ reg: 'N45678', seenAt: 1000 });
+    expect(ledger.UA789).toBeUndefined();
+  });
+  it('latest sighting wins', () => {
+    const ledger = { UA123: { reg: 'N11111', seenAt: 1000 } };
+    recordSightings(ledger, [{ flightIATA: 'UA123', reg: 'N22222' }], 2000);
+    expect(ledger.UA123).toEqual({ reg: 'N22222', seenAt: 2000 });
+  });
+});
+
+describe('lookupReg — sighting must fall inside this flight instance', () => {
+  const dep = 1_750_000_000;            // scheduled departure (unix seconds)
+  const arr = dep + 4 * 3600;           // scheduled arrival
+  const ledgerAt = (seenAt) => ({ UA123: { reg: 'N12345', seenAt } });
+
+  it('fills when seen between departure and arrival', () => {
+    expect(lookupReg(ledgerAt(dep * 1000 + H), 'UA 123', dep, arr)).toBe('N12345');
+  });
+  it('allows taxi-out (2h before dep) and post-arrival (3h after)', () => {
+    expect(lookupReg(ledgerAt(dep * 1000 - 1.9 * H), 'UA123', dep, arr)).toBe('N12345');
+    expect(lookupReg(ledgerAt(arr * 1000 + 2.9 * H), 'UA123', dep, arr)).toBe('N12345');
+  });
+  it("never pins another day's tail on this flight number", () => {
+    expect(lookupReg(ledgerAt(dep * 1000 - 24 * H), 'UA123', dep, arr)).toBeNull();
+    expect(lookupReg(ledgerAt(arr * 1000 + 24 * H), 'UA123', dep, arr)).toBeNull();
+  });
+  it('uses a 16h span when arrival is missing', () => {
+    expect(lookupReg(ledgerAt(dep * 1000 + 10 * H), 'UA123', dep, null)).toBe('N12345');
+    expect(lookupReg(ledgerAt(dep * 1000 + 20 * H), 'UA123', dep, null)).toBeNull();
+  });
+  it('returns null without a scheduled departure, unknown key, or malformed entry', () => {
+    expect(lookupReg(ledgerAt(dep * 1000), 'UA123', 0, arr)).toBeNull();
+    expect(lookupReg({}, 'UA123', dep, arr)).toBeNull();
+    expect(lookupReg({ UA123: { reg: 'N1', seenAt: 'nope' } }, 'UA123', dep, arr)).toBeNull();
+  });
+});
+
+describe('pruneLedger', () => {
+  it('drops entries older than 36h and caps at 1500 newest', () => {
+    const now = 100 * H;
+    const ledger = { OLD: { reg: 'N1', seenAt: now - 37 * H }, NEW: { reg: 'N2', seenAt: now - H } };
+    for (let i = 0; i < 1600; i++) ledger[`UA${i}`] = { reg: 'N3', seenAt: now - 2 * H - i };
+    pruneLedger(ledger, now);
+    expect(ledger.OLD).toBeUndefined();
+    expect(ledger.NEW).toBeDefined();
+    expect(Object.keys(ledger).length).toBe(1500);
+  });
+});
+
+describe('deserializeLedger', () => {
+  it('round-trips valid entries and rejects malformed ones', () => {
+    const json = JSON.stringify({
+      UA123: { reg: 'N12345', seenAt: 1000 },
+      BAD1: { reg: 42, seenAt: 1000 },
+      BAD2: { reg: 'N1' },
+    });
+    expect(deserializeLedger(json)).toEqual({ UA123: { reg: 'N12345', seenAt: 1000 } });
+  });
+  it('returns {} for garbage, arrays, null', () => {
+    expect(deserializeLedger('not json')).toEqual({});
+    expect(deserializeLedger('[1,2]')).toEqual({});
+    expect(deserializeLedger(null)).toEqual({});
+  });
+});


### PR DESCRIPTION
Owner feedback punch list (Jul 4). Spec: `docs/superpowers/specs/2026-07-04-punchlist-design.md`, plan: `docs/superpowers/plans/2026-07-04-punchlist.md`.

## Changes
- **Schedule banner**: stale/degraded boards say *"Statuses as of 7:12 PM CDT (2h old) — showing the latest data we have."* instead of *"live updates paused"* (which implied an intentional, resumable stop). Age escalation + Retry unchanged.
- **Live Ops Starlink markers**: glow-halo "orb" treatment removed; Starlink aircraft render with a violet fill `#A78BFA` (new `--ua-violet` token in DESIGN.md). Fill priority: watched green → Starlink violet → long-haul amber → phase color. Accepted trade-off: phase color not visible on Starlink planes (popup + filter still carry it). Legend dot updated.
- **Delays tab**: the `IROPS 56/100` chip is now a plain-language severity label (NORMAL OPERATIONS / MINOR DISRUPTION / SIGNIFICANT DISRUPTION). The numeric score is still computed and fed to `lastIropsScore` → header-ticker gating ("never say normal on a red night") is untouched. Radar map opens at zoom 4 (CONUS) instead of 3.
- **Schedule registration backfill** (new `src/lib/reg-ledger.js`, 12 unit tests): every live-feed poll records `flightNumber → {reg, seenAt}` (localStorage-persisted, 36h prune, 1500 cap). Blank schedule rows backfill provider-first → ledger, gated to the flight instance's operation window (2h before scheduled dep → 3h after scheduled arr) so yesterday's tail can never pin to today's number. Backfilled tails get a title tooltip, unlock the existing fleet enrichment (type, ⚡, special livery), and are visible to the Starlink filter, tail search, and reg sort via a single `schedRegFor()` helper.

Known limit (deliberate, in spec): flights that departed before any session saw them airborne stay blank — closing that needs a server-side reg ledger, deferred to schedule-overhaul Phase 2 (caching/freshness), Phase 3 = visual redesign.

## Verification
- `bun run test`: **916/916** · `bun run typecheck`: clean · `bun run build`: 42 pages
- Headless smoke on `astro preview`: app boots with no runtime exceptions (API 404s are the expected static-preview gaps), radar tiles confirmed requesting z4, IROPS degrades gracefully.

⚠️ Reminder: merge = production deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)