### PR TITLE
fix(schedule): measure delay at the gate, not the runway (v1.7.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.7] - 2026-07-09
+
+### Fixed
+- **The Blue Board was measuring taxi time, not delay.** `time.real.departure` was AeroDataBox's `runwayTime` — the actual *runway* time, wheels-up on departure and wheels-down on arrival — compared against `scheduledTime`, which is a scheduled **gate** time. Every reported delay silently carried taxi-out, and every arrival was timestamped before the aircraft reached the gate. Over 10,518 operated departures the median "delay" was **+24 min** with only **3.7%** at or before schedule, while the same days' arrivals skewed **−18 min** with **73.9%** at or before schedule. Departures late by a taxi, arrivals early by a taxi: operations cannot produce that asymmetry. Now `revisedTime` (the gate time) is preferred, falling back to `runwayTime` only when the provider omits it.
+- Verified before changing anything. v1.7.6 shipped instrumentation only, and one hour of production traffic (521 operated legs, live EWR + SFO boards) settled it: `revisedTime` coverage is **100%** (the vendor's "if any" concern was unfounded), and the gate time is **never after** the runway time — 0 of 255 departures — so this swap can only shrink a reported delay, never grow one.
+- Measured effect on that sample: departures at or before schedule **2.4% → 26.3%**; `delayed30` **85 → 53** (−38%); `delayed60` 20 → 18. Arrivals now land at the gate rather than on the runway.
+- **Honest limit, and a correction to our own spec.** For **64% of departures the provider sets `revisedTime == runwayTime`**, so the fix corrects only the other 36% — where the median gap is 26 min (p90 39 min), which is exactly taxi. The gate-based median departure delay is **+15 min, not ~0**: EWR and SFO at midday are genuinely late. The earlier spec claimed the delay layer was essentially all taxi. It is not, and the instrumentation is what caught the overstatement. `_source.timeSource.gateDistinctDep` / `gateDistinctArr` now mark the rows where `time.real.*` is honestly gate-based, so consumers can tell the difference instead of assuming.
+- Downstream, this lowers the IROPS `score`, `delayed30`/`delayed60` and `worstDelays`, and raises hub OTP. The `SIGNIFICANT DISRUPTION` banner (`score >= 15`) is **not** fixed by this alone — that is Phase 2, and it needs a week of gate-based data before thresholds are re-derived. Do not hand-pick new cutoffs.
+
 ## [1.7.6] - 2026-07-09
 
 ### Added

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -225,25 +225,31 @@ function normalizeFlight(flight: any, hub: string, dir: string) {
   const status = String(flight?.status || '');
   const departedLike = ['Departed', 'EnRoute', 'Approaching', 'Arrived', 'Diverted'].includes(status);
   const arrivedLike = ['Arrived', 'Diverted'].includes(status);
-  // INSTRUMENTATION ONLY — behaviour unchanged, see docs/specs/irops-delay-measurement.md.
+  // Measure delay at the GATE, not the runway. See docs/specs/irops-delay-measurement.md.
   //
-  // `runwayTime` is the actual RUNWAY time (wheels-up on departure, wheels-down on arrival);
-  // `revisedTime` is a revised GATE time, "if any". Preferring runwayTime and then comparing it
-  // against `scheduledTime` — a scheduled GATE time — mixes units, so every delay we report
-  // silently includes taxi. Measured over 10,518 operated departures: median "delay" +24 min with
-  // only 3.7% at/before schedule, while the same days' arrivals skew −18 min with 73.9% at/before
-  // schedule. That asymmetry is taxi-out/taxi-in, not operations.
+  // `scheduledTime` is a scheduled GATE time. `runwayTime` is the actual runway time — wheels-up on
+  // departure, wheels-down on arrival. Comparing the two mixes units, so a delay computed from
+  // runwayTime silently carries taxi-out, and an arrival computed from it lands before the aircraft
+  // reaches the gate. `revisedTime` is the gate time. Prefer it; fall back to runwayTime only when
+  // the provider omits it.
   //
-  // We cannot simply prefer revisedTime: it exists only when a schedule was revised, so a naive
-  // swap could leave on-time flights taxi-inflated while delayed ones become gate-based — a mixed
-  // distribution that is worse than a uniformly wrong one. `schedule_snapshots` upserts by
-  // cache_key and keeps no intermediate states, so coverage cannot be recovered retroactively.
-  // Record the raw availability and the gate timestamp so one hour of production traffic answers
-  // it. Delete this block in the PR that fixes the measurement.
-  const gateDep = departedLike ? revisedDep : null;
-  const gateArr = arrivedLike ? revisedArr : null;
-  const realDep = departedLike ? (runwayDep || revisedDep) : null;
-  const realArr = arrivedLike ? (runwayArr || revisedArr) : null;
+  // Measured on 521 operated legs from live EWR + SFO boards (2026-07-09), after shipping
+  // instrumentation rather than guessing:
+  //   - revisedTime coverage is 100% — it is not the sparse "if any" field the vendor docs imply
+  //   - the gate time is NEVER after the runway time (0 of 255 departures), so this swap can only
+  //     shrink a reported delay, never grow one. That is the safety property that makes it shippable
+  //   - where the two differ (92 of 255 departures) the median gap is 26 min, p90 39 min — taxi
+  //   - departures at/before schedule: 2.4% by runwayTime → 26.3% by gate. delayed30: 85 → 53
+  //   - arrivals: runwayTime put 78.2% at/before schedule (touchdown), gate puts 72.2% (the gate)
+  //
+  // Honest limit: for 64% of departures the provider sets revisedTime == runwayTime, giving us no
+  // distinct gate report. Those rows stay taxi-inflated and we cannot do better with this feed.
+  // `_source.timeSource.gateDistinct` marks the rows where we genuinely have a gate time, so
+  // consumers can tell the difference instead of assuming.
+  const realDep = departedLike ? (revisedDep || runwayDep) : null;
+  const realArr = arrivedLike ? (revisedArr || runwayArr) : null;
+  const gateDistinctDep = departedLike && revisedDep != null && revisedDep !== runwayDep;
+  const gateDistinctArr = arrivedLike && revisedArr != null && revisedArr !== runwayArr;
   const estDep = !realDep ? (revisedDep || toUnixDateTime(departureMovement?.predictedTime)) : null;
   const estArr = !realArr ? (revisedArr || toUnixDateTime(arrivalMovement?.predictedTime)) : null;
 
@@ -287,16 +293,18 @@ function normalizeFlight(flight: any, hub: string, dir: string) {
         ...(arrivalMovement?.quality || []),
         ...(movement?.quality || []),
       ],
-      // See the INSTRUMENTATION ONLY note above. Measurement-only; nothing reads these yet.
-      // `gate.*` is revisedTime (gate) for an already-operated leg; `has*` records which raw
-      // fields the provider actually sent, so coverage is measurable instead of assumed.
+      // `gateDistinct*` is true when the provider gave a gate time that differs from the runway
+      // time — i.e. when time.real.* is genuinely gate-based rather than a taxi-inflated runway
+      // time the provider happened to copy into revisedTime. 36% of departures on the measured
+      // sample. Consumers that care about honest delay stats should prefer these rows.
       timeSource: {
+        gateDistinctDep,
+        gateDistinctArr,
         hasGateDep: revisedDep != null,
         hasRunwayDep: runwayDep != null,
         hasGateArr: revisedArr != null,
         hasRunwayArr: runwayArr != null,
       },
-      gate: { departure: gateDep, arrival: gateArr },
     },
   };
 }

