### PR TITLE
feat(schedule): instrument gate-vs-runway times before fixing the delay measurement (v1.7.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.6] - 2026-07-09
+
+### Added
+- **Instrumentation for the taxi-vs-delay bug** (`docs/specs/irops-delay-measurement.md`). The board reports AeroDataBox's `runwayTime` (wheels-up) as the actual departure and compares it against `scheduledTime`, which is a scheduled *gate* time — so every delay the site reports silently includes taxi-out. Across 10,518 operated departures the median "delay" is **+24 min** with only **3.7%** at or before schedule, while the same days' arrivals skew **−18 min** with **73.9%** at or before schedule. That asymmetry is taxi-out and taxi-in, not operations.
+- The obvious fix — prefer `revisedTime` (gate) — is **not safe blind.** The provider sends `revisedTime` only "if any", so a naive swap could leave on-time flights taxi-inflated while delayed ones became gate-based: a mixed distribution worse than a uniformly wrong one. `schedule_snapshots` upserts by `cache_key` and keeps no intermediate states, so coverage cannot be recovered retroactively, and the one raw provider call that would settle it needs a credential this session declined to materialize.
+- Therefore: `_source.timeSource` now records which raw fields the provider actually sent (`hasGateDep`, `hasRunwayDep`, `hasGateArr`, `hasRunwayArr`), and `_source.gate` carries the gate timestamp for an already-operated leg. **No behaviour change** — `time.real.departure` is still `runwayTime || revisedTime`, pinned by a test. One hour of production traffic makes the coverage measurable, after which the fix is a one-line preference swap with evidence behind it.
+
 ## [1.7.5] - 2026-07-09
 
 ### Fixed

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -225,6 +225,23 @@ function normalizeFlight(flight: any, hub: string, dir: string) {
   const status = String(flight?.status || '');
   const departedLike = ['Departed', 'EnRoute', 'Approaching', 'Arrived', 'Diverted'].includes(status);
   const arrivedLike = ['Arrived', 'Diverted'].includes(status);
+  // INSTRUMENTATION ONLY — behaviour unchanged, see docs/specs/irops-delay-measurement.md.
+  //
+  // `runwayTime` is the actual RUNWAY time (wheels-up on departure, wheels-down on arrival);
+  // `revisedTime` is a revised GATE time, "if any". Preferring runwayTime and then comparing it
+  // against `scheduledTime` — a scheduled GATE time — mixes units, so every delay we report
+  // silently includes taxi. Measured over 10,518 operated departures: median "delay" +24 min with
+  // only 3.7% at/before schedule, while the same days' arrivals skew −18 min with 73.9% at/before
+  // schedule. That asymmetry is taxi-out/taxi-in, not operations.
+  //
+  // We cannot simply prefer revisedTime: it exists only when a schedule was revised, so a naive
+  // swap could leave on-time flights taxi-inflated while delayed ones become gate-based — a mixed
+  // distribution that is worse than a uniformly wrong one. `schedule_snapshots` upserts by
+  // cache_key and keeps no intermediate states, so coverage cannot be recovered retroactively.
+  // Record the raw availability and the gate timestamp so one hour of production traffic answers
+  // it. Delete this block in the PR that fixes the measurement.
+  const gateDep = departedLike ? revisedDep : null;
+  const gateArr = arrivedLike ? revisedArr : null;
   const realDep = departedLike ? (runwayDep || revisedDep) : null;
   const realArr = arrivedLike ? (runwayArr || revisedArr) : null;
   const estDep = !realDep ? (revisedDep || toUnixDateTime(departureMovement?.predictedTime)) : null;
@@ -270,6 +287,16 @@ function normalizeFlight(flight: any, hub: string, dir: string) {
         ...(arrivalMovement?.quality || []),
         ...(movement?.quality || []),
       ],
+      // See the INSTRUMENTATION ONLY note above. Measurement-only; nothing reads these yet.
+      // `gate.*` is revisedTime (gate) for an already-operated leg; `has*` records which raw
+      // fields the provider actually sent, so coverage is measurable instead of assumed.
+      timeSource: {
+        hasGateDep: revisedDep != null,
+        hasRunwayDep: runwayDep != null,
+        hasGateArr: revisedArr != null,
+        hasRunwayArr: runwayArr != null,
+      },
+      gate: { departure: gateDep, arrival: gateArr },
     },
   };
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/tests/aerodatabox-dq.test.js
+++ b/tests/aerodatabox-dq.test.js
@@ -287,3 +287,76 @@ describe('fetchViaAeroDataBox end-to-end board hygiene', () => {
     expect(ua2610.status.icon).toBe('yellow');
   });
 });
