### PR TITLE
fix(build): revert TypeScript 7 — it silently broke every production deploy (v1.7.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.5] - 2026-07-09
+
+### Fixed
+- **Production had not deployed for 11 hours.** The TypeScript 6 → 7 upgrade (#222) silently broke every production build. `main` kept merging; nothing shipped. The last deploy to reach production was v1.7.3, which means v1.7.4's Schedule fixes never went live.
+  ```
+  Using TypeScript 7.0.2 (local user-provided)
+  Error: Cannot read properties of undefined (reading 'readFile')
+  ```
+  TypeScript 7 is the native port. Its package ships the CLI but drops the legacy programmatic compiler API — `ts.sys`, `ts.createProgram` and friends are simply gone. `@vercel/node` compiles the `api/*.ts` functions and reads `tsconfig` through `ts.sys.readFile`, so it throws before building a single function. Every published `@vercel/node`, checked through the current 5.8.22, still calls it: there is no TS7-compatible version today. Reverted to `typescript@^6.0.3`.
+- **Nothing in CI could have caught it, which is the more interesting problem.** `bun run test`, `tsc --noEmit` and `bun run build` were all green under TS7 — the `tsc` CLI works fine, only the programmatic surface is missing — and the PR's Vercel check reported "pass" because its preview build was skipped by the Ignored Build Step. A failed *production* deploy is not wired to any GitHub check. Added `tests/vercel-build-compat.test.js`, which asserts the installed TypeScript still exposes the API `@vercel/node` compiles with, and that `package.json` pins a major that ships it. Confirmed it fails under 7.0.2 and passes under 6.0.3.
+
+### Note
+Restoring TS7 requires `@vercel/node` to support it. When that lands, bump `typescript` and delete `tests/vercel-build-compat.test.js` in the same PR.
+
 ## [1.7.4] - 2026-07-09
 
 ### Fixed

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "@types/web-push": "^3.6.4",
         "@vercel/node": "^5.6.12",
         "playwright": "^1.58.2",
-        "typescript": "^7.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.7",
       },
     },
@@ -351,46 +351,6 @@
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/web-push": ["@types/web-push@3.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ=="],
-
-    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
-
-    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
-
-    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
-
-    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
-
-    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
-
-    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
-
-    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
-
-    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
-
-    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
-
-    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
-
-    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
-
-    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
-
-    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
-
-    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
-
-    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
-
-    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
-
-    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
-
-    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
-
-    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
-
-    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
@@ -1032,7 +992,7 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
-    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"
@@ -38,7 +38,7 @@
     "@types/web-push": "^3.6.4",
     "@vercel/node": "^5.6.12",
     "playwright": "^1.58.2",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.7"
   }
 }

--- a/tests/vercel-build-compat.test.js
+++ b/tests/vercel-build-compat.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+// Regression guard for the silent production-deploy break of 2026-07-09.
+//
+// Upgrading `typescript` to ^7.0.2 passed every gate — `bun run test`, `tsc --noEmit`, and
+// `bun run build` were all green, and the PR's Vercel check reported "pass" because its preview
+// build was skipped by the Ignored Build Step. Production then failed to deploy for 11 hours:
+//
+//     Using TypeScript 7.0.2 (local user-provided)
+//     Error: Cannot read properties of undefined (reading 'readFile')
+//
+// TypeScript 7 is the native port. Its package exports the CLI but not the legacy programmatic
+// compiler API: `ts.sys`, `ts.createProgram` and friends are gone. `@vercel/node` compiles the
+// api/*.ts functions and reads tsconfig via `ts.sys.readFile`, so it throws before a single
+// function is built. Every published @vercel/node (checked through 5.8.22) still calls it.
+//
+// `tsc --noEmit` cannot catch this: the CLI works fine under TS7. Only the programmatic surface
+// is missing. So this test guards the surface @vercel/node actually depends on.
+//
+// When @vercel/node gains TS7 support, delete this file in the same PR that bumps typescript.
+
+describe('Vercel build compatibility', () => {
+  it('the installed typescript exposes the programmatic API @vercel/node compiles with', () => {
+    const ts = require('typescript');
+
+    expect(ts.sys, `typescript@${ts.version} does not export ts.sys — @vercel/node calls ts.sys.readFile and the production build will fail`).toBeDefined();
+    expect(typeof ts.sys.readFile).toBe('function');
+    // The other legacy entry points @vercel/node and ts-node reach for.
+    expect(typeof ts.createProgram).toBe('function');
+  });
+
+  it('package.json pins typescript to a major that still ships that API', () => {
+    const pkg = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf8'));
+    const range = pkg.devDependencies.typescript;
+    const major = Number(range.replace(/^[^\d]*/, '').split('.')[0]);
+    expect(
+      major,
+      `typescript ${range} — majors >= 7 drop ts.sys and break the Vercel Node builder`
+    ).toBeLessThan(7);
+  });
+});