--- a/docs/specs/irops-delay-measurement.md
+++ b/docs/specs/irops-delay-measurement.md
@@ -1,0 +1,106 @@
+# The Blue Board measures delay at the gate, not the runway
+
+**Status:** fixed (Phase 1) · **Date:** 2026-07-09
+
+## What was wrong
+
+`api/_schedule-aerodatabox.ts` reported AeroDataBox's `runwayTime` as the actual departure:
+
+```ts
+const realDep = departedLike ? (runwayDep || revisedDep) : null;   // runwayTime = wheels-up
+const realArr = arrivedLike ? (runwayArr || revisedArr) : null;    // runwayTime = wheels-down
+```
+
+`runwayTime` is the actual **runway** time. It was compared against `scheduledTime`, which is a
+scheduled **gate** time. Mixing those units meant every reported delay silently carried taxi-out,
+and every arrival was timestamped before the aircraft reached the gate. DOT on-time performance —
+the number travellers have internalised — is measured at the gate.
+
+The signature, over 10,518 operated departures and 10,490 arrivals (2026-06-30 → 07-02):
+
+| direction | median | at/before schedule |
+|---|---|---|
+| departures | +24 min | 3.7% |
+| arrivals | −18 min | 73.9% |
+
+Departures late by a taxi, arrivals early by a taxi. Operations cannot produce that asymmetry.
+
+## How it was verified before changing anything
+
+The obvious fix — prefer `revisedTime` — was **not** safe on the evidence available. The vendor
+documents `revisedTime` as "the revised departure time, *if any*". If it existed only for flights
+whose schedule had been revised, swapping the preference would have left on-time flights
+taxi-inflated while delayed ones became gate-based: a mixed distribution, worse than a uniformly
+wrong one.
+
+`schedule_snapshots` upserts by `cache_key` and keeps no intermediate states, so coverage could not
+be recovered retroactively, and the one raw provider call that would settle it needs a credential
+dump. So v1.7.6 shipped **instrumentation only** — `_source.timeSource` and `_source.gate`, with a
+test pinning that behaviour did not change — and one hour of production traffic answered it.
+
+## What the instrumentation showed (521 operated legs, live EWR + SFO, 2026-07-09)
+
+| | departures (n=255) | arrivals (n=266) |
+|---|---|---|
+| gate time missing | **0** | **0** |
+| `revisedTime == runwayTime` | **63.9%** | 4.9% |
+| runway − gate (p50) | 0 min | −3 min |
+| **gate time after runway time** | **0 rows** | — |
+| gate vs scheduled (p50) | **+15 min** | −12 min |
+| runway vs scheduled (p50) | +24 min | −17 min |
+| at/before schedule — gate | **26.3%** | 72.2% |
+| at/before schedule — runway | 2.4% | 78.2% |
+
+Three conclusions, two of which corrected the original spec:
+
+1. **`revisedTime` coverage is 100%.** The "if any" concern was unfounded.
+2. **The gate time is never after the runway time** — 0 of 255 departures. Preferring it can only
+   shrink a reported delay, never grow one. That safety property is what made the fix shippable.
+3. **The original spec overstated the effect.** Where the two timestamps differ (92 of 255
+   departures, 36%) the median gap is 26 min and p90 is 39 min — that is taxi, as predicted. But for
+   **64% of departures the provider sets `revisedTime == runwayTime`**, so the fix corrects only a
+   third of flights. Gate-based median departure delay is **+15 min, not ~0**: EWR and SFO at midday
+   are genuinely late. The delay layer was not *entirely* taxi.
+
+Measured effect on the sample: `delayed30` **85 → 53** (−38%), `delayed60` 20 → 18.
+
+## The fix (shipped)
+
+```ts
+const realDep = departedLike ? (revisedDep || runwayDep) : null;
+const realArr = arrivedLike ? (revisedArr || runwayArr) : null;
+```
+
+Plus `_source.timeSource.gateDistinctDep` / `gateDistinctArr`, true when the provider gave a gate
+time that genuinely differs from the runway time. Those are the rows where `time.real.*` is honestly
+gate-based. The other 64% remain taxi-inflated, and we cannot do better with this feed — but now we
+can *tell*, instead of assuming.
+
+## Still open
+
+**Phase 2 — thresholds.** `score >= 15` renders `SIGNIFICANT DISRUPTION`. The index scored ≥ 51 on
+26 of 26 days with real data (median ~62); `NORMAL` (<5) and `MINOR` (5–15) were unreachable. Phase 1
+cuts the numerator materially but will not, on its own, make the label informative. Re-derive the
+cutoffs from percentiles of the corrected trailing-90-day distribution — `schedule_snapshots` holds
+99 days, so the backfill is a query, not a pipeline — so that the label means *"today is worse than
+most days"* and self-corrects as United's baseline shifts.
+
+Do **not** hand-pick new cutoffs. Wait for a week of gate-based data first.
+
+**Phase 3 — `canceled_uncertain` weighting.** AeroDataBox's *"suspects a cancellation, has not
+confirmed it"*. The UI honestly renders it "Likely Canceled"; the index counts it at ×3, identical to
+a confirmed cancellation. The mapping changed around 2026-07-03: before, these arrived as hard
+`canceled` (~3.7% of flights); after, as `canceled_uncertain` (~5–7%). Understand the rate change
+before touching the weight.
+
+**Consumers that should prefer `gateDistinct` rows.** Hub OTP, `delayed30`/`delayed60`, and
+`worstDelays` still mix gate-based and runway-based rows. The project already has this pattern for
+`_source.liveFeedFallback` and `_source.scheduleTimeDerivedFromActual`; the same exclusion belongs
+here once a week of data shows how much it moves the numbers.
+
+## Refuted along the way
+
+The "ratcheting denominator" hypothesis — that the score climbs because it divides by the whole
+day's schedule. A due-flights denominator reads 100.0 at n=3 flights and goes SIGNIFICANT the
+previous evening; a 3-hour rolling window reads 65 mid-evening. Neither fixes the label, because the
+numerator was inflated. Recorded so nobody re-derives it.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/tests/aerodatabox-dq.test.js
+++ b/tests/aerodatabox-dq.test.js
@@ -288,15 +288,16 @@ describe('fetchViaAeroDataBox end-to-end board hygiene', () => {
   });
 });
 
