### PR TITLE
fix(schedule): derive aircraft.model.code from AeroDataBox free text — revives the equipment-swap banner (v1.7.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.8] - 2026-07-09
+
+### Fixed
+- **The equipment-swap banner never fired, the Aircraft column was all `—`, and the type filter matched nothing — because the aircraft code was hardcoded empty.** `api/_schedule-aerodatabox.ts` built every schedule row with `model.code: ''`. AeroDataBox only ships a free-text model name and *never* a code — 0 of 647 live rows carried one, 610 carried text like `Airbus A321 NEO`, `Boeing 737 MAX 9`, `Boeing 787-9`. The dashboard keys three features off `aircraft.model.code`: the `⚠️ N equipment swaps detected` detector (`detectEquipmentSwaps` gates on `if (fnum && acCode)`, so its baseline map stayed empty and no swap could ever be recorded), the Schedule table's Aircraft column (rendered `—` on every row), and the aircraft-type filter (could never match). The adapter now derives an ICAO-style designator from the model text via a new pure, exported `modelTextToIcaoCode()`, in the same vocabulary the client's `ICAO_TO_FLEET_TYPE` map already speaks (A319/A320/A21N, B737/B738/B739, B38M/B39M, B752/B753, B763/B764, B772/B77E/B77W, B788/B789/B78X) plus the United Express regionals the boards carry (E170/E175, CRJ2/CRJ7/CRJ9).
+- **Honest by design: ambiguous text maps to nothing, never a guess.** A bare `Boeing 737` with no `-700`/`-800`/`-900`/`MAX` suffix is ambiguous across four codes, so it returns `''` — likewise bare `Boeing 787`, `Boeing 777`, `Airbus A321` (ceo vs neo), `Bombardier CRJ`, and any unrecognised string. An empty code is honest: the swap detector skips the row and the column shows `—`. A *guessed* variant would be worse than the dead banner it revives — two polls that resolved the same physical jet to different guessed codes would mint a **false** swap alert. AeroDataBox's free text also can't distinguish a 777-200 from a 777-200ER unless it spells out `ER`, so plain `Boeing 777-200` collapses to the generic `B772` (consistent, so it can't fabricate a swap; it only loses the ER split for fleet-stats display).
+- User-visible effect: the equipment-swap banner can now actually fire when a flight's aircraft type changes between polls, the Aircraft column shows real type codes (with the full model name beneath), and the aircraft-type filter works. Rows the provider left genuinely ambiguous still read `—`, as they should. `time.*` and `_source.timeSource` (the v1.7.7 gate-vs-runway fix) are untouched.
+
 ## [1.7.7] - 2026-07-09
 
 ### Fixed

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -179,6 +179,91 @@ function isUnitedFlight(flight: any): boolean {
   );
 }
 
