### PR TITLE
fix(irops): stop scoring stale board rows as multi-hour ground holds — v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-07-08
+
+### Fixed
+- **IROPS index was manufacturing a network meltdown out of stale board rows.** The `overdueDelayMinutes()` rule added by the v2.0 program (F073) charged `now - scheduledDeparture` minutes to any row that lacked a terminal status — uncapped, and with no way to tell a flight held at the gate from a flight that departed hours ago whose status never updated. Because the board carries a full local day, a 07:00 departure was still accruing "hold" minutes at 23:00. Measured on production: 548 rows scored overdue >30m (122 of them beyond six hours), worst 1,028 minutes — a 17.1-hour hold on a 90-minute regional hop — driving the index to 74.4 against a SIGNIFICANT threshold of 15 and putting impossible phantom holds in the user-visible "worst delays" list.
+- Two guards, in order of trust: a flight cannot still be awaiting departure once the clock has passed its **scheduled arrival** (decisive, removes 61% of the phantoms with no policy judgment); and an absolute `OVERDUE_MAX_MIN = 240` cap for the ~25 production rows that carry no scheduled arrival, chosen above the FAA's 3-hour tarmac limit, past which a hold is cancelled rather than held. Beyond that we cannot distinguish a hold from a stale row, so we under-report rather than fabricate — the same honest-degradation rule the boards and freshness chip already follow.
+- The F073 ground-stop signal the rule exists for is preserved: a genuine hold still short of its scheduled arrival still counts toward `delayed30`/`delayed60` and still surfaces in `worstDelays`.
+- On live production data this moves `delayed30` 1184 → 906, `delayed60` 638 → 378, the worst reported hold 944min → 415min (and that 415 is a real, timestamp-backed delay, not an inferred one). The index reads 74.4 → 55.5. It remains above the SIGNIFICANT threshold: there is a real delay backlog underneath, and this change removes only the fabricated part of it. Scoring calibration is a separate, pre-existing question.
+- Regression guard: five new `F073b` cases in `tests/irops.test.js`, including a 15-hour stale row, an unknown-arrival row past the cap, and an assertion that `worstDelays` never reports a hold beyond the cap.
+
 ## [1.7.1] - 2026-07-08
 
 ### Fixed

