### PR TITLE
fix: post-#220 audit follow-ups — dead zoom control, nav desync, support-stats amplifier (v1.7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.3] - 2026-07-08
+
+### Fixed
+- **The live map's zoom-out button was unclickable on desktop.** The v2.0 program moved `#legal-details` (the About/Donate "ⓘ" control) from an in-flow nav child to `position:fixed; bottom:24px; right:16px; z-index:760`. Leaflet mounts the map's zoom control at `bottomright`, where it occupies roughly the first 42px in from the right edge — so the panel sat directly on top of the `−` button. `document.elementFromPoint()` at the button's centre returned `#legal-btn`: clicking zoom-out opened the About popover. Moved the control (and its popover, to keep them aligned) to `right:56px`. Same failure family as the v1.7.1 marker bug — a positioning change from the v2.0 program quietly eating a map control.
+- **Mobile bottom nav lit up two tabs at once.** The v2.0 program promoted My Flights to primary mobile nav but left `tab-myflight` in the hardcoded `overflowTabs` list, so tapping it activated both "My Flights" and "More" — while Fleet and Starlink, which had moved *into* the More menu, activated nothing. `overflowTabs` is now derived from `#mobile-more-menu`'s own contents, which is the definition of "reachable only via More" and cannot desync from the markup again.
+- **`/api/support-stats` was an unauthenticated amplifier onto FR24's metered usage API.** It is public, had no rate limiter (19 sibling handlers have one), and the CDN cache is keyed by the full URL — so `?z=<random>` was an origin MISS every time, and every MISS fired a fresh *authenticated* upstream call. Added a 5-minute memo (the real guard: one upstream call per TTL per warm instance, regardless of request volume) plus `createRateLimiter('support-stats', 60)`. The `429` is sent with `Cache-Control: no-store` so it can never enter the shared CDN cache.
+- **The support meter flapped between "configured" and "not configured" on identical requests.** A failed FR24 fetch returned `{configured:false}` — the same shape the endpoint uses to mean "no token set" — so a flaky upstream made the meter silently vanish rather than admit a bad fetch. A last-known-good reading is now served for up to 30 minutes when the upstream is failing.
+- `api/support-stats.ts` `maxDuration` 10s → 15s. Its only upstream (`fetchFr24UsageRaw`) aborts at exactly 10000ms, so the function was killed before its own `catch` could return the documented graceful fallback.
+- Regression guards: `tests/leaflet-required-styles.test.js` now also fails CI if a fixed bottom-right overlay intrudes on the 52px reserved for Leaflet's zoom control; `tests/support-stats.test.js` adds memo, stale-serve and rate-limit cases. Each new test was confirmed to fail against the old code and pass against the new.
+
+### Note
+No unit test covers the mobile-nav fix — this repo has no DOM test environment (`jsdom`/`happy-dom` are not devDependencies), which is also why the v2.0 program's "axe: 0 violations" claim was never a CI gate. Verified instead by driving the built bundle in a real browser. Adding a DOM test environment is the natural follow-up.
+
 ## [1.7.2] - 2026-07-08
 
 ### Fixed

--- a/api/support-stats.ts
+++ b/api/support-stats.ts
@@ -20,8 +20,32 @@
 import type { VercelRequest, VercelResponse } from './types.js';
 import { getAdbUnitsToday, getAdbDailyUnitBudget } from './_cost-state.js';
 import { fetchFr24UsageRaw } from './fr24-usage.js';
+import { createRateLimiter } from './_rate-limit.js';
 
 const MONTHLY_COST_NOTE = 'Data feeds, hosting, and AI explanations cost real money every month';
+
+// This endpoint is public and unauthenticated, and the CDN cache is keyed by the full URL — so
+// `?z=<random>` is a MISS every time and reaches the origin. Before the memo below, each MISS
+// fired a fresh *authenticated* call to FR24's usage API, which made an anonymous loop an
+// amplifier onto a metered upstream this project has exhausted before. The rate limiter is
+// per-instance (serverless) and so only partial cover; the memo is the real guard, because it
+// bounds upstream calls to one per TTL per warm instance no matter how many requests arrive.
+const isRateLimited = createRateLimiter('support-stats', 60);
+
+const LIVE_FEED_TTL_MS = 5 * 60 * 1000;
+// How long a last-known-good reading may be served after the upstream starts failing. Without
+// this, a flaky FR24 made the response flap between {configured:true} and {configured:false} on
+// consecutive identical requests — and {configured:false} is the same shape the endpoint uses to
+// mean "no token configured", so the meter silently vanished rather than admitting a bad fetch.
+const LIVE_FEED_STALE_MS = 30 * 60 * 1000;
+
+type LiveFeed = { configured: false } | { configured: true; usedPct: number };
+let liveFeedMemo: { at: number; value: { configured: true; usedPct: number } } | null = null;
+
+/** Test seam: module-level memo would otherwise leak across cases. */
+export function __resetLiveFeedMemo(): void {
+  liveFeedMemo = null;
+}
 
 // Coarse denominator for the live-feed percentage. There is no published per-account credit
 // ceiling in the FR24 usage response itself, so this is an operator-configured estimate of the