-// ── Gate-vs-runway time instrumentation ────────────────────────────────────────────────
-// See docs/specs/irops-delay-measurement.md. The board reports runwayTime (wheels-up) as the
-// actual departure and compares it against scheduledTime (a GATE time), so every delay silently
-// includes taxi-out: across 10,518 operated departures the median "delay" was +24 min with only
-// 3.7% at/before schedule, while the same days' arrivals skewed -18 min with 73.9% at/before
-// schedule. Preferring revisedTime is NOT a safe blind swap — the provider sends it only "if any",
-// so on-time flights could stay taxi-inflated while delayed ones became gate-based. These fields
-// record raw availability and the gate timestamp, changing nothing, so coverage can be measured.
-describe('gate-vs-runway time instrumentation', () => {
+// ── Delay is measured at the GATE, not the runway ───────────────────────────────────────
+// docs/specs/irops-delay-measurement.md. `scheduledTime` is a gate time; `runwayTime` is wheels-up
+// (departure) or wheels-down (arrival). Comparing them mixed units, so every reported delay carried
+// taxi-out and every arrival landed before reaching the gate. `revisedTime` is the gate time.
+//
+// Measured on 521 operated legs from live EWR + SFO boards before this change: revisedTime coverage
+// is 100%; the gate time is NEVER after the runway time (0 of 255 departures), so preferring it can
+// only shrink a reported delay, never grow one; where they differ (36% of departures) the median gap
+// is 26 min. Departures at/before schedule went 2.4% -> 26.3%; delayed30 went 85 -> 53.
+describe('gate-based delay measurement', () => {
   const nowSec = 1_700_000_000;
   const iso = (offsetS) => new Date((nowSec + offsetS) * 1000).toISOString();
 
@@ -312,11 +313,11 @@ describe('gate-vs-runway time instrumentation', () => {
     __resetAdbSpendForTests();
   });
 
-  async function board(departure, status = 'Departed') {
+  async function board(departure, arrival = {}, status = 'Departed') {
     const departures = [{
       number: 'UA 100', status, airline: { iata: 'UA', name: 'United Airlines' },
       departure: { scheduledTime: { utc: iso(0) }, airport: { iata: 'ORD' }, ...departure },
-      arrival: { scheduledTime: { utc: iso(7200) }, airport: { iata: 'DEN', name: 'Denver' } },
+      arrival: { scheduledTime: { utc: iso(7200) }, airport: { iata: 'DEN', name: 'Denver' }, ...arrival },
       aircraft: { model: 'A320', reg: 'N12345' },
     }];
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) =>
@@ -328,35 +329,48 @@ describe('gate-vs-runway time instrumentation', () => {
     return result.flights[0];
   }
 
-  it('records a runway time with no gate time', async () => {
+  it('reports the GATE departure, not wheels-up', async () => {
+    // Pushback +10 min (a real 10-minute delay); wheels-up +36 min (10 delay + 26 taxi).
+    const f = await board({ revisedTime: { utc: iso(600) }, runwayTime: { utc: iso(2160) } });
+    expect(f.time.real.departure).toBe(nowSec + 600);
+    expect(f._source.timeSource.gateDistinctDep).toBe(true);
+  });
+
+  it('an on-time pushback is no longer reported as a 26-minute delay', async () => {
+    // Departed exactly on schedule; 26 min taxi. Old code called this +26 min late.
+    const f = await board({ revisedTime: { utc: iso(0) }, runwayTime: { utc: iso(1560) } });
+    expect(f.time.real.departure - f.time.scheduled.departure).toBe(0);
+  });
+
+  it('falls back to the runway time when the provider omits the gate time', async () => {
     const f = await board({ runwayTime: { utc: iso(1500) } });
-    expect(f._source.timeSource).toEqual({
-      hasGateDep: false, hasRunwayDep: true, hasGateArr: false, hasRunwayArr: false,
-    });
-    expect(f._source.gate.departure).toBeNull();
+    expect(f.time.real.departure).toBe(nowSec + 1500);
+    expect(f._source.timeSource.gateDistinctDep).toBe(false);
+    expect(f._source.timeSource.hasGateDep).toBe(false);
   });
 
-  it('records the gate timestamp when the provider sends revisedTime', async () => {
-    // revisedTime = gate-out at +10 min; runwayTime = wheels-up at +30 min. The gap is taxi-out.
-    const f = await board({ revisedTime: { utc: iso(600) }, runwayTime: { utc: iso(1800) } });
+  it('marks the row as not-gate-distinct when the provider copies runwayTime into revisedTime', async () => {
+    // 64% of real departures look like this. The delay stays taxi-inflated; say so honestly.
+    const f = await board({ revisedTime: { utc: iso(1500) }, runwayTime: { utc: iso(1500) } });
+    expect(f.time.real.departure).toBe(nowSec + 1500);
+    expect(f._source.timeSource.gateDistinctDep).toBe(false);
     expect(f._source.timeSource.hasGateDep).toBe(true);
-    expect(f._source.timeSource.hasRunwayDep).toBe(true);
-    expect(f._source.gate.departure).toBe(nowSec + 600);
   });
 
-  it('does NOT change which timestamp becomes time.real.departure', async () => {
-    // The point of this change: instrument, do not fix. runwayTime must still win.
-    const f = await board({ revisedTime: { utc: iso(600) }, runwayTime: { utc: iso(1800) } });
-    expect(f.time.real.departure).toBe(nowSec + 1800);
-
-    const g = await board({ revisedTime: { utc: iso(600) } });
-    expect(g.time.real.departure).toBe(nowSec + 600); // unchanged fallback
+  it('reports the GATE arrival, not wheels-down', async () => {
+    // Touchdown at +7200; on-blocks 18 min later. Old code called this an 18-min-early arrival.
+    const f = await board(
+      { runwayTime: { utc: iso(1500) } },
+      { runwayTime: { utc: iso(7200) }, revisedTime: { utc: iso(8280) } },
+      'Arrived'
+    );
+    expect(f.time.real.arrival).toBe(nowSec + 8280);
+    expect(f._source.timeSource.gateDistinctArr).toBe(true);
   });
 
-  it('leaves gate.departure null for a leg that has not operated', async () => {
-    const f = await board({ revisedTime: { utc: iso(600) } }, 'Scheduled');
+  it('leaves a not-yet-operated leg alone', async () => {
+    const f = await board({ revisedTime: { utc: iso(600) } }, {}, 'Scheduled');
     expect(f.time.real.departure).toBeNull();
-    expect(f._source.gate.departure).toBeNull();
-    expect(f._source.timeSource.hasGateDep).toBe(true); // provider sent it; the leg just hasn't gone
+    expect(f._source.timeSource.gateDistinctDep).toBe(false);
   });
 });


### PR DESCRIPTION
The instrumentation from #228 came back. Here is the fix — and a correction to my own spec.

**Supersedes #227** (that spec is included here, updated with the measured results). Close #227 when this lands.

## The bug

```ts
const realDep = departedLike ? (runwayDep || revisedDep) : null;   // runwayTime = wheels-up
```

`runwayTime` is the actual **runway** time. It was compared against `scheduledTime`, a scheduled **gate** time. So every delay the site reported carried taxi-out, and every arrival was timestamped before the aircraft reached the gate.

Over 10,518 operated departures: median "delay" **+24 min**, only **3.7%** at or before schedule. The same days' arrivals: **−18 min**, **73.9%** at or before schedule. Departures late by a taxi, arrivals early by a taxi.

## What the instrumentation actually said

521 operated legs, live EWR + SFO boards, written by v1.7.6 at 18:01 UTC:

| | departures (n=255) | arrivals (n=266) |
|---|---|---|
| gate time missing | **0** | **0** |
| `revisedTime == runwayTime` | **63.9%** | 4.9% |
| **gate time after runway time** | **0 rows** | — |
| gate vs scheduled (p50) | **+15 min** | −12 min |
| runway vs scheduled (p50) | +24 min | −17 min |
| at/before schedule — gate | **26.3%** | 72.2% |
| at/before schedule — runway | 2.4% | 78.2% |

Three findings, two of which **corrected the spec**:

1. **`revisedTime` coverage is 100%.** The vendor's "if any" wording had me worried it was sparse. It isn't. That fear is what made me instrument instead of shipping blind — worth it anyway, because of #3.

2. **The gate time is never after the runway time** — 0 of 255 departures. So preferring it can only *shrink* a reported delay, never grow one. That's the safety property that makes this shippable without a staged rollout.

3. **I overstated the bug.** Where the timestamps differ (92 of 255 departures, 36%) the median gap is **26 min**, p90 39 — exactly taxi, as predicted. But for **64% of departures the provider sets `revisedTime == runwayTime`**, so this corrects only a third of flights. The gate-based median departure delay is **+15 min, not ~0**. EWR and SFO at midday are genuinely late. The delay layer was not *entirely* taxi, and my spec said it was.

Measured effect: `delayed30` **85 → 53** (−38%), `delayed60` 20 → 18, departures at/before schedule **2.4% → 26.3%**.

## The fix

```ts
const realDep = departedLike ? (revisedDep || runwayDep) : null;
const realArr = arrivedLike ? (revisedArr || runwayArr) : null;
```

Plus `_source.timeSource.gateDistinctDep` / `gateDistinctArr` — true when the provider gave a gate time that genuinely differs from the runway time. Those are the rows where `time.real.*` is honestly gate-based. The other 64% stay taxi-inflated and we cannot do better with this feed, but now we can **tell**, instead of assuming.

## What this does and does not fix

**Does:** lowers IROPS `score`, `delayed30`/`delayed60` and `worstDelays`; raises hub OTP; stops the Schedule board telling a traveller their on-time flight departed `+24m` late; stops arrivals rendering green as "landed early" before reaching the gate.

**Does not:** fix the `SIGNIFICANT DISRUPTION` banner. `score >= 15`, and the index scored ≥51 on 26 of 26 days with real data. Phase 1 cuts the numerator materially but not enough. **Phase 2 needs a week of gate-based data before thresholds are re-derived from percentiles.** Do not hand-pick new cutoffs — that was the mistake this whole investigation started by avoiding.

## Verification

- `bun run test` — **1070 pass** (6 new) · `bun run typecheck` clean · `bun run build` clean
- All 6 new tests confirmed to **fail against the old behaviour** (verified by stashing only `api/_schedule-aerodatabox.ts`)
- No other test broke, which is itself informative: nothing in the suite pinned the runway-based semantics

Two tests worth reading: *"an on-time pushback is no longer reported as a 26-minute delay"* and *"marks the row as not-gate-distinct when the provider copies runwayTime into revisedTime"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)