+
+// ── Gate-vs-runway time instrumentation ────────────────────────────────────────────────
+// See docs/specs/irops-delay-measurement.md. The board reports runwayTime (wheels-up) as the
+// actual departure and compares it against scheduledTime (a GATE time), so every delay silently
+// includes taxi-out: across 10,518 operated departures the median "delay" was +24 min with only
+// 3.7% at/before schedule, while the same days' arrivals skewed -18 min with 73.9% at/before
+// schedule. Preferring revisedTime is NOT a safe blind swap — the provider sends it only "if any",
+// so on-time flights could stay taxi-inflated while delayed ones became gate-based. These fields
+// record raw availability and the gate timestamp, changing nothing, so coverage can be measured.
+describe('gate-vs-runway time instrumentation', () => {
+  const nowSec = 1_700_000_000;
+  const iso = (offsetS) => new Date((nowSec + offsetS) * 1000).toISOString();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __resetAdbSpendForTests();
+    process.env.AERODATABOX_API_KEY = 'adb-test-key';
+    process.env.AERODATABOX_INTER_WINDOW_DELAY_MS = '0';
+  });
+  afterEach(() => {
+    delete process.env.AERODATABOX_API_KEY;
+    delete process.env.AERODATABOX_INTER_WINDOW_DELAY_MS;
+    __resetAdbSpendForTests();
+  });
+
+  async function board(departure, status = 'Departed') {
+    const departures = [{
+      number: 'UA 100', status, airline: { iata: 'UA', name: 'United Airlines' },
+      departure: { scheduledTime: { utc: iso(0) }, airport: { iata: 'ORD' }, ...departure },
+      arrival: { scheduledTime: { utc: iso(7200) }, airport: { iata: 'DEN', name: 'Denver' } },
+      aircraft: { model: 'A320', reg: 'N12345' },
+    }];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) =>
+      String(url).includes('aedbx/aerodatabox')
+        ? { ok: true, status: 200, json: async () => ({ departures }) }
+        : { ok: false, status: 403, text: async () => 'blocked', headers: { get: () => null } }
+    );
+    const result = await fetchViaAeroDataBox('ORD', 'departures', nowSec, 8000);
+    return result.flights[0];
+  }
+
+  it('records a runway time with no gate time', async () => {
+    const f = await board({ runwayTime: { utc: iso(1500) } });
+    expect(f._source.timeSource).toEqual({
+      hasGateDep: false, hasRunwayDep: true, hasGateArr: false, hasRunwayArr: false,
+    });
+    expect(f._source.gate.departure).toBeNull();
+  });
+
+  it('records the gate timestamp when the provider sends revisedTime', async () => {
+    // revisedTime = gate-out at +10 min; runwayTime = wheels-up at +30 min. The gap is taxi-out.
+    const f = await board({ revisedTime: { utc: iso(600) }, runwayTime: { utc: iso(1800) } });
+    expect(f._source.timeSource.hasGateDep).toBe(true);
+    expect(f._source.timeSource.hasRunwayDep).toBe(true);
+    expect(f._source.gate.departure).toBe(nowSec + 600);
+  });
+
+  it('does NOT change which timestamp becomes time.real.departure', async () => {
+    // The point of this change: instrument, do not fix. runwayTime must still win.
+    const f = await board({ revisedTime: { utc: iso(600) }, runwayTime: { utc: iso(1800) } });
+    expect(f.time.real.departure).toBe(nowSec + 1800);
+
+    const g = await board({ revisedTime: { utc: iso(600) } });
+    expect(g.time.real.departure).toBe(nowSec + 600); // unchanged fallback
+  });
+
+  it('leaves gate.departure null for a leg that has not operated', async () => {
+    const f = await board({ revisedTime: { utc: iso(600) } }, 'Scheduled');
+    expect(f.time.real.departure).toBeNull();
+    expect(f._source.gate.departure).toBeNull();
+    expect(f._source.timeSource.hasGateDep).toBe(true); // provider sent it; the leg just hasn't gone
+  });
+});


