### PR TITLE
hotfix(map): restore aircraft marker positioning — v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-07-08
+
+### Fixed
+- **Live map: every aircraft was drawn in the wrong place.** The marker hit-slop rule added in the v2.0 program set `position:relative` on `.leaflet-marker-icon`, overriding the `position:absolute` that leaflet.css declares under "required styles". Marker icons are `display:block`, so relative positioning returned all 700+ planes to normal flow inside the marker pane: each one stacked below the previous before Leaflet applied its `translate3d()`, sinking marker N by exactly 5N pixels. On a 1280x800 viewport only ~70 of 766 markers landed on screen; the rest smeared south across South America and off the map. Hub markers were unaffected because they are `L.circleMarker` (SVG in the overlay pane), which is what made the outage look partial rather than total.
+- The 10px→20px touch target that rule was added for is unchanged: the `::after` hit-slop still resolves against the icon, because an absolutely positioned element is already a containing block for its abspos descendants. `position:relative` was never needed.
+- Regression guard: `tests/leaflet-required-styles.test.js` fails CI on any rule that sets `position` on the elements leaflet.css positions itself.
+
 ## [1.7.0] - 2026-07-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -213,8 +213,11 @@ main{display:contents}
    Instead we grow the *clickable* box with a ::after pseudo-element — pseudo-elements are part
    of the parent's own box for hit-testing purposes, so a click anywhere in the padded area still
    fires on .leaflet-marker-icon itself (the element Leaflet's click handler is bound to). This
-   is purely a hit-slop: the visible plane glyph inside stays exactly the size main.js drew it. */
-.leaflet-marker-icon.leaflet-interactive{position:relative}
+   is purely a hit-slop: the visible plane glyph inside stays exactly the size main.js drew it.
+   Do NOT add `position:relative` here to anchor the ::after — leaflet.css lists
+   position:absolute on .leaflet-marker-icon under "required styles", and the icons are
+   display:block, so relative positioning returns 600+ markers to normal flow and stacks them
+   down the pane. The icon is already a containing block for the ::after as-is. */
 .leaflet-marker-icon.leaflet-interactive::after{content:'';position:absolute;inset:-5px;background:transparent}
 
 /* Popups */

--- a/tests/leaflet-required-styles.test.js
+++ b/tests/leaflet-required-styles.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Regression guard for the v2.0 map outage (PR #220): a marker hit-slop rule
+// shipped `.leaflet-marker-icon.leaflet-interactive{position:relative}`, which
+// outranks the `position:absolute` in Leaflet's own "required styles" block.
+// Marker icons are display:block, so relative positioning drops all 600+ plane
+// markers back into normal flow inside .leaflet-marker-pane — each one stacks
+// below the previous before Leaflet's translate3d() is applied, smearing the
+// fleet southward off the map. Hub markers survived only because they are
+// L.circleMarker (SVG in the overlay pane), which is why the outage looked
+// partial.
+//
+// Leaflet positions every marker with a transform relative to the pane origin;
+// any rule that changes `position` on these elements breaks that contract.
+
+const REQUIRED_ABSOLUTE = [
+  'leaflet-pane',
+  'leaflet-tile',
+  'leaflet-marker-icon',
+  'leaflet-marker-shadow',
+  'leaflet-tile-container',
+  'leaflet-zoom-box',
+  'leaflet-image-layer',
+  'leaflet-layer',
+];
+
+describe('Leaflet required styles are not overridden', () => {
+  const css = readFileSync(
+    resolve(__dirname, '..', 'public', 'css', 'style.css'),
+    'utf8'
+  );
+
+  // Strip comments so prose describing these rules can't trip the scan.
+  const stripped = css.replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // [selectorList, declarationBlock] for every rule in the sheet.
+  const rules = [...stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((m) => [
+    m[1].trim(),
+    m[2],
+  ]);
+
+  for (const cls of REQUIRED_ABSOLUTE) {
+    it(`does not set \`position\` on .${cls}`, () => {
+      const offenders = rules.filter(([selector, body]) => {
+        // Pseudo-elements get their own box; only the element itself is bound
+        // by Leaflet's positioning contract. `::after{position:absolute}` is
+        // the correct way to draw a hit-slop and must stay legal.
+        const targetsElementItself = new RegExp(
+          `\\.${cls}(?![\\w-])(?![^,]*::)`
+        ).test(selector);
+        const setsPosition = /(^|[;\s])position\s*:/.test(body);
+        return targetsElementItself && setsPosition;
+      });
+
+      expect(
+        offenders.map(([s]) => s),
+        `.${cls} must inherit position:absolute from leaflet.css`
+      ).toEqual([]);
+    });
+  }
+
+  it('keeps the marker hit-slop pseudo-element', () => {
+    // The accessibility win from PR #220 (10px touch targets are a click hazard)
+    // is preserved by the ::after alone — an absolutely positioned marker is
+    // already a containing block for its abspos descendants.
+    expect(stripped).toMatch(
+      /\.leaflet-marker-icon[^{]*::after\s*\{[^}]*inset\s*:\s*-\d/
+    );
+  });
+});


### PR DESCRIPTION
## The outage

PR #220 broke the live map. Every aircraft rendered in the wrong place: on a 1280x800 viewport only ~70 of 766 markers landed on screen, the rest smeared south across South America and off the map. Hub markers stayed correct, which made it look like a partial data problem rather than a rendering one.

## Root cause

The marker hit-slop rule added in #220 (`public/css/style.css`, P2-B item 2):

```css
.leaflet-marker-icon.leaflet-interactive{position:relative}
.leaflet-marker-icon.leaflet-interactive::after{content:'';position:absolute;inset:-5px;background:transparent}
```

`leaflet.css` declares `position:absolute` on `.leaflet-marker-icon` inside its **required styles** block. The new selector has specificity (0,2,0) and outranks it. Marker icons are also `display:block`, so relative positioning returned all 700+ plane markers to normal flow inside `.leaflet-marker-pane`. Each marker's static box advances by `marginTop(-5px) + height(10px) = 5px`, and Leaflet's `translate3d()` then offsets from *that* stacked origin instead of the pane origin — so marker N sinks 5N pixels.

Hub markers were unaffected because they are `L.circleMarker` (SVG `<path>` in the overlay pane, never `.leaflet-marker-icon`). Same for route lines and origin/destination dots. That asymmetry is why the map looked half-alive.

## Evidence (measured against live production, pre-fix)

| marker index | driftX | driftY |
|---|---|---|
| 0 | 0 | 0 |
| 20 | 0 | 100px |
| 60 | 0 | 300px |
| 100 | 0 | 500px |
| 300 | 0 | 1500px |
| 700 | 0 | 3500px |

`driftY == 5 * index` exactly. `computedStyle.position === "relative"` on every marker.

Patching the live DOM with `position:absolute` and re-measuring: **drift 0 on every marker, on-screen count 70 → 728 of 766.**

## The fix

Delete the `position:relative` declaration. One line.

The accessibility win from #220 is fully preserved — the 10px plane glyphs still get a 20x20 touch target. An absolutely positioned element is already a containing block for its absolutely positioned descendants, so `::after{position:absolute;inset:-5px}` resolves against the icon with or without `position:relative`. Verified on the live DOM: icon box `10x10`, `::after` box `20x20`, `position: absolute`.

## Regression guard

`tests/leaflet-required-styles.test.js` fails CI on any rule that sets `position` on the elements leaflet.css positions itself (`.leaflet-marker-icon`, `.leaflet-pane`, `.leaflet-tile`, ...). It deliberately still allows `::after{position:absolute}`, since that is the correct way to draw a hit-slop. Confirmed it fails on the old CSS and passes on the new.

## Verification

- `bun run test` — 74 files, 1042 tests pass (9 new)
- `bun run typecheck` — clean
- `bun run build` — clean, 43 pages
- Live-DOM measurement before and after, above

## Note for follow-up

PR #220 shipped 199 files and ~15k insertions without bumping `package.json` or adding a CHANGELOG entry — the v2.0 program's work is currently unversioned and undocumented. This PR cuts `1.7.1` for the hotfix only. A broader audit of what else #220 changed is running separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)