+/**
+ * Derive an ICAO-style type designator from AeroDataBox's free-text aircraft model.
+ *
+ * AeroDataBox ships only a human-readable model name ("Airbus A321 NEO", "Boeing 737 MAX 9")
+ * and NEVER a code — 0 of 647 rows on the live board carried one, 610 carried text. The
+ * dashboard keys three features off `aircraft.model.code`: the equipment-swap detector
+ * (detectEquipmentSwaps), the Aircraft column, and the aircraft-type filter
+ * (populateAircraftFilter). With the code hardcoded to '' all three were structurally dead.
+ * This maps the text into the client's ICAO_TO_FLEET_TYPE vocabulary (src/dashboard/main.js):
+ * A319/A320/A21N, B737/B738/B739, B38M/B39M, B752/B753, B763/B764, B772/B77E/B77W,
+ * B788/B789/B78X, plus the United Express regional designators the boards also carry
+ * (E170/E175, CRJ2/CRJ7/CRJ9).
+ *
+ * HONESTY OVER COMPLETENESS: any text that does not resolve to a SINGLE variant returns ''.
+ * A bare "Boeing 737" (no -700/-800/-900/MAX suffix) is ambiguous across four codes, so it
+ * maps to nothing — likewise bare "Boeing 787" / "Boeing 777", "Airbus A321" (ceo vs neo),
+ * "Bombardier CRJ", and any unrecognised string. An empty code is honest: the swap detector
+ * skips the row and the Aircraft column shows '—'. A GUESSED variant would be worse than the
+ * dead banner it revives — two polls that resolved the same physical jet to different guessed
+ * codes would mint a FALSE "equipment swap detected" alert. Never guess a variant.
+ *
+ * Note on 777-200: AeroDataBox free text cannot distinguish a 777-200 from a 777-200ER unless
+ * it spells out "ER", so plain "Boeing 777-200" maps to the generic B772. This is consistent
+ * (all -200s without an ER marker collapse to one code) so it cannot fabricate a swap; it only
+ * loses the ER distinction for getTypicalFleetStats, a display nicety, not a correctness issue.
+ */
+export function modelTextToIcaoCode(text: string): string {
+  const t = String(text || '').toUpperCase().replace(/\s+/g, ' ').trim();
+  if (!t) return '';
+
+  // ── Airbus ──
+  if (t.includes('A319')) return 'A319';
+  if (t.includes('A320')) return 'A320';
+  if (t.includes('A321')) return /NEO/.test(t) ? 'A21N' : ''; // bare A321 = ceo/neo ambiguous
+
+  // ── Boeing 737 (check MAX + numbered variants; bare "737" is ambiguous) ──
+  if (t.includes('737')) {
+    if (/MAX ?8/.test(t)) return 'B38M';
+    if (/MAX ?9/.test(t)) return 'B39M';
+    if (/737-?700/.test(t)) return 'B737';
+    if (/737-?800/.test(t)) return 'B738';
+    if (/737-?900/.test(t)) return 'B739';
+    return ''; // bare "Boeing 737" — could be -700/-800/-900, never guess
+  }
+
+  // ── Boeing 757 / 767 ──
+  if (/757-?200/.test(t)) return 'B752';
+  if (/757-?300/.test(t)) return 'B753';
+  if (/767-?300/.test(t)) return 'B763';
+  if (/767-?400/.test(t)) return 'B764';
+
+  // ── Boeing 777 (check -300 and -200ER before plain -200) ──
+  if (t.includes('777')) {
+    if (/777-?300/.test(t)) return 'B77W'; // United 777-300 is 777-300ER only
+    if (/777-?200ER/.test(t)) return 'B77E';
+    if (/777-?200/.test(t)) return 'B772';
+    return ''; // bare "Boeing 777"
+  }
+
+  // ── Boeing 787 (check -10 before -1x/-8/-9) ──
+  if (t.includes('787')) {
+    if (/787-?10/.test(t)) return 'B78X';
+    if (/787-?9/.test(t)) return 'B789';
+    if (/787-?8/.test(t)) return 'B788';
+    return ''; // bare "Boeing 787"
+  }
+
+  // ── Embraer (United Express) ──
+  if (t.includes('EMBRAER') || /\bE-?1[0-9][0-9]\b/.test(t)) {
+    if (/175|E-?175|E-?75/.test(t)) return 'E175';
+    if (/170|E-?170|E-?70/.test(t)) return 'E170';
+    return '';
+  }
+
+  // ── Bombardier CRJ (CRJ-550 is an ICAO CRJ7 airframe) ──
+  if (t.includes('CRJ') || t.includes('BOMBARDIER') || t.includes('CANADAIR')) {
+    if (/CRJ ?-?900/.test(t)) return 'CRJ9';
+    if (/CRJ ?-?(550|700)/.test(t)) return 'CRJ7';
+    if (/CRJ ?-?200/.test(t)) return 'CRJ2';
+    return ''; // bare "Bombardier CRJ" — 200/550/700/900 all possible
+  }
+
+  return '';
+}
+
 function normalizeFlight(flight: any, hub: string, dir: string) {
   if (!isUnitedFlight(flight)) return null;
 
@@ -283,7 +368,7 @@ function normalizeFlight(flight: any, hub: string, dir: string) {
       },
     },
     aircraft: {
-      model: { code: '', text: flight?.aircraft?.model || '' },
+      model: { code: modelTextToIcaoCode(flight?.aircraft?.model || ''), text: flight?.aircraft?.model || '' },
       registration: validateRegistration(flight?.aircraft?.reg) || '',
     },
     _source: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/tests/aerodatabox-dq.test.js
+++ b/tests/aerodatabox-dq.test.js
@@ -7,6 +7,7 @@ import {
   dedupeBoardFlights,
   validateRegistration,
   fetchViaAeroDataBox,
+  modelTextToIcaoCode,
 } from '../api/_schedule-aerodatabox.js';
 import { __resetAdbSpendForTests } from '../api/_cost-state.js';
 