### PR DESCRIPTION
Phase 1 of #227, with the spec's own precondition honoured: **measure before changing.**

**No behaviour change.** `time.real.departure` is still `runwayTime || revisedTime`, and a test pins that.

## Why not just fix it

The spec says prefer `revisedTime` (gate) over `runwayTime` (wheels-up). Then I read the vendor docs:

> **runwayTime** — the actual time the aircraft left the runway
> **revisedTime** — the revised departure time, **if any**

That "if any" is the whole problem. If `revisedTime` exists only when a schedule was *revised*, then flipping the preference leaves on-time flights taxi-inflated while delayed flights become gate-based — a **mixed** distribution, worse than a uniformly wrong one. My own spec warned against exactly that.

I tried three ways to settle coverage without shipping anything:

1. **Stored snapshots** — `schedule_snapshots` upserts by `cache_key` and keeps no intermediate states, so a departed flight's pre-departure `estimated.departure` (which *is* `revisedTime`) is overwritten. Joining earlier to later snapshots returns **0 matched flights**.
2. **Quality flags** — departed rows carry `["Basic","Live","Basic","Live"]`, so live data is present. But `estimated.departure` appears on only **~26%** of pre-departure rows, which hints `revisedTime` is sparse rather than universal. A hint, not an answer.
3. **One raw provider call** — needs `AERODATABOX_API_KEY`, and `vercel env pull` dumps the *entire* production secret set (VAPID private key, Supabase service key) to disk. Correctly refused. Not worth it to read one value.

So: instrument, deploy, measure, then fix with evidence.

## What this adds

```ts
_source.timeSource = { hasGateDep, hasRunwayDep, hasGateArr, hasRunwayArr }
_source.gate       = { departure, arrival }   // revisedTime; operated legs only
```

Additive, nothing reads them. After one hour of production traffic, this query answers it:

```sql
select
  count(*) filter (where (f->'_source'->'timeSource'->>'hasGateDep')::bool)   as gate_available,
  count(*) filter (where (f->'_source'->'timeSource'->>'hasRunwayDep')::bool) as runway_available,
  count(*) as departed_rows
from schedule_snapshots s, jsonb_array_elements(s.payload->'flights') f
where s.direction='departures'
  and nullif(f->'time'->'real'->>'departure','') is not null;
```

If `gate_available / departed_rows` is high, the fix is a one-line swap. If it's low, we need a per-hub taxi baseline instead — and `_source.gate` lets us *derive* that baseline directly, since `runwayTime − revisedTime` is the taxi-out for every flight that has both.

## Evidence recap

| direction | n | median | at/before schedule |
|---|---|---|---|
| departures | 10,518 | **+24 min** | **3.7%** |
| arrivals | 10,490 | **−18 min** | **73.9%** |

Wheels-up is ~20 min after pushback; wheels-down ~18 min before the gate. Gate-to-gate data would be roughly symmetric.

## Verification

- `bun run test` — 1068 pass (4 new) · `bun run typecheck` clean · `bun run build` clean
- The three descriptive tests **fail without the source change** (verified by stashing only `api/_schedule-aerodatabox.ts`)
- The behaviour-invariance test passes either way, as it must — that's the point

Deleting this instrumentation is an explicit TODO in the PR that fixes the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)