### PR DESCRIPTION
## Production has not deployed for 11 hours

The last deploy to reach production was **v1.7.3** (`j3xzdvfi1`, 05:12Z). Everything merged since has failed to build. That includes **v1.7.4's Schedule fixes, which are not live.**

```
$ vercel ls --prod
  10m   ...gzq1fcxz2   ● Error    Production   7s     <- PR #225 (v1.7.4 schedule fixes)
  11h   ...4zq3tztsr   ● Error    Production   5s     <- PR #222 (TypeScript 6 → 7)
  11h   ...j3xzdvfi1   ● Ready    Production   21s    <- PR #224 (v1.7.3)  ← what's live
```

Both failures are identical, and both land immediately after the Astro build succeeds:

```
16:10:27 [build] Complete!
Stamped dist/index.html with home dateModified 2026-07-08
Using TypeScript 7.0.2 (local user-provided)
Error: Cannot read properties of undefined (reading 'readFile')
```

The last good build says `Using TypeScript 6.0.3`.

## Root cause

TypeScript 7 is the native (Go) port. Its npm package ships the CLI but **drops the legacy programmatic compiler API**:

```console
$ node -e "const ts=require('typescript'); console.log(ts.version, typeof ts.sys, typeof ts.createProgram)"
7.0.2 undefined undefined

$ node -e "const ts=require('typescript'); console.log(ts.version, typeof ts.sys.readFile)"
6.0.3 function
```

`@vercel/node` compiles the `api/*.ts` serverless functions and reads `tsconfig` through `ts.sys.readFile`. Under TS7 that's `undefined`, so it throws before building a single function.

There is no TS7-compatible `@vercel/node` today. I checked the newest published version:

```console
$ npm view @vercel/node version
5.8.22
$ npm pack @vercel/node@5.8.22 && grep -c 'sys\.readFile' package/dist/index.js
2
```

**Fix:** `typescript` back to `^6.0.3`.

## The part worth fixing properly

Nothing in CI could have caught this, and that's why it sat for 11 hours.

Under TypeScript 7, all three gates are green — the `tsc` CLI works fine, only the programmatic surface is missing:

| gate | under TS7 |
|---|---|
| `bun run test` | ✅ pass |
| `tsc --noEmit` | ✅ pass |
| `bun run build` | ✅ pass |
| PR's Vercel check | ✅ "pass" — *preview build skipped by the Ignored Build Step* |
| **production deploy** | ❌ **Error — wired to no GitHub check** |

So `main` happily accepted #222 and #225, both reported all-green, and neither shipped.

This PR adds `tests/vercel-build-compat.test.js`, which asserts the installed TypeScript still exposes the API `@vercel/node` actually compiles with, and that `package.json` pins a major that ships it. Verified in both directions:

```
# with typescript@7.0.2 installed
× the installed typescript exposes the programmatic API @vercel/node compiles with
  AssertionError: typescript@7.0.2 does not export ts.sys — @vercel/node calls
  ts.sys.readFile and the production build will fail
× package.json pins typescript to a major that still ships that API

# with typescript@6.0.3 installed
✓ 2 passed
```

## Verification

- `bun run test` — **1064 tests pass** (2 new)
- `bun run typecheck` — clean
- `bun run build` — clean, 43 pages
- Root cause reproduced locally (`ts.sys === undefined` on 7.0.2, `function` on 6.0.3) and confirmed against both failing Vercel build logs

## Follow-ups, not in this PR

1. **A failed production deploy should fail something visible.** Right now it's silent. Worth a `deployment_status` webhook → GitHub check, or a post-merge canary.
2. Restoring TS7 needs `@vercel/node` support. When it lands, bump `typescript` and delete `tests/vercel-build-compat.test.js` in the same PR.

Reverts the dependency change in #222. Nothing else from that PR is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)