@@ -372,5 +373,137 @@ describe('gate-based delay measurement', () => {
     const f = await board({ revisedTime: { utc: iso(600) } }, {}, 'Scheduled');
     expect(f.time.real.departure).toBeNull();
     expect(f._source.timeSource.gateDistinctDep).toBe(false);
+  });
+});
+
+// ── Aircraft model.code is derived from AeroDataBox's free-text model (#8) ────────────────────
+// AeroDataBox ships only a human-readable model name and never a code (0 of 647 live rows had
+// one). The dashboard keys three features off aircraft.model.code — the equipment-swap detector,
+// the Aircraft column, and the type filter — so with the code hardcoded to '' all three were
+// structurally dead. modelTextToIcaoCode() fills it, in the client's ICAO_TO_FLEET_TYPE
+// vocabulary. Ambiguous/unknown text must return '' (never a guessed variant: a wrong code mints
+// a FALSE swap alert, which is worse than the dead banner it revives).
+describe('modelTextToIcaoCode — free-text model → ICAO code', () => {
+  it('maps each live mainline/regional model to its client-vocabulary code', () => {
+    const cases = [
+      ['Airbus A319', 'A319'],
+      ['Airbus A320', 'A320'],
+      ['Airbus A321 NEO', 'A21N'],
+      ['Boeing 737-700', 'B737'],
+      ['Boeing 737-800', 'B738'],
+      ['Boeing 737-900', 'B739'],
+      ['Boeing 737 MAX 8', 'B38M'],
+      ['Boeing 737 MAX 9', 'B39M'],
+      ['Boeing 757-200', 'B752'],
+      ['Boeing 757-300', 'B753'],
+      ['Boeing 767-300', 'B763'],
+      ['Boeing 767-400', 'B764'],
+      ['Boeing 777-200', 'B772'],
+      ['Boeing 777-200ER', 'B77E'],
+      ['Boeing 777-300ER', 'B77W'],
+      ['Boeing 787-8', 'B788'],
+      ['Boeing 787-9', 'B789'],
+      ['Boeing 787-10', 'B78X'],
+      ['Embraer 175', 'E175'],
+      ['Embraer 170', 'E170'],
+      ['Bombardier CRJ 200', 'CRJ2'],
+      ['Bombardier CRJ 700', 'CRJ7'],
+      ['Bombardier CRJ 550', 'CRJ7'],
+      ['Bombardier CRJ 900', 'CRJ9'],
+    ];
+    for (const [text, code] of cases) {
+      expect(modelTextToIcaoCode(text)).toBe(code);
+    }
+  });
+
+  it('every derived mainline code is a key the client ICAO_TO_FLEET_TYPE map understands', () => {
+    // Guards the vocabulary contract: these are exactly the keys in src/dashboard/main.js.
+    const CLIENT_MAINLINE_KEYS = new Set([
+      'A319', 'A320', 'A21N',
+      'B737', 'B738', 'B739', 'B39M', 'B38M',
+      'B752', 'B753', 'B763', 'B764',
+      'B772', 'B77E', 'B77W', 'B788', 'B789', 'B78X',
+    ]);
+    for (const text of ['Airbus A319', 'Airbus A321 NEO', 'Boeing 737 MAX 9', 'Boeing 777-200ER', 'Boeing 787-10']) {
+      expect(CLIENT_MAINLINE_KEYS.has(modelTextToIcaoCode(text))).toBe(true);
+    }
+  });
+
+  it("returns '' for a bare 'Boeing 737' — ambiguous across -700/-800/-900, never guess", () => {
+    expect(modelTextToIcaoCode('Boeing 737')).toBe('');
+  });
+
+  it("returns '' for other ambiguous bare families (787, A321 ceo/neo, CRJ)", () => {
+    expect(modelTextToIcaoCode('Boeing 787')).toBe('');
+    expect(modelTextToIcaoCode('Airbus A321')).toBe('');
+    expect(modelTextToIcaoCode('Bombardier CRJ')).toBe('');
+    expect(modelTextToIcaoCode('Boeing 777')).toBe('');
+  });
+
+  it("returns '' for unknown / empty / nullish text", () => {
+    expect(modelTextToIcaoCode('Cessna 172')).toBe('');
+    expect(modelTextToIcaoCode('Saab 340')).toBe('');
+    expect(modelTextToIcaoCode('')).toBe('');
+    expect(modelTextToIcaoCode(undefined)).toBe('');
+    expect(modelTextToIcaoCode(null)).toBe('');
+  });
+
+  it('tolerates casing and whitespace noise', () => {
+    expect(modelTextToIcaoCode('  boeing   787-9  ')).toBe('B789');
+    expect(modelTextToIcaoCode('AIRBUS A321NEO')).toBe('A21N');
+  });
+});
+
+// ── End-to-end: the derived code rides the normalized board (swap-detector precondition) ──────
+describe('fetchViaAeroDataBox — aircraft.model.code end-to-end', () => {
+  const nowSec = 1_700_000_000;
+  const iso = (offsetS) => new Date((nowSec + offsetS) * 1000).toISOString();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __resetAdbSpendForTests();
+    process.env.AERODATABOX_API_KEY = 'adb-test-key';
+    process.env.AERODATABOX_INTER_WINDOW_DELAY_MS = '0';
+  });
+  afterEach(() => {
+    delete process.env.AERODATABOX_API_KEY;
+    delete process.env.AERODATABOX_INTER_WINDOW_DELAY_MS;
+    __resetAdbSpendForTests();
+  });
+
+  async function boardWithModel(model) {
+    const departures = [{
+      number: 'UA 100', status: 'Scheduled', airline: { iata: 'UA', name: 'United Airlines' },
+      departure: { scheduledTime: { utc: iso(3600) }, airport: { iata: 'ORD' } },
+      arrival: { scheduledTime: { utc: iso(10800) }, airport: { iata: 'DEN' } },
+      aircraft: { model, reg: 'N12345' },
+    }];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) =>
+      String(url).includes('aedbx/aerodatabox')
+        ? { ok: true, status: 200, json: async () => ({ departures }) }
+        : { ok: false, status: 403, text: async () => 'blocked', headers: { get: () => null } }
+    );
+    const result = await fetchViaAeroDataBox('ORD', 'departures', nowSec, 8000);
+    return result.flights[0];
+  }
+
+  it('carries the derived code AND the raw text on the normalized row', async () => {
+    const f = await boardWithModel('Embraer 175');
+    expect(f.aircraft.model.code).toBe('E175');
+    expect(f.aircraft.model.text).toBe('Embraer 175');
+  });
+
+  it('two boards with changed model text produce DIFFERING codes (the swap precondition)', async () => {
+    const before = await boardWithModel('Boeing 787-9');
+    const after = await boardWithModel('Boeing 777-300ER');
+    expect(before.aircraft.model.code).toBe('B789');
+    expect(after.aircraft.model.code).toBe('B77W');
+    expect(before.aircraft.model.code).not.toBe(after.aircraft.model.code);
+  });
+
+  it("leaves the code empty for a bare 'Boeing 737' — no false swap, honest '—' in the column", async () => {
+    const f = await boardWithModel('Boeing 737');
+    expect(f.aircraft.model.code).toBe('');
+    expect(f.aircraft.model.text).toBe('Boeing 737');
   });
 });


