### PR TITLE
fix(support-stats): hydrate cross-instance ADB spend so the public cost meter stops reading 0 (v1.7.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.11] - 2026-07-16
+
+### Fixed
+- **The public support meter's "boards used" bar was structurally stuck at 0.** `/api/support-stats` read `getAdbUnitsToday()`, a per-instance in-memory counter — but the support-stats lambda never records AeroDataBox spend itself (only the schedule and warm-cron paths call `recordAdbUnits`), so that counter is always 0 while the real cross-instance total (Supabase `schedule_provider_spend`, maintained by the `increment_adb_units` RPC) runs past the 700/day budget. Production served `{"boards":{"used":0,…}}` at every hour of the day, understating the site's cost to visitors. The handler now calls `hydrateAdbSpend()` — the existing TTL-limited, never-throwing cross-instance reader — concurrently with the FR24 usage fetch and reports its total, so the meter reflects real spend and degrades to the in-memory value (never an error) if Supabase is unavailable. The FR24 live-feed reading is untouched: its ~0% is truthful, since the FR24 kill-switch keeps credit consumption near zero. (`api/support-stats.ts`)
+- **The snapshot GC ran silently on success, so an audit couldn't confirm from logs that it was draining the backlog.** `cleanupExpiredSnapshots` logged only failures; a clean run left no trace of whether it fired or how many rows it removed. It now counts deletions across batches and emits one info summary — `Schedule snapshot cleanup: deleted <N> expired rows` — whenever it deleted anything, appending ` (batch cap reached; backlog may remain)` when it stops at the per-run batch ceiling with a still-full final batch (the operationally important signal that expired rows remain for the next hourly fire). The common empty hourly run stays silent to avoid log noise, and a mid-run select/delete error still reports what was already deleted. (`api/_schedule-snapshots.ts`)
+
 ## [1.7.10] - 2026-07-11
 
 ### Fixed

