### PR TITLE
fix(schedule): stop opening on an empty board overnight; kill "→ ?" and "Unknown" (v1.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.4] - 2026-07-09
+
+### Fixed
+- **The Schedule tab was empty and useless overnight.** Opened at 00:23 hub-local, it defaulted to "Today" — a board of 644 flights that had not happened yet: `0 OPERATED`, `0 ON TIME`, `0 LATE`, `0 CANCELED`, `644 UPCOMING`, and every row reading `Expected · RISK: LOW`. The completed day, with all of its real data, sat one click away under "Yesterday". `api/irops.ts` has applied the right rule server-side all along — *"Before 6 AM local: no flights have departed yet, show yesterday's data"* — but the client never did. The Schedule board now opens on the completed day before the hub's 6 AM rollover, via a new shared `defaultSchedDayOffset()` in `src/lib/hubTz.js` so client and server can't drift apart again. Today and Tomorrow remain one click away.
+- **`ORD → ?` in the route column.** 7 of 644 rows on a real ORD board carry a destination city but no IATA code, and the renderer printed a bare `?` while stranding the city in the subtitle. The city is now promoted into the route line when the code is missing (`ORD → Los Angeles`), with no duplicated subtitle.
+- **One flight in 644 read `Unknown` while the rest read `Expected`.** Both had the same normalized `generic.status.text: "scheduled"`, no estimated time, no real time, and were hours in the future. `classifyBase()` surfaced AeroDataBox's free-text `status.text` verbatim — its `|| 'Scheduled'` fallback never fired because `"Unknown"` is truthy. A meaningless provider word now falls back to `Scheduled`; a meaningful one (`Expected`) is still shown. The status `key` is untouched, so time-based reclassification to `Departed` still works.
+- Also restamps the Yesterday/Today/Tomorrow date labels after the home hub resolves. They were previously rendered before `schedCurrentHub` was known and fell back to the wrong timezone.
+
+### Note
+`tests/schedule.test.js > honors officialFallback=0 when scraping fails` failed twice while this branch was being built (both runs ≈00:45 America/Chicago) and passes on this branch and on `main` at other hours. It is **not** caused by this change: the same commit is green now, and clean `main` shows the identical behaviour. That suite pins `Date` (`vi.setSystemTime`) but leaves real timers real, and `api/_rate-limit.ts:9` captures `Date.now()` at import — before the fake clock installs. Worth chasing separately; flagged rather than papered over.
+
 ## [1.7.3] - 2026-07-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -8,7 +8,7 @@ import { bucketInstallsByMonth, computeInstallPace, buildDeparturesBoard } from 
 import { getFlightPopupMetrics } from '../lib/flight-popup.js';
 import { getScheduleFleetFamily } from '../lib/schedule-filters.js';
 import { classifySchedStatus } from '../lib/schedule-status.js';
-import { getStartOfHubDay, getHubDayLabel } from '../lib/hubTz.js';
+import { getStartOfHubDay, getHubDayLabel, defaultSchedDayOffset } from '../lib/hubTz.js';
 import { classifyConnection, MIN_CONNECTION_TIMES, TERMINAL_WALK_TIMES } from '../lib/connection-risk.js';
 import { formatDataAge, dataAgeSeverity } from '../lib/data-age.js';
 import { formatTimeWithTz } from '../lib/time-format.js';
@@ -4611,6 +4611,16 @@ function initScheduleTab() {
       document.getElementById('sched-hub').value = homeHub;
       schedCurrentHub = homeHub;
     }
+    // Before the hub's first departures roll, "today" is an empty board: every flight upcoming,
+    // 0 operated, every stat zero. Open on the completed day instead — the same rule api/irops.ts
+    // applies server-side. The Today button is still one click away.
+    schedCurrentDay = defaultSchedDayOffset(schedCurrentHub);
+    document.querySelectorAll('.sched-day-btn').forEach(b => {
+      b.classList.toggle('active', parseInt(b.dataset.day, 10) === schedCurrentDay);
+    });
+    // Labels were rendered above before schedCurrentHub was resolved, so they used the fallback
+    // timezone. Now that the hub is known, restamp them in hub-local dates.
+    updateSchedDayLabels();
     loadScheduleData();
   }
 }