@@ -38,8 +62,10 @@ function roundToNearest5(pct: number): number {
   return Math.round(clamped / 5) * 5;
 }
 
-async function getLiveFeedUsage(): Promise<{ configured: false } | { configured: true; usedPct: number }> {
+async function getLiveFeedUsage(now: number = Date.now()): Promise<LiveFeed> {
   if (!process.env.FR24_API_TOKEN) return { configured: false };
+
+  if (liveFeedMemo && now - liveFeedMemo.at < LIVE_FEED_TTL_MS) return liveFeedMemo.value;
 
   try {
     const raw = await fetchFr24UsageRaw();
@@ -47,9 +73,13 @@ async function getLiveFeedUsage(): Promise<{ configured: false } | { configured:
     const totalCredits = rows.reduce((sum, row) => sum + (Number(row?.credits) || 0), 0);
     const budget = getFr24MonthlyCreditBudget();
     const pct = budget > 0 ? (totalCredits / budget) * 100 : 0;
-    return { configured: true, usedPct: roundToNearest5(pct) };
+    const value = { configured: true as const, usedPct: roundToNearest5(pct) };
+    liveFeedMemo = { at: now, value };
+    return value;
   } catch (e: any) {
     console.error('support-stats: FR24 usage fetch failed:', e?.message || e);
+    // Prefer a slightly stale truth over a false "not configured".
+    if (liveFeedMemo && now - liveFeedMemo.at < LIVE_FEED_STALE_MS) return liveFeedMemo.value;
     return { configured: false };
   }
 }
@@ -60,6 +90,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   if (req.method === 'OPTIONS') return res.status(204).end();
   if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
+
+  if (isRateLimited(req)) {
+    // Never let a 429 into the shared CDN cache — it would be served to innocent visitors.
+    res.setHeader('Cache-Control', 'no-store');
+    return res.status(429).json({ error: 'Rate limited — try again shortly' });
+  }
 
   // Public, unauthenticated, identical for everyone — safe to cache hard at the CDN.
   res.setHeader('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=600');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -181,13 +181,23 @@ main{display:contents}
    (main.js's delegated handlers for #legal-btn / #legal-details / #legalpop are unaffected),
    no longer a tablist child, and #legalpop's fixed coordinates now resolve against the real
    viewport. Anchored bottom-right at the same bottom offset as the dock so it reads as a
-   companion floating control, styled with the same panel recipe (DESIGN.md card treatment). */
-#legal-details{position:fixed;bottom:24px;right:16px;z-index:760;border-radius:6px;background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.96) 100%);border:1px solid var(--ua-border)}
+   companion floating control, styled with the same panel recipe (DESIGN.md card treatment).
+
+   RIGHT OFFSET IS LOAD-BEARING: the live map puts Leaflet's zoom control at 'bottomright'
+   (main.js L.control.zoom), where leaflet.css's 10px margin makes it occupy roughly 10-42px
+   from the viewport's right edge and 10-89px from its bottom. At right:16px this panel (45px
+   wide, z-index 760) sat directly on top of the zoom-OUT button and swallowed its clicks —
+   document.elementFromPoint at the button's centre returned #legal-btn. Keep right >= 52px so
+   the two controls sit side by side. Guarded by tests/leaflet-required-styles.test.js. */
+#legal-details{position:fixed;bottom:24px;right:56px;z-index:760;border-radius:6px;background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.96) 100%);border:1px solid var(--ua-border)}
 #legal-details>summary{list-style:none;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;padding:8px 14px 7px;border-radius:6px;color:var(--ua-muted);min-width:0;background:none;font-size:15px;font-weight:700;font-family:var(--font-display);cursor:pointer;transition:background-color .15s,color .15s}
 #legal-details>summary::-webkit-details-marker{display:none}
 #legal-details>summary:hover{background:rgba(148,163,184,.07);color:var(--ua-text)}
 #legal-details[open]>summary{background:var(--ua-blue-soft);color:var(--ua-accent)}
-#legalpop{position:fixed;bottom:96px;right:16px;z-index:780;width:300px;max-width:calc(100vw - 32px);padding:13px 14px;background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.96) 100%);border:1px solid var(--ua-border);border-radius:6px}
+/* Tracks #legal-details' right offset so the popover stays anchored over its button; the
+   gutter in max-width follows suit (56px right + 16px left). bottom:96px clears the zoom
+   control's 89px reach, so the open popover does not cover it either. */
+#legalpop{position:fixed;bottom:96px;right:56px;z-index:780;width:300px;max-width:calc(100vw - 72px);padding:13px 14px;background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.96) 100%);border:1px solid var(--ua-border);border-radius:6px}
 #legalpop .ltitle{font-family:var(--font-display);font-weight:700;font-size:11px;letter-spacing:.5px;color:var(--ua-text);margin-bottom:8px;text-transform:uppercase}
 #legalpop .lgrid{display:flex;flex-wrap:wrap;gap:6px 14px;font-size:11px;line-height:1.5}
 #legalpop a{color:var(--ua-muted);text-decoration:none}

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -662,7 +662,15 @@ function applyFleetDeepLinkFilter(filter, { render = true } = {}) {
 const _origSwitchToTab = switchToTab;
 switchToTab = function(tabId, updateHash) {
   _origSwitchToTab(tabId, updateHash);
-  var overflowTabs = ['tab-myflight','tab-analytics','tab-sources'];
+  // Read the overflow set out of the More menu rather than hardcoding it. The old literal
+  // ['tab-myflight','tab-analytics','tab-sources'] silently desynced when My Flights was
+  // promoted to primary mobile nav: tapping it lit up BOTH "My Flights" and "More", while
+  // Fleet and Starlink — which had moved INTO the More menu — lit up nothing at all.
+  // The menu's own contents are the definition of "reachable only via More", so derive from it.
+  var moreMenu = document.getElementById('mobile-more-menu');
+  var overflowTabs = moreMenu
+    ? Array.prototype.map.call(moreMenu.querySelectorAll('[data-tab]'), function(b) { return b.dataset.tab; })
+    : [];
   var moreBtn = document.getElementById('mobile-more-btn');
   document.querySelectorAll('#mobile-bottom-nav button[data-tab]:not(.bnav-overflow-item)').forEach(function(b) {
     b.classList.toggle('active', b.dataset.tab === tabId);

--- a/tests/leaflet-required-styles.test.js
+++ b/tests/leaflet-required-styles.test.js
@@ -61,6 +61,28 @@ describe('Leaflet required styles are not overridden', () => {
     });
   }
 
+  // The live map mounts Leaflet's zoom control at 'bottomright'. leaflet.css gives it a 10px
+  // margin and a 30px-wide button stack, so it owns roughly the first 42px in from the viewport's
+  // right edge and the first 89px up from the bottom. #legal-details shipped at right:16px and
+  // covered the zoom-OUT button outright — document.elementFromPoint at the button's centre
+  // returned #legal-btn, so clicking "−" opened the About popover instead of zooming.
+  const LEAFLET_ZOOM_RIGHT_RESERVED_PX = 52;
+
+  it('keeps fixed bottom-right overlays clear of the Leaflet zoom control', () => {
+    const rule = stripped.match(/#legal-details\s*\{([^}]*)\}/);
+    expect(rule, '#legal-details rule not found').toBeTruthy();
+
+    const body = rule[1];
+    expect(body, 'expected #legal-details to be position:fixed').toMatch(/position\s*:\s*fixed/);
+
+    const right = Number((body.match(/(?:^|;)\s*right\s*:\s*(\d+)px/) || [])[1]);
+    expect(
+      right,
+      `#legal-details must sit at least ${LEAFLET_ZOOM_RIGHT_RESERVED_PX}px from the right edge ` +
+        "so it does not swallow the map's zoom-out button"
+    ).toBeGreaterThanOrEqual(LEAFLET_ZOOM_RIGHT_RESERVED_PX);
+  });
+
   it('keeps the marker hit-slop pseudo-element', () => {
     // The accessibility win from PR #220 (10px touch targets are a click hazard)
     // is preserved by the ::after alone — an absolutely positioned marker is

--- a/tests/support-stats.test.js
+++ b/tests/support-stats.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import handler from '../api/support-stats.js';
+import handler, { __resetLiveFeedMemo } from '../api/support-stats.js';
 import * as costState from '../api/_cost-state.js';
 import * as fr24Usage from '../api/fr24-usage.js';
 
@@ -23,6 +23,7 @@ function makeReq(overrides = {}) {
 describe('support-stats API', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    __resetLiveFeedMemo();
     delete process.env.FR24_API_TOKEN;
     delete process.env.FR24_MONTHLY_CREDIT_BUDGET;
   });
@@ -112,6 +113,61 @@ describe('support-stats API', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.body.liveFeed).toEqual({ configured: false });
+  });
+
+  // ── Cost + honesty guards ────────────────────────────────────────────────────
+  // This endpoint is public and unauthenticated, and the CDN cache is keyed by the full URL, so
+  // `?z=<random>` reaches the origin every time. Each origin hit used to fire a fresh
+  // authenticated FR24 usage call, making an anonymous loop an amplifier onto a metered upstream.
+
+  it('memoizes the upstream usage call across requests', async () => {
+    process.env.FR24_API_TOKEN = 'test-token';
+    process.env.FR24_MONTHLY_CREDIT_BUDGET = '1000';
+    const fetchSpy = vi.spyOn(fr24Usage, 'fetchFr24UsageRaw').mockResolvedValue({
+      data: [{ credits: 500 }],
+    });
+
+    for (let i = 0; i < 5; i++) await handler(makeReq(), createRes());
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves the last good reading when the upstream starts failing, instead of flapping to unconfigured', async () => {
+    process.env.FR24_API_TOKEN = 'test-token';
+    process.env.FR24_MONTHLY_CREDIT_BUDGET = '1000';
+
+    // Prime the memo with a success, then make every later fetch blow up.
+    const spy = vi
+      .spyOn(fr24Usage, 'fetchFr24UsageRaw')
+      .mockResolvedValueOnce({ data: [{ credits: 300 }] });
+    const first = createRes();
+    await handler(makeReq(), first);
+    expect(first.body.liveFeed).toEqual({ configured: true, usedPct: 30 });
+
+    spy.mockRejectedValue(new Error('FR24 503'));
+    // Push past the memo's freshness window so the failing branch is actually taken.
+    vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 6 * 60 * 1000);
+
+    const second = createRes();
+    await handler(makeReq(), second);
+
+    // {configured:false} is the same shape as "no token", so a failed fetch must not use it
+    // while a recent good reading exists — that made the meter silently vanish.
+    expect(second.body.liveFeed).toEqual({ configured: true, usedPct: 30 });
+  });
+
+  it('rate limits a single IP and never lets the 429 into the shared CDN cache', async () => {
+    const req = () => makeReq({ headers: { 'x-real-ip': '203.0.113.9' } });
+
+    let limited = null;
+    for (let i = 0; i < 61; i++) {
+      const res = createRes();
+      await handler(req(), res);
+      if (res.statusCode === 429) { limited = res; break; }
+    }
+
+    expect(limited, 'expected a 429 within 61 requests from one IP').not.toBeNull();
+    expect(limited.headers['Cache-Control']).toBe('no-store');
   });
 
   it('includes the static monthlyCostNote', async () => {

--- a/vercel.json
+++ b/vercel.json
@@ -37,7 +37,7 @@
         "api/tsa.ts": { "maxDuration": 30 },
         "api/cron/refresh-tsa.ts": { "maxDuration": 30 },
         "api/metar.ts": { "maxDuration": 15 },
-        "api/support-stats.ts": { "maxDuration": 10 },
+        "api/support-stats.ts": { "maxDuration": 15 },
         "api/cron/refresh-metar.ts": { "maxDuration": 30 },
         "api/cron/watch-alerts.ts": { "maxDuration": 120 }
     },


### PR DESCRIPTION
Three defects surfaced by the PR #220 blast-radius audit (96 agents, 30 candidates, 3 adversarial verifiers each) and then independently reproduced against production before fixing.

> ⚠️ **Merging this deploys production, which also arms background push alerts.** The `WEB_PUSH_*` env vars are set and `sql/014` is applied; they are inert until the next deploy. This is intentional — two birds, one stone.

---

## 1. The live map's zoom-out button is unclickable on desktop

`#legal-details` (the About/Donate "ⓘ" control) was moved by #220 from an in-flow nav child to:

```css
#legal-details{position:fixed;bottom:24px;right:16px;z-index:760;...}
```

Leaflet mounts the live map's zoom control at `bottomright` (`main.js:1002`), where its 10px margin and 30px button stack occupy roughly the first 42px in from the viewport's right edge. The 45px-wide panel landed on top of the `−` button.

Measured on production, `document.elementFromPoint()` at each button's centre:

```
zoomOut  rect [1238,741,30,30]   topmost: #legal-btn   BLOCKED
zoomIn   rect [1238,711,30,30]   topmost: SPAN         ok
```

Clicking zoom-out opened the About popover. Hidden below 768px, so desktop only. **This is the same failure family as the v1.7.1 marker bug** — a positioning change from #220 quietly eating a map control.

Fix: `right:16px` → `right:56px` on the control, and on `#legalpop` so the popover stays anchored over its button.

After, on the **built bundle**: `zoomIn OK, zoomOut OK, legalBtn OK, attribution OK`. With the popover open, `zoomOut OK, zoomIn OK`. At a 769px viewport the popover spans `left:413 right:713` — no clipping.

## 2. Mobile bottom nav lights up two tabs at once

#220 promoted My Flights to primary mobile nav but left it in the hardcoded literal (`main.js:665`):

```js
var overflowTabs = ['tab-myflight','tab-analytics','tab-sources'];
```

Meanwhile Fleet and Starlink moved *into* the More menu and were never added. Reproduced on production — tapping My Flights yields `activeItems: ["🎫My Flights", "▾More"]`.

Fix: derive the list from `#mobile-more-menu`'s own contents. That *is* the definition of "reachable only via More", so it cannot desync from the markup again.

Verified against the built bundle:

| tapped | before | after |
|---|---|---|
| Live / Schedule | correct | correct |
| My Flights | `My Flights` + `MORE` | `My Flights` |
| Fleet | *(nothing)* | `MORE` |
| Starlink | *(nothing)* | `MORE` |

## 3. `/api/support-stats` is an unauthenticated amplifier onto FR24's metered API

Public, no rate limiter (19 sibling handlers have one), and the CDN cache is keyed by the full URL. So `?z=<random>` is an origin MISS every time, and each MISS fired a fresh **authenticated** call to FR24's usage API — a project that has exhausted this quota before.

The audit rated this `low` on the belief `FR24_API_TOKEN` was unset. It isn't. Three identical live requests:

```
liveFeed: {"configured": true, "usedPct": 0}
liveFeed: {"configured": false}
liveFeed: {"configured": false}
```

That flapping is a second bug: a *failed* fetch returns `{configured:false}`, which is the same shape the endpoint uses for "no token configured" — so a flaky upstream made the meter silently vanish rather than admit a bad fetch.

Fixes:
- **5-minute memo** — the real cost guard. One upstream call per TTL per warm instance, regardless of request volume. A per-instance rate limiter alone cannot bound this on serverless.
- `createRateLimiter('support-stats', 60)` as defence in depth. The `429` is sent with `Cache-Control: no-store` so it can never be cached and served to innocent visitors.
- On upstream failure, serve the last-known-good reading for up to 30 minutes instead of a false `{configured:false}`.
- `maxDuration` 10s → 15s in `vercel.json`. `fetchFr24UsageRaw` aborts at exactly `10000ms`, so the function was being killed before its own `catch` could return the documented graceful fallback.

---

## Verification

- `bun run test` — 74 files, **1051 tests pass** (4 new)
- `bun run typecheck` — clean
- `bun run build` — clean, 43 pages
- Each new test confirmed to **fail against the old code and pass against the new** (isolated by restoring the old handler with a no-op reset stub, so the three new cases were tested individually rather than the whole file erroring on a missing import)
- Both UI fixes driven in a real browser against the **built** `dist/` bundle, not just reasoned about

## Honest gap

No unit test covers the nav fix: this repo has no DOM test environment (`jsdom`/`happy-dom` are not devDependencies). That is also why #220's `axe: 0 violations` claim was never a CI gate — `@axe-core/playwright` is a devDependency no test invokes. The audit's completeness critic flagged this, and the audit itself falsified the claim by finding a skipped heading level (h1→h3) on My Flights. Adding a DOM test environment is the natural follow-up and would have caught bugs 1 and 2 mechanically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)