--- a/api/_schedule-snapshots.ts
+++ b/api/_schedule-snapshots.ts
@@ -251,6 +251,13 @@ export async function cleanupExpiredSnapshots(): Promise<void> {
   const supabase = await getSupabaseAdmin();
   if (!supabase) return;
 
+  // Observability: the GC previously logged only failures, so a clean run left no trace it had
+  // run or how much it deleted — an audit couldn't confirm from logs that the backlog was
+  // draining. Count what we delete and emit ONE summary at the end when deleted > 0. A run that
+  // exhausts every batch with a still-full final batch likely left a backlog, which is the
+  // operationally important signal to surface.
+  let deleted = 0;
+  let batchCapReached = false;
   try {
     for (let batch = 0; batch < CLEANUP_MAX_BATCHES; batch++) {
       const { data, error } = await supabase
@@ -261,10 +268,10 @@ export async function cleanupExpiredSnapshots(): Promise<void> {
         .limit(CLEANUP_BATCH_SIZE);
       if (error) {
         console.error('Schedule snapshot cleanup select failed:', error.message);
-        return;
+        break;
       }
       const keys = ((data || []) as Array<{ cache_key: string }>).map((r) => r.cache_key);
-      if (!keys.length) return;
+      if (!keys.length) break;
 
       const { error: delError } = await supabase
         .from(SNAPSHOT_TABLE)
@@ -272,11 +279,22 @@ export async function cleanupExpiredSnapshots(): Promise<void> {
         .in('cache_key', keys);
       if (delError) {
         console.error('Schedule snapshot cleanup failed:', delError.message);
-        return;
+        break;
       }
-      if (keys.length < CLEANUP_BATCH_SIZE) return;
+      deleted += keys.length;
+      if (keys.length < CLEANUP_BATCH_SIZE) break;
+      // A full batch on the last allowed iteration means we stopped at the cap, not because the
+      // backlog was drained — more expired rows probably remain for the next hourly fire.
+      if (batch === CLEANUP_MAX_BATCHES - 1) batchCapReached = true;
     }
   } catch (error: any) {
     console.error('Schedule snapshot cleanup threw:', error?.message || error);
+  }
+
+  if (deleted > 0) {
+    console.log(
+      `Schedule snapshot cleanup: deleted ${deleted} expired rows` +
+      (batchCapReached ? ' (batch cap reached; backlog may remain)' : '')
+    );
   }
 }

--- a/api/support-stats.ts
+++ b/api/support-stats.ts
@@ -3,9 +3,14 @@
 //
 // Renders the About/Donate popover's support meter (public/js/support-meter.js). Everything
 // returned here is deliberately SANITIZED and COARSE:
-//   - boards.{used,budget}: today's AeroDataBox schedule-refresh unit counter, reused as-is from
-//     api/_cost-state.ts (getAdbUnitsToday / getAdbDailyUnitBudget). AeroDataBox is already
-//     publicly credited on the Sources page, so naming it is fine; no raw account/plan info.
+//   - boards.{used,budget}: today's AeroDataBox schedule-refresh unit total + the daily budget
+//     (api/_cost-state.ts). This lambda never records ADB spend itself — only the schedule/warm-cron
+//     paths call recordAdbUnits — so its per-instance getAdbUnitsToday counter is structurally 0.
+//     We therefore call hydrateAdbSpend() first to pull the real CROSS-INSTANCE total from Supabase
+//     (schedule_provider_spend); it is TTL-limited, never throws, and degrades to the in-memory
+//     value on any failure, so a broken read shows a stale/zero meter rather than erroring.
+//     AeroDataBox is already publicly credited on the Sources page, so naming it is fine; no raw
+//     account/plan info.
 //   - liveFeed.usedPct: a coarse (rounded to nearest 5%) FR24 billing-period credit-consumption
 //     percentage. Computed from the SAME upstream fetch used by the CRON_SECRET-gated
 //     api/fr24-usage.ts (fetchFr24UsageRaw, a minimal export added there for this reuse — that
@@ -18,7 +23,7 @@
 // second and it is public, unauthenticated, and safe to share across all visitors.
 
 import type { VercelRequest, VercelResponse } from './types.js';
-import { getAdbUnitsToday, getAdbDailyUnitBudget } from './_cost-state.js';
+import { hydrateAdbSpend, getAdbDailyUnitBudget } from './_cost-state.js';
 import { fetchFr24UsageRaw } from './fr24-usage.js';
 import { createRateLimiter } from './_rate-limit.js';
 
@@ -100,11 +105,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Public, unauthenticated, identical for everyone — safe to cache hard at the CDN.
   res.setHeader('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=600');
 
-  const liveFeed = await getLiveFeedUsage();
+  // Both never throw; run them concurrently. hydrateAdbSpend returns the cross-instance ADB unit
+  // total (this lambda's own per-instance counter is always 0 — see the header note).
+  const [liveFeed, boardsUsed] = await Promise.all([getLiveFeedUsage(), hydrateAdbSpend()]);
 
   return res.status(200).json({
     boards: {
-      used: getAdbUnitsToday(),
+      used: boardsUsed,
       budget: getAdbDailyUnitBudget(),
     },
     liveFeed,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/tests/schedule-snapshots.test.js
+++ b/tests/schedule-snapshots.test.js
@@ -344,4 +344,79 @@ describe('cleanupExpiredSnapshots', () => {
     // The failed delete must end the run — no second select round.
     expect(m.selectLt).toHaveBeenCalledTimes(1);
   });
+
+  // ── Observability: the GC used to log only failures, so a clean run left no trace it had run
+  // or how much it deleted. It now emits ONE info summary whenever it deleted anything.
+  const cleanupSummaries = (logSpy) =>
+    logSpy.mock.calls.map((c) => String(c[0])).filter((m) => /Schedule snapshot cleanup: deleted/.test(m));
+
+  it('logs a single success summary with the total deleted across batches', async () => {
+    const full = Array.from({ length: 300 }, (_, i) => `k${i}`);
+    mockCleanupSupabase([full, ['agg:SFO:arrivals:1', 'agg:SFO:arrivals:2']]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await cleanupExpiredSnapshots();
+
+    const summaries = cleanupSummaries(logSpy);
+    expect(summaries).toHaveLength(1);
+    // 300 (full batch) + 2 (short remainder) — one line, the true total, no backlog note.
+    expect(summaries[0]).toBe('Schedule snapshot cleanup: deleted 302 expired rows');
+  });
+
+  it('stays silent when nothing was deleted (no hourly log noise on the common empty run)', async () => {
+    mockCleanupSupabase([[]]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await cleanupExpiredSnapshots();
+
+    expect(cleanupSummaries(logSpy)).toHaveLength(0);
+  });
+
+  it('flags a likely backlog when the batch cap is reached with a full final batch', async () => {
+    const full = Array.from({ length: 300 }, (_, i) => `k${i}`);
+    // Every batch is full, so the run stops at CLEANUP_MAX_BATCHES with rows still likely expired.
+    mockCleanupSupabase([full, full, full, full, full, full]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await cleanupExpiredSnapshots();
+
+    const summaries = cleanupSummaries(logSpy);
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toBe(
+      'Schedule snapshot cleanup: deleted 1200 expired rows (batch cap reached; backlog may remain)'
+    );
+  });
+
+  it('still reports the rows already deleted when a later batch errors mid-run', async () => {
+    // First batch deletes cleanly; the second delete fails (e.g. statement timeout). The error
+    // logs on its own channel, but the summary must still credit what WAS deleted — and, since
+    // the run ended on an error rather than the cap, it must NOT claim a backlog.
+    const full = Array.from({ length: 300 }, (_, i) => `k${i}`);
+    let deleteCall = 0;
+    supa.from = vi.fn(() => ({
+      select: () => ({
+        lt: () => ({
+          order: () => ({
+            limit: async () => ({ data: full.map((k) => ({ cache_key: k })), error: null }),
+          }),
+        }),
+      }),
+      delete: () => ({
+        in: async () => {
+          deleteCall++;
+          return deleteCall === 1
+            ? { error: null }
+            : { error: { message: 'canceling statement due to statement timeout' } };
+        },
+      }),
+    }));
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await cleanupExpiredSnapshots();
+
+    const summaries = cleanupSummaries(logSpy);
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toBe('Schedule snapshot cleanup: deleted 300 expired rows');
+  });
 });

--- a/tests/support-stats.test.js
+++ b/tests/support-stats.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import handler, { __resetLiveFeedMemo } from '../api/support-stats.js';
 import * as costState from '../api/_cost-state.js';
 import * as fr24Usage from '../api/fr24-usage.js';
+import * as scheduleSnapshots from '../api/_schedule-snapshots.js';
 
 function createRes() {
   return {
@@ -24,6 +25,9 @@ describe('support-stats API', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     __resetLiveFeedMemo();
+    // boards.used is now hydrated from cross-instance spend via hydrateAdbSpend, which carries
+    // module-level counter + TTL state; reset it so cases do not leak into each other.
+    costState.__resetAdbSpendForTests();
     delete process.env.FR24_API_TOKEN;
     delete process.env.FR24_MONTHLY_CREDIT_BUDGET;
   });
@@ -53,7 +57,9 @@ describe('support-stats API', () => {
   });
 
   it('returns the sanitized boards summary from _cost-state helpers', async () => {
-    vi.spyOn(costState, 'getAdbUnitsToday').mockReturnValue(340);
+    // used comes from hydrateAdbSpend (the cross-instance total), not the per-instance
+    // getAdbUnitsToday counter, which is structurally 0 in this lambda.
+    vi.spyOn(costState, 'hydrateAdbSpend').mockResolvedValue(340);
     vi.spyOn(costState, 'getAdbDailyUnitBudget').mockReturnValue(400);
 
     const res = createRes();
@@ -61,6 +67,46 @@ describe('support-stats API', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.body.boards).toEqual({ used: 340, budget: 400 });
+  });
+
+  it('reports boards.used from the cross-instance Supabase total, not the per-instance 0 counter', async () => {
+    // The support-stats lambda never records AeroDataBox spend itself, so its in-memory counter
+    // (getAdbUnitsToday) is structurally 0 while the real cross-instance total lives in the
+    // schedule_provider_spend table. hydrateAdbSpend must read that table so the public meter is
+    // truthful. Wire getSupabaseAdmin to return today's row of 123 units.
+    vi.spyOn(scheduleSnapshots, 'getSupabaseAdmin').mockResolvedValue({
+      from: (table) => ({
+        select: () => ({
+          eq: () => ({
+            limit: async () => ({
+              data: table === 'schedule_provider_spend' ? [{ units: 123 }] : [],
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    });
+
+    const res = createRes();
+    await handler(makeReq(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.boards.used).toBe(123);
+  });
+
+  it('degrades to the in-memory value and still 200s when Supabase is unavailable', async () => {
+    // hydrateAdbSpend never throws: when getSupabaseAdmin yields null (schema missing, blip, or a
+    // test that mocks it away) the response must still return the last-known in-memory count
+    // instead of erroring the whole endpoint. Prime the in-memory counter so this proves the
+    // fallback carries a real value through, not a hardcoded 0.
+    vi.spyOn(scheduleSnapshots, 'getSupabaseAdmin').mockResolvedValue(null);
+    await costState.recordAdbUnits(45); // stays in-memory (Supabase null)
+
+    const res = createRes();
+    await handler(makeReq(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.boards.used).toBe(45);
   });
 
   it('reports liveFeed as unconfigured when FR24_API_TOKEN is absent', async () => {


### PR DESCRIPTION
Two small fixes from the Jul 15 post-ship-train live audit (report-only audit; these are the two items approved for fixing).

## 1. The public support meter was structurally stuck at 0

`/api/support-stats` reported `boards.used` from `getAdbUnitsToday()` — a **per-instance in-memory counter**. The support-stats lambda never records AeroDataBox spend itself (only the schedule and warm-cron paths call `recordAdbUnits`), so its counter reads 0 forever while the real cross-instance total (Supabase `schedule_provider_spend` via the `increment_adb_units` RPC) blows past the 700/day budget — confirmed live: production returned `{"boards":{"used":0,"budget":700}}` at every hour while runtime logs showed the real counter at 760/700. The donate widget told visitors "Today's board refreshes **0/700**", i.e. that the site costs nothing to run.

Fix: the handler now awaits `hydrateAdbSpend()` — the existing TTL-limited, never-throwing cross-instance reader — concurrently with the FR24 usage fetch, and reports its total. On any Supabase failure it degrades to the in-memory value (never an error). The FR24 live-feed bar is deliberately untouched: its ~0% is truthful while the FR24 kill-switch keeps official-API credit consumption near zero.

## 2. The snapshot GC was silent on success

The v1.7.10 bounded-batch GC logged only failures, so the audit could not confirm from logs that it ran or how much it deleted (Vercel log retention is ~1 day; the proof had to come from a DB-side row count). `cleanupExpiredSnapshots` now counts deletions across batches and emits one summary line when it deleted anything — `Schedule snapshot cleanup: deleted <N> expired rows`, with ` (batch cap reached; backlog may remain)` appended when it stops at the 4-batch ceiling with a still-full final batch. Empty hourly runs stay silent (no log noise); a mid-run error still reports what was already deleted. Contract unchanged (`Promise<void>`, never throws).

## Tests

+6 tests (suite 1262 → 1268), all sabotage-proven (fix reverted → test fails → fix restored):
- support-stats: `boards.used` comes from the hydrated cross-instance total (mocked `schedule_provider_spend` → 123 appears in the response); Supabase-unavailable degradation still 200s with the in-memory value.
- GC: single summary with correct total across batches; silent on empty runs; backlog-cap note on 4 full batches; partial total still reported when a later batch errors.

Gates: `bun run test` 1268 passed · `bun run typecheck` clean · `bun run build` 43 pages.

**After merging:** verify `vercel ls --prod` shows `● Ready`, then `curl -s 'https://theblueboard.co/api/support-stats?z=1' | jq .boards` — `used` should be nonzero (CDN caches the unparameterized URL for 5 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)