### PR TITLE
fix(snapshots): bounded-batch GC — the v1.7.9 sweep always hit the statement timeout (v1.7.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.10] - 2026-07-11
+
+### Fixed
+- **The v1.7.9 snapshot GC could never actually delete anything.** Its first production run hit `canceling statement due to statement timeout`: `schedule_snapshots` had accumulated **4,110 expired rows (~320 MB of JSONB, 98% of the table) since March**, and a timed-out `DELETE` rolls back whole — so the single-statement sweep would fail identically every hour forever, which is the quiet-failure mode the GC was added to prevent. It now deletes by primary-key batches (300 rows × up to 4 batches per warm-cron fire): every statement is small enough to finish, a deep backlog drains incrementally (~4 hours for the current one), and steady state (~18 new rows/day) completes in one short round. A failed batch still logs and never fails the cron. (`api/_schedule-snapshots.ts`)
+
 ## [1.7.9] - 2026-07-11
 
 Full-codebase audit: 20 scoped review agents produced 106 findings, every one adversarially verified (95 confirmed, 11 refuted), then 93 were applied. The suite grew **1,079 → 1,259 tests** (75 → 85 files), and the production diff is a net −150 lines. Every new test was proven load-bearing — sabotage the code, watch it fail, revert — not just green.

--- a/api/_schedule-snapshots.ts
+++ b/api/_schedule-snapshots.ts
@@ -237,17 +237,44 @@ export async function saveScheduleSnapshot({ cacheKey, hub, dir, ts, data }: Sav
 // merely filters live rows via .gt('expires_at', now); this is the DELETE the idx_schedule_snapshots_expires_at
 // index (sql/003) was created for. Best-effort and idempotent: piggy-backed on the hourly warm cron,
 // at most once per run, and any failure is logged, never thrown.
+// Bounded batches, not one statement. The single `DELETE ... WHERE expires_at < now()` was rolled
+// back whole by the Postgres statement timeout on its first production run (Jul 11 2026: 4,110
+// expired rows / ~320 MB of TOASTed JSONB accumulated since March — precisely the backlog this GC
+// exists to prevent), so it could never make progress no matter how often the cron retried.
+// Deleting by primary-key batches keeps every statement small enough to finish, and a deep backlog
+// drains incrementally at up to CLEANUP_MAX_BATCHES × CLEANUP_BATCH_SIZE rows per hourly fire,
+// while steady-state runs (~18 new rows/day) finish in one short round.
+const CLEANUP_BATCH_SIZE = 300;
+const CLEANUP_MAX_BATCHES = 4;
+
 export async function cleanupExpiredSnapshots(): Promise<void> {
   const supabase = await getSupabaseAdmin();
   if (!supabase) return;
 
   try {
-    const { error } = await supabase
-      .from(SNAPSHOT_TABLE)
-      .delete()
-      .lt('expires_at', new Date().toISOString());
-    if (error) {
-      console.error('Schedule snapshot cleanup failed:', error.message);
+    for (let batch = 0; batch < CLEANUP_MAX_BATCHES; batch++) {
+      const { data, error } = await supabase
+        .from(SNAPSHOT_TABLE)
+        .select('cache_key')
+        .lt('expires_at', new Date().toISOString())
+        .order('expires_at', { ascending: true })
+        .limit(CLEANUP_BATCH_SIZE);
+      if (error) {
+        console.error('Schedule snapshot cleanup select failed:', error.message);
+        return;
+      }
+      const keys = ((data || []) as Array<{ cache_key: string }>).map((r) => r.cache_key);
+      if (!keys.length) return;
+
+      const { error: delError } = await supabase
+        .from(SNAPSHOT_TABLE)
+        .delete()
+        .in('cache_key', keys);
+      if (delError) {
+        console.error('Schedule snapshot cleanup failed:', delError.message);
+        return;
+      }
+      if (keys.length < CLEANUP_BATCH_SIZE) return;
     }
   } catch (error: any) {
     console.error('Schedule snapshot cleanup threw:', error?.message || error);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/tests/schedule-snapshots.test.js
+++ b/tests/schedule-snapshots.test.js
@@ -265,23 +265,83 @@ describe('cleanupExpiredSnapshots', () => {
     vi.restoreAllMocks();
   });
 
-  it('deletes only rows whose expires_at is already in the past', async () => {
-    const lt = vi.fn(async () => ({ error: null }));
-    const del = vi.fn(() => ({ lt }));
-    supa.from = vi.fn(() => ({ delete: del }));
+  // Wire the fake so each select batch returns the next entry of `batches` and every delete
+  // records the keys it was asked to remove. Mirrors the PostgREST select→delete.in two-step.
+  function mockCleanupSupabase(batches, { selectError = null, deleteError = null } = {}) {
+    let call = 0;
+    const selectLt = vi.fn();
+    const deleted = [];
+    supa.from = vi.fn(() => ({
+      select: () => ({
+        lt: (col, iso) => {
+          selectLt(col, iso);
+          return {
+            order: () => ({
+              limit: async () => {
+                if (selectError) return { data: null, error: selectError };
+                const rows = (batches[call++] || []).map((k) => ({ cache_key: k }));
+                return { data: rows, error: null };
+              },
+            }),
+          };
+        },
+      }),
+      delete: () => ({
+        in: async (col, keys) => {
+          if (deleteError) return { error: deleteError };
+          deleted.push([col, keys]);
+          return { error: null };
+        },
+      }),
+    }));
+    return { selectLt, deleted };
+  }
+
+  it('deletes expired rows in bounded key batches and stops after a short batch', async () => {
+    const full = Array.from({ length: 300 }, (_, i) => `agg:EWR:departures:${i}`);
+    const m = mockCleanupSupabase([full, ['agg:SFO:arrivals:1', 'agg:SFO:arrivals:2']]);
     const before = Date.now();
     await cleanupExpiredSnapshots();
     expect(supa.from).toHaveBeenCalledWith('schedule_snapshots');
-    expect(del).toHaveBeenCalledTimes(1);
-    expect(lt).toHaveBeenCalledTimes(1);
-    const [column, iso] = lt.mock.calls[0];
+    // Two select+delete rounds: a full batch, then the 2-row remainder ends the loop.
+    expect(m.selectLt).toHaveBeenCalledTimes(2);
+    const [column, iso] = m.selectLt.mock.calls[0];
     expect(column).toBe('expires_at');
     expect(Date.parse(iso)).toBeGreaterThanOrEqual(before);
     expect(Date.parse(iso)).toBeLessThanOrEqual(Date.now());
+    expect(m.deleted).toHaveLength(2);
+    expect(m.deleted[0][0]).toBe('cache_key');
+    expect(m.deleted[0][1]).toEqual(full);
+    expect(m.deleted[1][1]).toEqual(['agg:SFO:arrivals:1', 'agg:SFO:arrivals:2']);
   });
 
-  it('swallows a delete error instead of throwing', async () => {
-    supa.from = vi.fn(() => ({ delete: () => ({ lt: async () => ({ error: { message: 'boom' } }) }) }));
+  it('issues no delete when nothing is expired', async () => {
+    const m = mockCleanupSupabase([[]]);
+    await cleanupExpiredSnapshots();
+    expect(m.selectLt).toHaveBeenCalledTimes(1);
+    expect(m.deleted).toHaveLength(0);
+  });
+
+  it('caps the work per run at the batch ceiling even with a deep backlog', async () => {
+    const full = Array.from({ length: 300 }, (_, i) => `k${i}`);
+    // Every select returns a full batch — the run must stop at the ceiling, not drain forever.
+    const m = mockCleanupSupabase([full, full, full, full, full, full]);
+    await cleanupExpiredSnapshots();
+    expect(m.selectLt).toHaveBeenCalledTimes(4);
+    expect(m.deleted).toHaveLength(4);
+  });
+
+  it('swallows a select error instead of throwing and issues no delete', async () => {
+    const m = mockCleanupSupabase([], { selectError: { message: 'boom' } });
     await expect(cleanupExpiredSnapshots()).resolves.toBeUndefined();
+    expect(m.deleted).toHaveLength(0);
+  });
+
+  it('swallows a delete error instead of throwing and stops batching', async () => {
+    const full = Array.from({ length: 300 }, (_, i) => `k${i}`);
+    const m = mockCleanupSupabase([full, full], { deleteError: { message: 'canceling statement due to statement timeout' } });
+    await expect(cleanupExpiredSnapshots()).resolves.toBeUndefined();
+    // The failed delete must end the run — no second select round.
+    expect(m.selectLt).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What broke

Post-deploy monitoring of v1.7.9 caught the new snapshot GC failing on its very first production run:

```
Schedule snapshot cleanup failed: canceling statement due to statement timeout
```

The premise of the cleanup was right — `schedule_snapshots` has **4,110 expired rows (~320 MB of JSONB, 98% of the table) accumulated since March 21** (verified live). But that backlog is exactly why the single `DELETE ... WHERE expires_at < now()` can't work: a timed-out statement rolls back entirely, so the sweep makes zero progress and will fail identically every hour forever. The cron itself is unaffected (best-effort by design: 5 warmed / 0 failed on the same run).

## The fix

Delete in primary-key batches: select up to 300 expired `cache_key`s (oldest first), delete by key, up to 4 batches per warm-cron fire. Every statement is small enough to finish inside the timeout; the current backlog drains in ~4 hourly runs; steady state (~18 new rows/day) completes in one short round. A failed batch still logs and never fails the cron.

Note the table won't shrink in `pg_total_relation_size` immediately — Postgres reuses the freed space after autovacuum. The number that matters is `expired_rows → 0`, and reads were never affected (every read path already filters `expires_at > now()`).

## Verification

- TDD: the five new/updated cleanup tests fail against the single-statement implementation, pass against the batched one (batching, short-batch stop, no-op path, per-run ceiling with a deep backlog, select/delete error handling).
- Full gates: `bun run test` 1262/1262 · `tsc --noEmit` clean.
- After merging: within a few hours `warm-schedules` logs should stop showing the cleanup failure; I'd expect `SELECT count(*) FROM schedule_snapshots WHERE expires_at < now()` to read 0 by tonight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)