### PR TITLE
security: harden /api/schedule against denial-of-wallet + track sql/015 RPC revoke

### DIFF
--- a/api/_cost-state.ts
+++ b/api/_cost-state.ts
@@ -201,12 +201,66 @@ export async function hydrateAdbSpend(): Promise<number> {
   }
 }
 
-/** Test helper: clear ADB spend state so it does not leak across tests. Production never calls it. */
+// ── Official FR24 API daily call ceiling (proactive, per-instance) ──
+//
+// The paid FR24 Official API (schedule.ts's fetchViaOfficialAPI) is bounded only REACTIVELY today:
+// the cross-instance 402 "credit limit reached" block (persistQuotaBlock/getMirroredQuotaBlockedUntil)
+// and an in-memory 15-min sliding-window circuit breaker (MAX_FALLBACKS_PER_WINDOW). Neither is an
+// ABSOLUTE daily ceiling — the 15-min window resets, so a low-and-slow attacker forcing scrape
+// outages on the public /api/schedule endpoint can keep the paid official API firing all day, each
+// 402 block expiring after 30m and spend resuming, up to the account credit limit. This counter is a
+// PROACTIVE absolute per-UTC-day cap so we stop before ever hitting the paid credit ceiling.
+//
+// LIMITATION: unlike the AeroDataBox unit budget above, this is in-memory PER LAMBDA INSTANCE (no
+// Supabase write-through) — matching the existing 15-min circuit breaker's own scope. Under wide
+// fan-out the cross-instance bound remains the reactive 402 block. A fully cross-instance ceiling
+// would need a new provider-spend row/RPC (see sql/009 for the ADB pattern); this in-file counter is
+// the smaller extension that closes the "window resets → unbounded daily total" gap without new DDL.
+
+let officialFr24Day = '';
+let officialFr24Calls = 0;
+
+function rollOfficialFr24Day(): void {
+  const today = utcToday();
+  if (officialFr24Day !== today) {
+    officialFr24Day = today;
+    officialFr24Calls = 0;
+  }
+}
+
+export function getOfficialFr24CallsToday(): number {
+  rollOfficialFr24Day();
+  return officialFr24Calls;
+}
+
+export function getOfficialFr24DailyCap(): number {
+  // An explicit 0 is a kill switch (stop ALL paid official-API calls now) and must be honoured.
+  // Garbage (negative, NaN) falls back to the default. Default 200 sits comfortably above organic
+  // official-fallback volume (bounded to 5/15min by the circuit breaker) while capping an attacker-
+  // driven day well under the account credit limit.
+  const configured = Number(process.env.OFFICIAL_FR24_DAILY_CALL_CAP);
+  return Number.isFinite(configured) && configured >= 0 ? configured : 200;
+}
+
+/** True once today's known official-API calls have reached the daily cap. Sync; safe in the hot path. */
+export function isOfficialFr24DailyCapReached(): boolean {
+  return getOfficialFr24CallsToday() >= getOfficialFr24DailyCap();
+}
+
+/** Count one committed paid official-API call against today's ceiling. Never throws. */
+export function recordOfficialFr24Call(): void {
+  rollOfficialFr24Day();
+  officialFr24Calls += 1;
+}
+
+/** Test helper: clear ADB spend + official-FR24 counters so they do not leak across tests. Production never calls it. */
 export function __resetAdbSpendForTests(): void {
   adbDay = '';
   adbUnits = 0;
   lastAdbHydratedAt = 0;
   warnedAdbSchemaMissing = false;
+  officialFr24Day = '';
+  officialFr24Calls = 0;
 }
 
 /**

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
 import { loadScheduleSnapshot, saveScheduleSnapshot, isSnapshotCandidateBetter } from './_schedule-snapshots.js';
-import { hydrateQuotaBlock, getMirroredQuotaBlockedUntil, persistQuotaBlock, resetMirroredQuotaBlock, __resetAdbSpendForTests } from './_cost-state.js';
+import { hydrateQuotaBlock, getMirroredQuotaBlockedUntil, persistQuotaBlock, resetMirroredQuotaBlock, __resetAdbSpendForTests, isOfficialFr24DailyCapReached, recordOfficialFr24Call, getOfficialFr24CallsToday, getOfficialFr24DailyCap } from './_cost-state.js';
 import { UNITED_HUB_SET, getHubTerminal } from './_hubs.js';
 import { isAuthorizedCronRequest } from './_cron-auth.js';
 import { isOfficialFr24Enabled } from './_official-fr24.js';
@@ -956,6 +956,14 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
     console.warn(`Official FR24 API: quota block active for ${logHub}, skipping for ${secondsRemaining}s`);
     return null;
   }
+  // Proactive absolute daily ceiling on paid official-API calls (denial-of-wallet guard): the 402
+  // block and 15-min circuit breaker are reactive/resetting, so this hard-stops before we ever reach
+  // the account credit limit. Every caller of the paid API funnels through here, so this is the one
+  // chokepoint that bounds the day. See _cost-state.ts for the per-instance limitation.
+  if (isOfficialFr24DailyCapReached()) {
+    console.warn(`Official FR24 API: daily call cap reached (${getOfficialFr24CallsToday()}/${getOfficialFr24DailyCap()}), skipping ${logHub} ${dir} until next UTC day`);
+    return null;
+  }
 
   timeoutMs = timeoutMs || HUB_TIMEOUT_MS[logHub.toUpperCase()] || 45000;
   const startTime = Date.now();
@@ -972,6 +980,11 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
     console.log(`Official FR24 API: window for ${logHub} ${dir} starts ${formatForFR24(dayStart)} (tomorrow UTC or later) — FR24 cannot serve it, skipping`);
     return null;
   }
+
+  // Count this as a committed paid official-API call for today's proactive ceiling. Recorded here —
+  // past all pre-flight skips (no token / quota block / cap reached / unservable-tomorrow window) —
+  // so skipped requests never burn the budget; the cap itself is enforced by the gate above.
+  recordOfficialFr24Call();
 
   console.log(`Official FR24 API: fetching ${logHub} ${dir} (filter=${dir === 'departures' ? 'outbound' : 'inbound'}:${logHub}) from=${formatForFR24(dayStart)} to=${formatForFR24(dayEnd)} limit=${OFFICIAL_API_PAGE_SIZE}`);
 

--- a/sql/015_revoke_anon_security_definer_rpcs.sql
+++ b/sql/015_revoke_anon_security_definer_rpcs.sql
@@ -1,0 +1,9 @@
+-- 015: Revoke anon/public EXECUTE on SECURITY DEFINER functions + pin search_path.
+-- SECURITY: increment_daily_usage + handle_new_user were EXECUTE-granted to anon/authenticated/PUBLIC;
+-- SECURITY DEFINER bypasses RLS, so any anon-key holder could POST /rest/v1/rpc/increment_daily_usage
+-- with an arbitrary user_id to tamper quotas. Dormant today (profiles/usage_daily empty) but callable.
+-- NOTE: this DDL was applied to prod live on 2026-07-23; this file tracks it for repo parity.
+REVOKE EXECUTE ON FUNCTION public.increment_daily_usage(uuid, text) FROM anon, authenticated, PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM anon, authenticated, PUBLIC;
+ALTER FUNCTION public.increment_daily_usage(uuid, text) SET search_path = public;
+ALTER FUNCTION public.handle_new_user() SET search_path = public;


### PR DESCRIPTION
## The vulnerability

The public **unauthenticated** `/api/schedule` endpoint fans out to metered upstream providers on a cache miss. Two classic cache-busting spend surfaces and one unbounded paid-API surface were in scope:
- **(a)** `hub` only shape-checked (`/^[A-Z]{3,4}$/i`) → every distinct code (AAA, BBB, ZZZ…) is a fresh cache key + metered fetch.
- **(b)** raw `timestamp` (per-second) in the cache key + provider window → infinite distinct keys by varying by 1 second.
- Paid FR24 Official API reachable from the public path with no absolute daily ceiling.

## What I found against v1.7.11 (live prod)

The audit that flagged (a) and (b) as open was run against the **stale v1.3.7** working tree. On live `origin/main` (v1.7.11) both are **already fixed**, so I did not touch them (verified, cited below):

| Fix | Status in v1.7.11 | Evidence |
|-----|------------------|----------|
| (a) Hub allowlist | **Already present** | `schedule.ts:1733-1736` — uppercases `hub`, rejects anything outside `UNITED_HUB_SET` with a 400 **before** any cache lookup / fetch |
| (b) Timestamp floor | **Already present** | `schedule.ts:1747` — `getStartOfHubDay(hub, 0, …)` snaps to hub-local start-of-day; the floored `ts` flows into the cache key (`sched:${hub}:${dir}:${ts}`) **and** every provider query window (FR24 URL, ADB, official `dayStart`/`dayEnd`) |
| Global daily cap (metered provider) | **Already present** | AeroDataBox — the default `srcPriority='provider'` — has a cross-instance daily unit budget (`isAdbBudgetExhausted` gate at `_schedule-aerodatabox.ts:630`, persisted via `increment_adb_units` / `sql/009`) |

**Hub allowlist used (reused, not hardcoded):** `UNITED_HUBS` from `api/_hubs.ts` — `['ORD','DEN','IAH','EWR','SFO','IAD','LAX','NRT','GUM']` (United's 8 official hubs + the NRT gateway).

## What this PR changes

### Residual gap — proactive daily ceiling on the paid FR24 Official API
The one remaining unbounded paid surface was `fetchViaOfficialAPI`, guarded **only reactively**: the cross-instance 402 "credit limit reached" block + an in-memory **15-min sliding window** (`MAX_FALLBACKS_PER_WINDOW=5`). The window *resets*, so a low-and-slow attacker forcing scrape outages on the public endpoint can keep the paid official API firing all day (each 402 block expires after 30m and spend resumes) up to the account credit limit.

Extended the existing `_cost-state.ts` spend-guard family with a **proactive absolute per-UTC-day cap**:
- `api/_cost-state.ts` — new `getOfficialFr24CallsToday` / `getOfficialFr24DailyCap` / `isOfficialFr24DailyCapReached` / `recordOfficialFr24Call`; env `OFFICIAL_FR24_DAILY_CALL_CAP` (default **200**; explicit **0 = kill switch**). Reset wired into `__resetAdbSpendForTests`.
- `api/schedule.ts:958` — gate: skip the paid call once the daily cap is reached (single chokepoint, so it bounds *every* official-API caller).
- `api/schedule.ts:986` — record one committed call past all pre-flight skips (no token / 402 block / cap reached / unservable-tomorrow window), so skipped requests never burn budget.

**Spend-cap approach + limitation:** this is the *smaller in-file* extension the task allows. Like the pre-existing 15-min breaker it is **in-memory per lambda instance** (no Supabase write-through) — the cross-instance bound remains the reactive 402 block. A fully cross-instance ceiling would need a new provider-spend row/RPC (see `sql/009` for the ADB pattern); deliberately deferred to keep this DDL-free and surgical. It still closes the "window resets → unbounded daily total" gap and stops calling the paid API *before* hitting the credit ceiling.

### sql/015 — tracking file for already-applied prod DDL
`sql/015_revoke_anon_security_definer_rpcs.sql` — **already applied to prod live on 2026-07-23**; committed for repo parity only, **no deploy action required**. Revokes `anon/authenticated/PUBLIC` EXECUTE on the `SECURITY DEFINER` functions `increment_daily_usage` + `handle_new_user` (which bypass RLS — an anon-key holder could POST `/rest/v1/rpc/increment_daily_usage` with an arbitrary `user_id` to tamper quotas; dormant today but callable) and pins their `search_path = public`.

## Verification
- `bun run typecheck` (`tsc --noEmit`) — **passes clean**.
- Targeted suites (`cost-state-adb`, `schedule`, `hubs`, `fr24-usage`) — **89/89 pass**.
- Full `bun run build` skipped (Astro/Vite prod build, slow; unrelated to these API-layer changes).

Do **not** merge or deploy — review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)