### PR DESCRIPTION
Found by the post-#220 doc cross-check: the equipment-swap banner — a marketed feature of the v2.0 program — is structurally dead in production, and has been since the AeroDataBox migration.

## The bug (verified on live production)

`api/_schedule-aerodatabox.ts` hardcoded `aircraft.model.code` to `''`. AeroDataBox only ships a free-text model name. Verified live: **0 of 647 rows on the ORD board carry a code; 610 carry text.**

Three features gate on that code, so all three were dead:
1. **The "⚠️ N equipment swaps detected" banner** — `detectEquipmentSwaps` requires a truthy `acCode`, so its baseline map was always empty and the banner could never fire.
2. **The Schedule Aircraft column** — rendered `—` on every row (visible in every screenshot of the board, all along).
3. **The aircraft-type filter** — could never match anything.

## The fix

A pure, exported `modelTextToIcaoCode(text)` mapping the provider text into the client's existing `ICAO_TO_FLEET_TYPE` vocabulary, wired in at the one dead assignment. Vocabulary was aligned by reading the actual consumers (`ICAO_TO_FLEET_TYPE`, `getScheduleFleetFamily`, `populateAircraftFilter`, the `#sched-aircraft` filter), not invented.

**Honesty over completeness:** text that doesn't resolve to a single variant returns `''` — bare `Boeing 737` (could be -700/-800/-900), bare `787`/`777`, bare `Airbus A321` (ceo vs neo), bare `Bombardier CRJ`, anything unrecognized. A guessed variant would be worse than the dead banner: two polls resolving the same jet to different guesses would mint a **false** swap alert. Two deliberate, consistent collapses are documented in the code: `777-200` without an `ER` marker → generic `B772`, and `CRJ-550`→`CRJ7` (its actual ICAO designator) — consistent collapses can't fabricate swaps, they only lose a display distinction.

Every text value observed on the live board maps correctly or refuses honestly (spot-checked against the running function).

`time.*` and `_source.timeSource` (the v1.7.7 gate-vs-runway fix) untouched.

## Verification

- Implemented in an isolated worktree by a subagent, then **independently re-reviewed and re-gated by the orchestrator**: full diff read, mapping executed against all live board text values, `bun run test` (75 files, **1079 pass**, 9 new) and `tsc --noEmit` re-run clean, cherry-picked onto latest `main` and the touched suite re-run green.
- Failing-first proven: with only the source change stashed, the 8 tests asserting a derived code fail; the bare-`Boeing 737 → ''` end-to-end test correctly passes both ways.
- First observable effect after deploy: Aircraft column shows real type codes on fresh boards; swap detection begins accumulating baselines from the first post-deploy poll (first poll diffs against an empty map, so no false alerts on rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)