--- a/api/irops.ts
+++ b/api/irops.ts
@@ -89,13 +89,40 @@ const CANCELED_STATUSES = new Set(['canceled', 'cancelled', 'canceled_uncertain'
 // fixed 30/60-min bucketing (rather than importing the schedule pipeline's disruption-
 // scaled inference grace) so this module stays self-contained; the buckets already
 // mirror the >30/>60 real-delay thresholds below. Returns 0 when not overdue.
+//
+// F073b: the rule above, unbounded, manufactures disruption. The board carries a FULL
+// LOCAL DAY, and a row whose status never advanced to a terminal value is indistinguishable
+// from a held flight — so a 07:00 departure that flew but never got a "departed" status was
+// still accruing overdue minutes at 23:00. Measured on production 2026-07-08: 548 rows
+// scored overdue >30m, 122 of them beyond 6 hours, worst 1028 minutes — a 17.1-hour "hold"
+// on a 90-minute regional hop — driving the index to 74.4 against a SIGNIFICANT threshold
+// of 15, and putting impossible phantom holds in the user-visible worstDelays list.
+//
+// Two guards, in order of how much we trust them:
+//   1. Scheduled arrival. A plane cannot still be awaiting departure once the clock has
+//      passed the time it was scheduled to LAND. This is decisive and removes 332 of the
+//      548 (61%) with no policy judgment at all.
+//   2. An absolute cap, for the ~25 production rows that carry no scheduled arrival.
+//      Beyond it we genuinely cannot tell a held flight from a stale row, so we
+//      under-report rather than fabricate — the same honest-degradation rule the boards
+//      and the freshness chip already follow. 240min sits above the FAA's 3-hour tarmac
+//      limit, past which a hold is cancelled rather than held.
+// Together: overdue-driven delayed30 falls 548 -> 186 and the worst hold 1028 -> 235 min,
+// while the F073 ground-stop signal the rule exists for is preserved (see tests).
+const OVERDUE_MAX_MIN = 240;
+
 function overdueDelayMinutes(fl: any, status: string, nowSec: number): number {
   if (CANCELED_STATUSES.has(status)) return 0;
   if (status === 'departed' || status === 'en-route' || status === 'landed' || status === 'diverted') return 0;
   if (fl.time?.real?.departure) return 0;
   const schedT = fl.time?.scheduled?.departure;
   if (!schedT || !nowSec || nowSec <= schedT) return 0;
-  return Math.round((nowSec - schedT) / 60);
+
+  const schedArr = fl.time?.scheduled?.arrival;
+  if (schedArr && nowSec > schedArr) return 0;
+
+  const overdue = Math.round((nowSec - schedT) / 60);
+  return overdue > OVERDUE_MAX_MIN ? 0 : overdue;
 }
 
 export function computeMetrics(flightsByHub: Record<string, any[]>, nowSec: number = Math.floor(Date.now() / 1000)) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/tests/irops.test.js
+++ b/tests/irops.test.js
@@ -5,6 +5,7 @@ import { computeMetrics, getStartOfDayForHub } from '../api/irops.js';
 function makeFlight(hub, {
   status = 'landed',
   schedDep = 1700000000,
+  schedArr = null,
   realDep = null,
   estDep = null,
   flightNum = 'UA100',
@@ -19,7 +20,7 @@ function makeFlight(hub, {
     },
     status: { generic: { status: { text: status } } },
     time: {
-      scheduled: { departure: schedDep },
+      scheduled: { departure: schedDep, arrival: schedArr },
       real: { departure: realDep },
       estimated: { departure: estDep },
     },
@@ -156,6 +157,78 @@ describe('computeMetrics', () => {
     // Held flights also surface in worstDelays with their overdue magnitude.
     expect(result.worstDelays.length).toBeGreaterThan(0);
     expect(result.worstDelays[0].delay).toBeGreaterThanOrEqual(120);
+  });
+
+  // ── F073b: overdue scoring must not manufacture disruption out of stale rows ──
+  // The board holds a full local day. A row whose status never advanced to a terminal
+  // value looks identical to a held flight, and the original F073 rule charged it
+  // (now - scheduledDeparture) minutes forever. Measured on production 2026-07-08:
+  // 548 rows scored as "overdue >30m", 122 of them over 6 hours, worst 1028 minutes
+  // (a 17.1-hour "hold" on a 90-minute regional hop), driving score 74.4 vs the
+  // SIGNIFICANT threshold of 15. A plane cannot still be at the gate after the clock
+  // has passed the time it was scheduled to land.
+
+  it('F073b: a row past its scheduled arrival is a stale row, not a held flight', () => {
+    const t = 1700000000;
+    const now = t + 15 * 3600; // 15h past scheduled departure
+    const result = computeMetrics({
+      ORD: [
+        // Scheduled to land 13.5h ago. It flew; the board never got a terminal status.
+        makeFlight('ORD', { schedDep: t, schedArr: t + 5400, realDep: null, status: 'scheduled' }),
+      ],
+    }, now);
+    expect(result.delayed30).toBe(0);
+    expect(result.delayed60).toBe(0);
+    expect(result.worstDelays).toEqual([]);
+  });
+
+  it('F073b: still counts a genuine ground-stop hold short of its scheduled arrival', () => {
+    const t = 1700000000;
+    const now = t + 2 * 3600; // held 2h at the gate
+    const result = computeMetrics({
+      EWR: [
+        // A 4-hour block: scheduled arrival is still 2h in the future, so it can
+        // plausibly still be sitting at the gate. This is the F073 signal — keep it.
+        makeFlight('EWR', { schedDep: t, schedArr: t + 4 * 3600, realDep: null, status: 'scheduled' }),
+      ],
+    }, now);
+    expect(result.delayed30).toBe(1);
+    expect(result.delayed60).toBe(1);
+    expect(result.worstDelays[0].delay).toBe(120);
+  });
+
+  it('F073b: caps overdue when scheduled arrival is unknown', () => {
+    const t = 1700000000;
+    const result = computeMetrics({
+      ORD: [
+        // No arrival time to reason with (25 such rows in production). Beyond the cap we
+        // cannot tell a held flight from a stale row, so we under-report rather than invent.
+        makeFlight('ORD', { schedDep: t, schedArr: null, realDep: null, status: 'scheduled' }),
+      ],
+    }, t + 5 * 3600);
+    expect(result.delayed30).toBe(0);
+    expect(result.worstDelays).toEqual([]);
+  });
+
+  it('F073b: an unknown-arrival hold inside the cap still counts', () => {
+    const t = 1700000000;
+    const result = computeMetrics({
+      ORD: [makeFlight('ORD', { schedDep: t, schedArr: null, realDep: null, status: 'scheduled' })],
+    }, t + 2 * 3600);
+    expect(result.delayed30).toBe(1);
+    expect(result.delayed60).toBe(1);
+  });
+
+  it('F073b: worstDelays never reports an overdue hold beyond the cap', () => {
+    const t = 1700000000;
+    const now = t + 20 * 3600;
+    const flights = [];
+    for (let i = 0; i < 30; i++) {
+      flights.push(makeFlight('ORD', { schedDep: t + i * 60, schedArr: null, realDep: null, status: 'scheduled', flightNum: `UA${i}` }));
+    }
+    const result = computeMetrics({ ORD: flights }, now);
+    for (const w of result.worstDelays) expect(w.delay).toBeLessThanOrEqual(240);
+    expect(result.score).toBe(0);
   });
 
   it('F073: does not treat departed/landed/canceled flights as overdue', () => {


### PR DESCRIPTION
## What's wrong, right now, in production

`/api/irops` currently reports:

```
score        : 74.4  ->  SIGNIFICANT DISRUPTION   (threshold is 15)
delayed30    : 1184 of 2858 flights  (41%)
worst holds  : ORD→BNA 944m | ORD→DEC 909m | DEN→SUX 819m | IAD→LGA 674m | ORD→CMX 659m
```

A 944-minute hold is 15.7 hours, on a 90-minute regional hop. These flights are not held. They flew this morning. Those numbers are on the Delays tab right now.

## Root cause

PR #220 added `overdueDelayMinutes()` (`api/irops.ts:92` — zero occurrences at the merge base `759c3df`). The intent was good and is documented as F073: during a ground stop, flights sit at the gate past their scheduled departure with no `departed` status, and the old code scored them zero, *understating* disruption exactly when it mattered.

But the rule is unbounded:

```ts
if (fl.time?.real?.departure) return 0;
const schedT = fl.time?.scheduled?.departure;
if (!schedT || !nowSec || nowSec <= schedT) return 0;
return Math.round((nowSec - schedT) / 60);   // <- no cap, no staleness guard
```

The board carries a **full local day** (`getStartOfDayForHub`). A row whose status never advanced to a terminal value is indistinguishable from a held flight. So a 07:00 departure that flew — but whose `departed` status never arrived, because upstream status coverage is incomplete — keeps accruing "hold" minutes all day. The index climbs monotonically through the evening as rows go stale. I watched it go 50.7 → 61.5 → 74.4 in one evening.

## Evidence, measured across all 9 hubs on live data

Replaying IROPS' exact inputs (same `/api/schedule` params it uses):

```
board rows fetched                                   : 2858
rows scored "overdue >30min"                         :  548
  of those, >6 hours overdue                         :  122
  worst                                              : 1028 min (17.1 h)
rows whose SCHEDULED ARRIVAL has already passed      :  332   <- cannot still be at the gate
rows carrying no scheduled arrival at all            :   25
```

## The fix

Two guards, ordered by how much we trust them:

1. **Scheduled arrival.** A plane cannot still be awaiting departure once the clock has passed the time it was scheduled to *land*. Decisive, removes 332 of 548 (61%), and requires no policy judgment whatsoever.
2. **`OVERDUE_MAX_MIN = 240`**, for the 25 rows that carry no scheduled arrival. Chosen above the FAA's 3-hour tarmac limit, past which a hold is cancelled rather than held. Beyond that we genuinely cannot distinguish a held flight from a stale row, so we under-report rather than fabricate — the same honest-degradation rule the boards and the freshness chip already follow.

The F073 ground-stop signal the rule exists for is **preserved**: a genuine hold still short of its scheduled arrival still counts toward `delayed30`/`delayed60` and still surfaces in `worstDelays`. The original F073 test passes unmodified.

## Effect, patched `computeMetrics` against the same live boards

| | before | after |
|---|---|---|
| `delayed30` | 1184 | 906 |
| `delayed60` | 638 | 378 |
| worst reported hold | 944 min | 415 min |
| score | 74.4 | 55.5 |

Two honest notes:

- The 415-minute entry that survives is from the **real-delay path** — a flight with an actual recorded departure timestamp 6.9h late. Not inferred. By construction nothing above 240 min can now come from the overdue path.
- **The score is still SIGNIFICANT.** This removes the fabricated part of the disruption, not the real backlog underneath. Whether 55.5 is correctly calibrated against a threshold of 15 is a separate question that predates PR #220 — the overdue rule only amplified it. Flagging, not fixing, in this PR.

## Regression guard

Five new `F073b` cases in `tests/irops.test.js`:
- a 15-hour stale row past its scheduled arrival scores 0 and never enters `worstDelays`
- a genuine ground-stop hold still short of its scheduled arrival still counts (F073 preserved)
- an unknown-arrival row beyond the cap scores 0; one inside the cap still counts
- `worstDelays` never reports an overdue hold beyond the cap

Confirmed the three bug-describing tests fail against the current code and pass after.

## Verification

- `bun run test` — 74 files, 1047 tests pass (5 new)
- `bun run typecheck` — clean
- Patched `computeMetrics` executed against live production board data (table above)

Found during the post-#220 blast-radius audit. The map hotfix was #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)