@@ -5160,13 +5170,25 @@ function renderScheduleTable() {
 
     const dest = fl.airport?.destination;
     const orig = fl.airport?.origin;
+    // Some provider rows carry a city name but no IATA code (7 of 644 on a real ORD board), which
+    // rendered as a bare "ORD → ?" with the city stranded in the subtitle. Promote the city into
+    // the route line when the code is missing rather than showing the user a question mark.
+    const shortName = (a) => (a?.name ? a.name.replace(/ Airport| International/g, '').substring(0, 30) : '');
+    const routeCell = (code, name, other, dirIsDep) => {
+      const primary = code || name || '—';
+      const line = dirIsDep
+        ? `${escapeHtml(other)} → ${escapeHtml(primary)}`
+        : `${escapeHtml(primary)} → ${escapeHtml(other)}`;
+      // Only add the subtitle when it is not already the primary text.
+      return code && name
+        ? `${line}<div style="font-size:9px;color:var(--ua-muted)">${escapeHtml(name)}</div>`
+        : line;
+    };
     let routeStr;
     if (schedCurrentDir === 'departures') {
-      routeStr = `${escapeHtml(hub)} → ${escapeHtml(dest?.code?.iata || '?')}`;
-      if (dest?.name) routeStr += `<div style="font-size:9px;color:var(--ua-muted)">${escapeHtml(dest.name.replace(/ Airport| International/g, '').substring(0, 30))}</div>`;
+      routeStr = routeCell(dest?.code?.iata, shortName(dest), hub, true);
     } else {
-      routeStr = `${escapeHtml(orig?.code?.iata || '?')} → ${escapeHtml(hub)}`;
-      if (orig?.name) routeStr += `<div style="font-size:9px;color:var(--ua-muted)">${escapeHtml(orig.name.replace(/ Airport| International/g, '').substring(0, 30))}</div>`;
+      routeStr = routeCell(orig?.code?.iata, shortName(orig), hub, false);
     }
 
     const acCode = fl.aircraft?.model?.code || '—';

--- a/src/lib/hubTz.js
+++ b/src/lib/hubTz.js
@@ -110,6 +110,25 @@ export function getHubDayLabel(hub, dayOffset = 0, now = new Date()) {
  * Hub-local calendar date parts (year/month/day) as zero-padded strings.
  * Useful when constructing API queries keyed on hub-local date.
  */
+// A hub's "today" board is empty until its first departures roll. Opening the Schedule tab at
+// 00:23 hub-local showed 644 flights that had not happened yet — 0 operated, 0 on-time, 0 late,
+// 0 cancelled, every row "Expected · RISK: LOW" — while the completed day sat one click away
+// under "Yesterday". api/irops.ts has always applied this rule server-side ("Before 6 AM local:
+// no flights have departed yet, show yesterday's data"); these two must stay in sync.
+export const BOARD_ROLLOVER_HOUR = 6;
+
+/** Hub-local hour of day, 0-23. */
+export function getHubLocalHour(hub, now = new Date()) {
+  const tz = HUB_TZ[hub] || 'America/New_York';
+  // partsToObj normalizes the ICU hour="24" midnight quirk to "00".
+  return +partsToObj(getFmt(tz).formatToParts(now)).hour;
+}
+
+/** Which day the Schedule board should open on: -1 (yesterday) before rollover, else 0 (today). */
+export function defaultSchedDayOffset(hub, now = new Date()) {
+  return getHubLocalHour(hub, now) < BOARD_ROLLOVER_HOUR ? -1 : 0;
+}
+
 export function getHubLocalDate(hub, timestampMs = Date.now()) {
   const tz = HUB_TZ[hub] || 'America/New_York';
   const parts = new Intl.DateTimeFormat('en-US', {

--- a/src/lib/schedule-status.js
+++ b/src/lib/schedule-status.js
@@ -94,7 +94,17 @@ function classifyBase(flight) {
   // A flight is en-route if: FR24 says so, OR it's live with a real departure (actually airborne)
   const isAirborne = s.live === true && (flight.time?.real?.departure != null);
   if (statusText === 'en-route' || txtLower.includes('en route') || isAirborne) return { text: txt || 'En Route', cls: 'enroute', key: 'enroute' };
-  if (statusText === 'scheduled') return { text: txt || 'Scheduled', cls: 'scheduled', key: 'scheduled' };
+  if (statusText === 'scheduled') {
+    // `txt` is the provider's free-text status and is shown verbatim in the Status column.
+    // AeroDataBox emits both 'Expected' and the meaningless 'Unknown' for rows that are
+    // identically not-yet-departed, so one flight in a board of 644 read "Unknown" while the
+    // rest read "Expected" — same generic status, no estimated time, no real time, both hours
+    // away. The `|| 'Scheduled'` fallback below never fired because "Unknown" is truthy.
+    // generic.status.text is the normalized truth; use it whenever the provider word carries no
+    // meaning. `key` stays 'scheduled' either way, so time-based reclassification is unaffected.
+    const meaningful = txt && txtLower !== 'unknown';
+    return { text: meaningful ? txt : 'Scheduled', cls: 'scheduled', key: 'scheduled' };
+  }
   if (statusText === 'estimated') {
     const schedTime = flight.time?.scheduled?.departure || flight.time?.scheduled?.arrival;
     const estTime = flight.time?.estimated?.departure || flight.time?.estimated?.arrival;

--- a/tests/hubTz.test.js
+++ b/tests/hubTz.test.js
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { getStartOfHubDay, getHubDayLabel, getHubLocalDate, HUB_TZ } from '../src/lib/hubTz.js';
+import {
+  getStartOfHubDay,
+  getHubDayLabel,
+  getHubLocalDate,
+  getHubLocalHour,
+  defaultSchedDayOffset,
+  HUB_TZ,
+} from '../src/lib/hubTz.js';
 
 // Helper: assert that `ts` (Unix seconds) falls exactly at midnight in the
 // given tz. Formats back via Intl.DateTimeFormat and compares the hour/minute.
@@ -126,5 +133,54 @@ describe('getHubLocalDate', () => {
     expect(month).toBe('04');
     // 15:00 UTC on 04-24 is 00:00 JST on 04-25.
     expect(day).toBe('25');
+  });
+});
+
+describe('defaultSchedDayOffset', () => {
+  // The Schedule tab opened at 00:23 hub-local and showed 644 flights that had not happened yet:
+  // 0 operated, 0 on-time, 0 late, 0 cancelled, every row "Expected · RISK: LOW". The completed
+  // day sat one click away under "Yesterday". api/irops.ts has always applied this rule
+  // server-side ("Before 6 AM local: no flights have departed yet, show yesterday's data");
+  // this is the client half of it.
+
+  it('defaults to yesterday before the rollover hour, hub-local', () => {
+    // 05:23 UTC = 00:23 CDT — the exact case from the bug report.
+    const now = new Date('2026-07-09T05:23:00Z');
+    expect(defaultSchedDayOffset('ORD', now)).toBe(-1);
+  });
+
+  it('defaults to today once the hub-local day is underway', () => {
+    // 14:00 UTC = 09:00 CDT.
+    const now = new Date('2026-07-09T14:00:00Z');
+    expect(defaultSchedDayOffset('ORD', now)).toBe(0);
+  });
+
+  it('switches exactly at the rollover hour, not before', () => {
+    // 10:59:59 UTC = 05:59:59 CDT (still yesterday); 11:00 UTC = 06:00 CDT (today).
+    expect(defaultSchedDayOffset('ORD', new Date('2026-07-09T10:59:59Z'))).toBe(-1);
+    expect(defaultSchedDayOffset('ORD', new Date('2026-07-09T11:00:00Z'))).toBe(0);
+  });
+
+  it('is hub-local, not viewer-local: NRT and ORD disagree at the same instant', () => {
+    // 05:23 UTC → 00:23 in Chicago (before rollover) but 14:23 in Tokyo (well after).
+    const now = new Date('2026-07-09T05:23:00Z');
+    expect(defaultSchedDayOffset('ORD', now)).toBe(-1);
+    expect(defaultSchedDayOffset('NRT', now)).toBe(0);
+  });
+
+  it('handles the midnight hour="24" ICU quirk', () => {
+    // 05:00 UTC = exactly 00:00 CDT. partsToObj normalizes hour 24 → 0; 0 < 6 ⇒ yesterday.
+    expect(defaultSchedDayOffset('ORD', new Date('2026-07-09T05:00:00Z'))).toBe(-1);
+  });
+
+  it('agrees with the server rule in api/irops.ts (hour < 6)', () => {
+    for (let h = 0; h < 24; h++) {
+      const now = new Date(Date.UTC(2026, 6, 9, (h + 5) % 24, 30));
+      const hubHour = Number(
+        new Intl.DateTimeFormat('en-US', { timeZone: 'America/Chicago', hour: '2-digit', hour12: false })
+          .format(now)
+      ) % 24;
+      expect(defaultSchedDayOffset('ORD', now)).toBe(hubHour < 6 ? -1 : 0);
+    }
   });
 });

--- a/tests/schedule-status.test.js
+++ b/tests/schedule-status.test.js
@@ -165,3 +165,44 @@ describe('live-sighting reclassification (Phase 2)', () => {
     expect(s.live).toBe(true);
   });
 });
+
+describe('classifySchedStatus — provider vocabulary must not leak into the status column', () => {
+  // On a real ORD board of 644 flights, 643 rows read "Expected" and exactly one read "Unknown"
+  // — UA2666. Both rows were identical: generic.status.text 'scheduled', no estimated time, no
+  // real time, both hours in the future. The difference was AeroDataBox's free-text status.text,
+  // which classifyBase surfaced verbatim via `text: txt || 'Scheduled'` — the fallback never
+  // fired because txt was the truthy string "Unknown".
+
+  it('does not show the provider\'s "unknown" for a plainly scheduled flight', () => {
+    const fl = flight({ statusText: 'scheduled', text: 'unknown', schedDep: NOW + 5 * 3600 });
+    const s = classifySchedStatus(fl, 'departures', NOW);
+    expect(s.key).toBe('scheduled');
+    expect(s.text).toBe('Scheduled');
+  });
+
+  it('still shows a meaningful provider word like "Expected"', () => {
+    const fl = flight({ statusText: 'scheduled', text: 'expected', schedDep: NOW + 5 * 3600 });
+    const s = classifySchedStatus(fl, 'departures', NOW);
+    expect(s.key).toBe('scheduled');
+    expect(s.text).toBe('Expected');
+  });
+
+  it('falls back to "Scheduled" when the provider says nothing at all', () => {
+    const fl = flight({ statusText: 'scheduled', text: '', schedDep: NOW + 5 * 3600 });
+    expect(classifySchedStatus(fl, 'departures', NOW).text).toBe('Scheduled');
+  });
+
+  it('two identically-scheduled flights never render two different words', () => {
+    const a = flight({ statusText: 'scheduled', text: 'unknown', schedDep: NOW + 5 * 3600 });
+    const b = flight({ statusText: 'scheduled', text: '', schedDep: NOW + 5 * 3600 });
+    expect(classifySchedStatus(a, 'departures', NOW).text).toBe(classifySchedStatus(b, 'departures', NOW).text);
+  });
+
+  it('an "unknown"-texted row is still reclassified as departed once it is long past', () => {
+    // key stays 'scheduled', so it remains in RECLASSIFIABLE_KEYS — this must not regress.
+    const fl = flight({ statusText: 'scheduled', text: 'unknown', schedDep: NOW - 6 * 3600 });
+    const s = classifySchedStatus(fl, 'departures', NOW);
+    expect(s.key).toBe('departed');
+    expect(s.presumed).toBe(true);
+  });
+});


### PR DESCRIPTION
The Schedule tab, opened at **00:23 hub-local**:

```
645 UA DEP · THU, JUL 9 | — ON-TIME (0 OPERATED) | 0 ON TIME | 0 LATE | 0 CANCELED | 644 UPCOMING
```

644 flights that hadn't happened yet. Every row `Expected · RISK: LOW`. Every stat zero. The completed day — with all of its real data — sat one click away under "Yesterday".

That's the "empty and wrong" report, and it's reproducible: it's what the board does every night between midnight and 6am at whichever hub you're looking at.

---

## 1. The board opened on a day that hadn't started

`api/irops.ts` has carried the correct rule server-side since it shipped:

```ts
// Before 6 AM local: no flights have departed yet, show yesterday's data
if (hour < 6) return startOfToday - 86400;
```

The client never got that half. `src/dashboard/main.js` hardcoded `let schedCurrentDay = 0`.

**Fix:** a shared `defaultSchedDayOffset(hub, now)` in `src/lib/hubTz.js` — the module that already exists precisely so *"client and server previously had divergent calendar logic"* doesn't happen again. The board opens on the completed day before the hub's rollover hour. Today and Tomorrow remain one click away.

Verified in a real browser against the **built** bundle, API proxied to production, using the fact that it is currently 11:00 in Chicago and 01:00 in Tokyo — so both branches of the rule are live at the same instant:

| home hub | hub-local time | active day button | requested timestamp |
|---|---|---|---|
| ORD | 11:00 CDT | `Today (Thu, Jul 9)` | — |
| NRT | 01:00 JST | `Yesterday (Thu, Jul 9)` | `1783522800` = Jul 9 00:00 JST ✓ |

## 2. `ORD → ?`

7 of 644 real rows carry a destination **city** but no IATA code. `main.js` printed `dest?.code?.iata || '?'` and stranded the city in the subtitle:

```
ORD → ?
Los Angeles
```

**Fix:** promote the city into the route line when the code is missing, and drop the now-duplicate subtitle. `UA2704` renders `ORD → Los Angeles`. (`UA3485` renders `ORD → Chicago`, which is upstream garbage from AeroDataBox — but at least we now show what we were given instead of a question mark.)

## 3. One flight in 644 read `Unknown`, the other 643 read `Expected`

Both rows were identical: `generic.status.text: "scheduled"`, no estimated time, no real time, both hours in the future. The difference was AeroDataBox's free-text `status.text`, which `classifyBase()` surfaced verbatim:

```js
if (statusText === 'scheduled') return { text: txt || 'Scheduled', ... }
```

The `|| 'Scheduled'` fallback never fired, because `"Unknown"` is truthy.

**Fix:** a meaningless provider word falls back to `Scheduled`; a meaningful one (`Expected`) is still shown. The status `key` stays `scheduled`, so it remains in `RECLASSIFIABLE_KEYS` and still gets reclassified to `Departed` by elapsed time — pinned by a regression test, since that's the subtle way this fix could have broken the EWR-pilot bug fix.

Sweeping all 646 rendered rows after the fix: **0 routes show `?`, 0 statuses show `Unknown`.** Distinct status words are now `Departed`, `Departed*`, `DepartedLIVE`, `Expected`, `Scheduled`, `Likely Canceled`.

## 4. Drive-by

Yesterday/Today/Tomorrow date labels were rendered before `schedCurrentHub` resolved, so they were stamped in the fallback timezone. Restamped after the hub is known.

---

## Verification

- `bun run test` — 74 files, **1062 tests pass** (11 new)
- `bun run typecheck` — clean · `bun run build` — clean
- Every new test confirmed to **fail before the fix**
- Both day-rule branches driven in a real browser against the built bundle (table above)

## Pre-existing flake, flagged not papered over

`tests/schedule.test.js > honors officialFallback=0 when scraping fails` failed twice while this branch was being built — **both runs at ≈00:45 America/Chicago**. It passes on this branch and on clean `main` at other hours; I ran the full suite on both to check. It is not caused by this change.

That suite pins `Date` via `vi.setSystemTime` but leaves real timers real, and `api/_rate-limit.ts:9` does `let lastCleanup = Date.now()` at **import time**, before the fake clock installs. The test's own comment says pinning to `07:00Z` reproduces an overnight failure deterministically. Worth chasing separately — CI running between 05:00–11:00 UTC would hit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)