### PR TITLE
fix(seo): make /tsa indexable again and restore it to the sitemap (v1.7.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.13] - 2026-07-27
+
+### Fixed
+- **The TSA page is indexable again.** `/tsa` still carried the `noindex, follow` meta from March (v1.5.x era), added when the live wait-times data was pulled and the page was dropped from the sitemap. The page has since been rebuilt as a full checkpoint guide (the WP2 truth sweep) and live TSA data is back via `/api/tsa` with an hourly refresh cron — but the stale `noindex` remained, and Google Search Console flagged it on July 27 as "Excluded by 'noindex' tag." The meta is now `index, follow` and `/tsa` is restored to the sitemap with its own lastmod paths. (`src/pages/tsa.astro`, `src/pages/sitemap.xml.ts`, `src/lib/buildMetadata.js`)
+
 ## [1.7.12] - 2026-07-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.12",
+  "version": "1.7.13",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/src/lib/buildMetadata.js
+++ b/src/lib/buildMetadata.js
@@ -91,6 +91,11 @@ export const newarkLastmodPaths = [
   'src/data/hubs/ewr.js',
 ];
 
+export const tsaLastmodPaths = [
+  'src/pages/tsa.astro',
+  'src/data/tsa/united-terminals.js',
+];
+
 export function xmlEscape(value) {
   return value
     .replaceAll('&', '&amp;')

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -10,6 +10,7 @@ import {
   hubIndexLastmodPaths,
   newarkLastmodPaths,
   newsIndexLastmodPaths,
+  tsaLastmodPaths,
   xmlEscape,
 } from '../lib/buildMetadata.js';
 
@@ -44,6 +45,7 @@ export function GET() {
       renderUrl(`/hubs/${key}`, getLastModified(getHubRouteLastmodPaths(key)), 'weekly', '0.8')
     ),
     renderUrl('/newark', getLastModified(newarkLastmodPaths), 'weekly', '0.8'),
+    renderUrl('/tsa', getLastModified(tsaLastmodPaths), 'weekly', '0.8'),
     renderUrl('/news', getLastModified(newsIndexLastmodPaths), 'daily', '0.9'),
     // Per-article lastmod — use the article's own publication date so each
     // entry has a distinct value. The previous getNewsRouteLastmodPaths call

--- a/src/pages/tsa.astro
+++ b/src/pages/tsa.astro
@@ -15,7 +15,7 @@ const faqEntries = getAllFaqEntries();
 <title>United Airlines TSA Checkpoints — Pre✓, CLEAR & Lane Guide at 7 Mainland Hubs | The Blue Board</title>
 <meta name="description" content="Complete TSA checkpoint guide for United Airlines terminals at its 7 mainland U.S. hubs (GUM and the Tokyo-Narita gateway don't have TSA checkpoints). Pre✓, CLEAR, Priority, and standard lane availability at ORD, DEN, IAH, EWR, SFO, IAD, and LAX. Checkpoint hours, tips, and which security line to use.">
 <meta name="author" content="The Blue Board">
-<meta name="robots" content="noindex, follow">
+<meta name="robots" content="index, follow">
 <link rel="canonical" href="https://theblueboard.co/tsa">
 <meta property="og:type" content="website">
 <meta property="og:locale" content="en_US">


### PR DESCRIPTION
## Why

Google Search Console emailed a new indexing reason for theblueboard.co on Jul 27: **Excluded by 'noindex' tag**.

A sweep of every sitemap URL plus the non-sitemap routes found exactly one 200-serving page with noindex: **/tsa**. The tag dates to 0fb4cfe (Mar 24, "live data removed, sitemap removed — Codex P3"). Since then the page was rebuilt as a full checkpoint guide in the WP2 truth sweep, and live TSA data is back via `/api/tsa` with an hourly `refresh-tsa` cron — the original reason for the gate no longer holds. Google just discovered the page (it's linked from the nav) and flagged it.

## What

- `src/pages/tsa.astro` — `noindex, follow` → `index, follow`
- `src/pages/sitemap.xml.ts` — `/tsa` restored (weekly, 0.8, own lastmod)
- `src/lib/buildMetadata.js` — new `tsaLastmodPaths` (page + united-terminals data)
- v1.7.13 bump + CHANGELOG

## Verification

- `bun run test`: 85 files, 1268 tests, all pass
- Local build: `dist/tsa.html` serves `index, follow`; `dist/sitemap.xml` contains `/tsa` with lastmod 2026-07-08

🤖 Generated with [Claude Code](https://claude.com/claude-code)