### PR TITLE
v1.7.14 fix: harden live feed, schedule freshness, and AI fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,20 @@ SCHEDULE_SOURCE_PRIORITY=provider
 # Same-day no-credit rescue: show active live FR24 flights when the full board is unavailable.
 SCHEDULE_LIVE_FEED_FALLBACK_ENABLED=true
 
+# /api/fr24-feed resilience (optional; defaults shown). FR24's free live feed intermittently 200s
+# with a meta-only body, in streaks of 1-5. The handler retries once (United only — "empty is never
+# truth" is a UA-specific claim) and otherwise serves its last-known-good payload as a 200 tagged
+# X-BB-Feed-Stale: <seconds>, which the dashboard uses to age its LIVE/STALE chip honestly.
+# FR24_FEED_STALE_SERVE_MAX_MS is the maximum age that may be served; the default is the client's own
+# FEED_FRESH_MS (src/lib/feed-health.js, 180000), so a stale-serve can never be older than the window
+# the chip would still call live. 0 disables stale-serve entirely and restores hard 503s. The value is
+# CLAMPED to 180000 — it can only tighten the ceiling, never loosen it, because hour-old positions
+# served as a 200 would also be stamped into the reg-sightings ledger as fresh sightings.
+# The resilience machinery (fresh cache, last-known-good, stale-serve, empty-feed retry) applies to
+# UAL only; the endpoint still answers other validated codes as plain rate-limited pass-throughs.
+# FR24_FEED_STALE_SERVE_MAX_MS=180000
+# FR24_EMPTY_RETRY_DELAY_MS=400
+
 # AeroDataBox = the full-board provider (REQUIRED for the forward schedule). Get a key at
 # https://api.market (product aedbx/aerodatabox, header x-magicapi-key) or RapidAPI. Free tier is
 # ~600 req-units/mo (FIDS = 2 units/call); a ~$5-30/mo tier is recommended for fresh all-hub refresh.
@@ -34,10 +48,21 @@ AERODATABOX_API_KEY=
 # SCHEDULE_WARM_DELAY_MS=3000
 # AERODATABOX_INTER_WINDOW_DELAY_MS=1500
 # Organic (non-cron) AeroDataBox spend gate, units/day. The warm cron BYPASSES this gate but still
-# records against it, so at the default stride the cron alone books ~384/day; raise this (e.g. 600)
-# if on-demand "yesterday" boards start getting blocked late in the UTC day. 0 = hard kill switch
-# for ALL metered spend. Default 400.
+# records against it, so at the default stride the cron alone books ~384/day — a FLOOR this budget
+# must sit comfortably above, or the organic path is starved from hour zero of every UTC day and
+# boards only ever refresh at warm-ring cadence. The code default of 400 leaves ~16 organic units/day
+# and is NOT a workable production value; production runs 700. Anything <= 450 logs a startup warning.
+# 0 = hard kill switch for ALL metered spend.
+# Under pacing (below), organic gating is a PRO-RATED LINE across the UTC day — each moment may have
+# spent only its slice so far, plus a 1h head start — not a late-day cliff. Raising the budget
+# changes the SLOPE of that line (units available per hour), it does not just move a wall further
+# out; the cron warm path is unaffected either way.
 # AERODATABOX_DAILY_UNIT_BUDGET=400
+# Pacing switch for the organic gate above. Default ON. Set to 0/off/false/no to restore the flat
+# first-come-first-served gate (spend freely until the whole daily budget is gone) — e.g. for a
+# deliberate backfill where front-loading the day is exactly what you want. UTC midnight is 7 PM CDT,
+# so with pacing off the US evening + overnight warms drain the pool before the next afternoon peak.
+# AERODATABOX_BUDGET_PACING=1
 
 # ScrapingBee has been REMOVED. The FR24 web scrape is Cloudflare-challenge-dead from datacenter IPs;
 # no free plain-fetch proxy can pass it, so there is no scraper transport in production.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.14] - 2026-08-04
+
+### Fixed
+- **The live map no longer errors when FR24's feed glitches — which it now does on ~20% of requests.** Since July 3, `/api/fr24-feed` returned 503 whenever FR24 served an empty body, and a direct probe showed those empties arrive in streaks (8 of 12 sequential upstream fetches, in runs of 2–5). The endpoint now retries once (UAL only — for United an empty feed is never truth) and, when upstream stays broken, serves its last-known-good UAL payload from up to 3 minutes ago as a 200 with an `X-BB-Feed-Stale` header. The ceiling is the client's own `FEED_FRESH_MS`, imported so the two can never drift, and the env override (`FR24_FEED_STALE_SERVE_MAX_MS`) can only tighten it. The dashboard reads the header, back-dates its freshness clock so the LIVE/STALE chip stays honest, and keeps the fast-retry ladder armed. The fallback state is deliberately United-only: the airline param is caller-controlled, and any per-airline store would hand curl a way to evict the one payload real users depend on. "Empty" is now decided by the client's own `parseFr24Feed` (entries need real positions), so a degraded all-null-position payload can't poison the fallback. First paint during a glitch shows planes instead of an error. (`api/fr24-feed.ts`, `src/lib/feed-health.js`, `src/dashboard/main.js`, `vercel.json`)
+- **AI delay explanations no longer hammer the gateway through a permission outage.** From Jul 28 to Aug 2 the AI Gateway rejected calls with 403 "Free tier users do not have access…", and because the AI-unavailable circuit only tripped on 402/billing-400, every click re-hit the gateway and logged a fresh error for the whole window. Account-level 403s now open the same 5-minute circuit and serve the calm fallback message; request-specific 403s get the graceful answer without switching the feature off for every visitor. (`api/delay-explain.ts`)
+
+### Changed
+- **Schedule refreshes are paced across the whole day instead of first-come-first-served.** The AeroDataBox daily budget resets at UTC midnight — 7 PM CDT — so evening traffic plus overnight warming drained the pool by ~1 PM and the board froze for exactly the afternoon hours delay drama peaks (observed Aug 4: 732/700 units spent, board stuck at "Statuses as of 1:02 PM CDT (3h old)"). On-demand refreshes are now gated against a pro-rated share of the budget (1-hour head start, same daily ceiling; `AERODATABOX_BUDGET_PACING=off` restores the old flat gate for deliberate backfills). Cron warming is unaffected, and while pacing — rather than true exhaustion — is holding the provider back, the paid FR24 official fallback stays off, so the pacing guard can never increase spend. A once-a-day warning now fires when the configured budget can't clear the warm cron's ~384 units/day floor. (`api/_cost-state.ts`, `api/_schedule-aerodatabox.ts`, `api/schedule.ts`, `.env.example`)
+
 ## [1.7.13] - 2026-07-27
 
 ### Fixed

--- a/TODOS.md
+++ b/TODOS.md
@@ -10,7 +10,7 @@
 - [ ] CI lint: ban inline `<script>` in public/index.html, ban raw `innerHTML` with template-literal interpolation, ban inline event handlers (`on*=` attributes).
 - [ ] Tighten CSP: drop `style-src 'unsafe-inline'` after inline-style audit.
 - [ ] Cost alerting: Anthropic + FR24 spend anomaly detection via Vercel log drain.
-- [ ] Circuit breakers / graceful degradation for FR24, Anthropic, Resend, Supabase. (partial: 60s negative cache + 4s timeout shipped for `api/predict-flight.ts` and `api/check-flight.ts` in v1.5.8)
+- [ ] Circuit breakers / graceful degradation for FR24, Anthropic, Resend, Supabase. (partial: 60s negative cache + 4s timeout shipped for `api/predict-flight.ts` and `api/check-flight.ts` in v1.5.8; FR24 live-feed last-known-good stale-serve + delay-explain gateway-403 circuit shipped in v1.7.14)
 - [ ] Feature kill-switches for non-core (waitlist, news-notify, delay-explain) via env flags.
 
 ### Security hygiene (backlog)

--- a/api/_cost-state.ts
+++ b/api/_cost-state.ts
@@ -133,6 +133,88 @@ export function isAdbBudgetExhausted(): boolean {
   return getAdbUnitsToday() >= getAdbDailyUnitBudget();
 }
 
+// ── Pacing the organic share of that budget across the UTC day ──
+//
+// The budget resets at UTC midnight, which is 7 PM CDT — the middle of the US evening. A flat
+// first-come-first-served gate therefore hands the whole day's pool to whoever asks first: US
+// evening traffic plus the overnight warm crons (~384 units/day, recorded against the organic pool
+// even though the cron path bypasses this gate) drain it by ~18:00 UTC, leaving ZERO organic units
+// for 18:00–24:00 UTC — 1 PM to 7 PM CDT, the exact hours delay drama peaks. Observed Aug 4 2026:
+// 732/700 units spent by 21:00 UTC with boards frozen at warm-ring cadence since "1:02 PM CDT
+// (3h old)".
+//
+// Linear pacing gives each moment of the UTC day only its pro-rated slice, so organic refreshes
+// trickle all day instead of binging early and starving the peak. The 1h head start means the pool
+// is never at literally zero right after rollover (~budget/24 is available immediately), which
+// keeps the first evening hour usable. The TOTAL daily ceiling is unchanged — at 23:00 UTC the
+// allowance is the full budget — and cron warms are unaffected (they take the bypassDailyBudget
+// path with its own 3x absolute ceiling).
+
+/** Units the organic path is allowed to have spent by `nowMs` within the current UTC day. */
+export function getAdbPacedAllowance(nowMs = Date.now()): number {
+  const budget = getAdbDailyUnitBudget();
+  if (budget <= 0) return 0;
+  const DAY_MS = 86_400_000;
+  const HEAD_START_MS = 3_600_000;
+  // Modulo twice so a negative epoch (pre-1970 clock skew) still lands inside the day.
+  const msIntoDay = ((nowMs % DAY_MS) + DAY_MS) % DAY_MS;
+  // Floor at 1 for any non-zero budget. floor(budget × 1h/24h) is 0 for every budget under 24, so a
+  // small-but-deliberate budget (say 12 units/day) would be gated to a complete standstill right
+  // after rollover — the opposite of the "never literally zero" promise above, and a silent full
+  // stop for exactly the operators who tuned the knob down on purpose. Only an explicit budget of 0
+  // — the kill switch, already returned above — is allowed to hand out nothing.
+  return Math.max(1, Math.min(budget, Math.floor((budget * (msIntoDay + HEAD_START_MS)) / DAY_MS)));
+}
+
+/**
+ * True when AERODATABOX_BUDGET_PACING is explicitly switched off, restoring the flat
+ * first-come-first-served gate. Trimmed + lowercased and accepting the same off-words as the rest
+ * of the codebase (see _official-fr24.ts), so a value pasted with stray whitespace or written as
+ * 'false' still does what the operator plainly meant.
+ */
+export function isAdbBudgetPacingDisabled(): boolean {
+  const setting = String(process.env.AERODATABOX_BUDGET_PACING ?? '').trim().toLowerCase();
+  return setting === '0' || setting === 'off' || setting === 'false' || setting === 'no';
+}
+
+// The hourly warm cron BYPASSES the organic gate but still records its units against this same
+// counter (~384/day at the default stride: 96 boards x 4 units). So the pool the organic path is
+// paced against is really "budget minus whatever the cron already booked" — and at the code default
+// of 400 that leaves ~16 units for the entire day. The boards do not break; they just quietly stop
+// refreshing outside the cron's ~6h ring, which reads as "the data is old" rather than "the budget
+// is misconfigured". Prod runs 700 for exactly this reason. One warn per instance per UTC day: this
+// is a config mistake that will not fix itself, and a per-call warn would drown the gate's own
+// (already hourly-throttled) log line.
+const ADB_CRON_UNITS_PER_DAY = 384;
+const ADB_MIN_WORKABLE_BUDGET = 450;
+let warnedStarvedBudgetDay = '';
+function warnIfBudgetStarvesOrganic(budget: number): void {
+  if (budget <= 0 || budget > ADB_MIN_WORKABLE_BUDGET) return;
+  const today = utcToday();
+  if (warnedStarvedBudgetDay === today) return;
+  warnedStarvedBudgetDay = today;
+  console.warn(
+    `AERODATABOX_DAILY_UNIT_BUDGET=${budget} cannot fund the warm cron AND organic refreshes: the ` +
+    `hourly warm cron alone consumes ~${ADB_CRON_UNITS_PER_DAY} units/day of this shared budget, so ` +
+    `organic refreshes will be starved from the start of the day. Raise it (production runs 700).`
+  );
+}
+
+/**
+ * True when the ORGANIC path should stop calling the provider right now — either the absolute
+ * daily budget is gone or today's spend has run ahead of its paced allowance. Sync; hot-path safe.
+ */
+export function isAdbOrganicRefreshGated(nowMs = Date.now()): boolean {
+  const budget = getAdbDailyUnitBudget();
+  warnIfBudgetStarvesOrganic(budget);
+  // The explicit-0 kill switch is absolute and must never be softened by pacing arithmetic.
+  if (budget === 0) return true;
+  // Escape hatch: AERODATABOX_BUDGET_PACING off restores the flat first-come-first-served gate
+  // (e.g. during a one-off backfill where front-loading the day is actually what you want).
+  if (isAdbBudgetPacingDisabled()) return isAdbBudgetExhausted();
+  return getAdbUnitsToday() >= getAdbPacedAllowance(nowMs);
+}
+
 /**
  * Record provider spend: bump the in-memory counter immediately, then write-through via the
  * atomic increment RPC and adopt the returned cross-instance total. Callers may ignore the
@@ -259,6 +341,7 @@ export function __resetAdbSpendForTests(): void {
   adbUnits = 0;
   lastAdbHydratedAt = 0;
   warnedAdbSchemaMissing = false;
+  warnedStarvedBudgetDay = '';
   officialFr24Day = '';
   officialFr24Calls = 0;
 }

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -2,7 +2,7 @@ import { waitUntil } from '@vercel/functions';
 import { HUB_TZ } from './irops.js';
 import { icaoToIata, isInternationalRoute } from '../src/lib/airport-metadata.js';
 import { getHubTerminal } from './_hubs.js';
-import { hydrateAdbSpend, isAdbBudgetExhausted, recordAdbUnits, getAdbUnitsToday, getAdbDailyUnitBudget } from './_cost-state.js';
+import { hydrateAdbSpend, isAdbOrganicRefreshGated, isAdbBudgetPacingDisabled, getAdbPacedAllowance, recordAdbUnits, getAdbUnitsToday, getAdbDailyUnitBudget } from './_cost-state.js';
 
 const AERODATABOX_BASE_URL = 'https://prod.api.market/api/v1/aedbx/aerodatabox';
 // Each FIDS window request is billed at 2 units by the provider (1 board = 2 windows = 4 units).
@@ -12,14 +12,18 @@ const ADB_UNITS_PER_REQUEST = 2;
 // spend far below this.
 const ADB_BYPASS_CEILING_MULTIPLIER = 3;
 
-// The "budget exhausted" warning previously fired on every gated organic request — dozens/hour for
-// ~11h/day once the budget trips, burying genuine warnings and inflating log-query latency. Throttle
-// it to once per instance per UTC day (mirrors warnedAdbSchemaMissing in _cost-state.ts).
-let lastBudgetWarnDay = '';
+// The gate warning previously fired on every gated organic request — dozens/hour for ~11h/day once
+// the budget tripped, burying genuine warnings and inflating log-query latency. Throttle it, but per
+// UTC HOUR rather than per UTC day: unlike the old flat budget (trips once, stays tripped), the
+// PACED gate is episodic by construction — spend crosses the pro-rated line, the line catches up,
+// spend crosses it again — so a once-per-day latch would report the 09:00 UTC episode and silently
+// swallow every afternoon one, hiding exactly the peak-hours behaviour this pacing was built for.
+// Hourly caps the volume at ≤24 lines per instance per day while preserving the shape of the day.
+let lastGateWarnHour = '';
 
-/** Test-only: clear the once-per-day warn throttle so per-test assertions start from a clean slate. */
+/** Test-only: clear the once-per-hour warn throttle so per-test assertions start from a clean slate. */
 export function __resetScheduleWarnsForTests(): void {
-  lastBudgetWarnDay = '';
+  lastGateWarnHour = '';
 }
 
 // Persist the spend write even if Vercel freezes the lambda right after the response is sent —
@@ -627,14 +631,23 @@ export async function fetchViaAeroDataBox(
       );
       return null;
     }
-  } else if (isAdbBudgetExhausted()) {
-    // Throttle: once the day's budget trips, every organic board load would otherwise log this —
-    // emit it once per instance per UTC day so the signal isn't drowned in its own repetition.
-    const today = new Date().toISOString().slice(0, 10);
-    if (lastBudgetWarnDay !== today) {
-      lastBudgetWarnDay = today;
+  } else if (isAdbOrganicRefreshGated()) {
+    // Paced gate (see _cost-state.ts): organic spend is capped at the day's pro-rated allowance,
+    // not just the absolute daily budget, so the US afternoon peak still has units left after the
+    // 7 PM CDT (UTC midnight) rollover crowd and the overnight warms.
+    // Throttle: once the gate trips, every organic board load would otherwise log this — emit it
+    // at most once per instance per UTC HOUR (see lastGateWarnHour above) so the signal isn't
+    // drowned in its own repetition without hiding the later episodes of a paced day.
+    const nowHour = new Date().toISOString().slice(0, 13); // YYYY-MM-DDTHH
+    if (lastGateWarnHour !== nowHour) {
+      lastGateWarnHour = nowHour;
+      // Report the rule that ACTUALLY tripped. With pacing switched off the gate is the flat
+      // absolute budget, and printing a paced allowance nobody is enforcing sends whoever reads
+      // this log chasing a line that does not exist.
       console.warn(
-        `AeroDataBox daily unit budget exhausted (${getAdbUnitsToday()}/${getAdbDailyUnitBudget()}); skipping further organic schedule fetches until next UTC day`
+        isAdbBudgetPacingDisabled()
+          ? `AeroDataBox daily unit budget exhausted (${getAdbUnitsToday()}/${getAdbDailyUnitBudget()}); pacing disabled; skipping organic schedule fetch`
+          : `AeroDataBox organic budget gate: ${getAdbUnitsToday()} units >= paced allowance ${getAdbPacedAllowance()} (budget ${getAdbDailyUnitBudget()}/day); skipping organic schedule fetch (cron warms unaffected)`
       );
     }
     return null;

--- a/api/delay-explain.ts
+++ b/api/delay-explain.ts
@@ -43,6 +43,25 @@ const AI_UNAVAILABLE_MSG =
 const AI_UNAVAILABLE_COOLDOWN_MS = 5 * 60 * 1000;
 let aiUnavailableUntil = 0;
 
+// One place to open the circuit, so the three ACCOUNT-level failure modes that share it (gateway 402
+// budget ceiling, gateway 403 tier/permission loss, Anthropic billing-400) cannot drift apart in
+// cooldown length or in what they log. `reason` is the only thing that varies.
+function openAiCircuit(reason: string): void {
+  aiUnavailableUntil = Date.now() + AI_UNAVAILABLE_COOLDOWN_MS;
+  console.warn(`Delay explain: ${reason} — AI-unavailable circuit open ${AI_UNAVAILABLE_COOLDOWN_MS / 1000}s`);
+}
+
+/**
+ * Test helper: close the AI-unavailable circuit and drop the explanation cache so module state does
+ * not leak between tests (repo convention: __resetRateLimitersForTests, __resetFeedStateForTests).
+ * Without this seam, tests that trip the circuit had to be ordered last or re-import the module.
+ * Production never calls it.
+ */
+export function __resetDelayExplainForTests(): void {
+  aiUnavailableUntil = 0;
+  cache.clear();
+}
+
 // Per-request input spend cap. Output is already bounded by max_tokens: 400; this bounds input so a
 // crafted-but-origin-valid POST can't inflate prompt tokens. Each field is already truncated by
 // sanitize(); this is a belt-and-suspenders ceiling on the assembled prompt.
@@ -221,8 +240,33 @@ Deliver 2-4 sentences of direct, specific analysis grounded in the provided data
     // gateway analog of Anthropic's billing-400 below. Trip the same circuit so we stop hammering it
     // and serve the calm 200 the modal renders as plain text.
     if (e.status === 402) {
-      aiUnavailableUntil = Date.now() + AI_UNAVAILABLE_COOLDOWN_MS;
-      console.warn(`Delay explain: AI Gateway budget/credit error (402) — AI-unavailable circuit open ${AI_UNAVAILABLE_COOLDOWN_MS / 1000}s`);
+      openAiCircuit('AI Gateway budget/credit error (402)');
+      return res.status(200).json({ explanation: AI_UNAVAILABLE_MSG, unavailable: true });
+    }
+    // The gateway rejects with 403 PermissionDenied when the ACCOUNT tier loses access to the
+    // model — observed Jul 28–Aug 2 2026 as "Free tier users do not have access to …" after the
+    // gateway's credits dipped to free tier. Without special handling that fell to the generic 502
+    // and every click re-hit the gateway for the whole outage window. (The handler's own
+    // origin-check 403 is a plain return before the try, so a THROWN 403 here is always from the
+    // gateway/SDK call.)
+    //
+    // Every 403 still gets the graceful 200 — it is never retryable for this request — but only an
+    // ACCOUNT-level one opens the SHARED circuit, mirroring the billing-400 branch below. A
+    // request-specific gateway 403 (a rejected model route, a per-request policy denial) must not
+    // disable "Explain Delay Risk" for every visitor for the next five minutes.
+    //
+    // The matcher is deliberately narrow on WHOLE phrases: bare `tier`/`plan`/`account` are
+    // substrings of 'frontier', 'plane'/'flight plan' and 'accounted', all flight-context words that
+    // can echo back inside an upstream error message and open a shared five-minute circuit on a
+    // request-specific rejection. `permission` stays in with eyes open — an Anthropic-shaped 403 body
+    // carries "type":"permission_error", so a per-request policy denial can match it — because in
+    // this stack gateway 403s are near-always account-level, the cost of a false positive is one
+    // self-healing 5-minute window of the calm 200, and the cost of a false NEGATIVE is missing the
+    // real outage signature and re-hitting the gateway on every click for hours (Jul 28–Aug 2).
+    if (e.status === 403) {
+      const msg = String(e?.error?.error?.message || e?.message || '').toLowerCase();
+      const isAccountLevel = /free tier|do not have access|permission/i.test(msg);
+      if (isAccountLevel) openAiCircuit('AI Gateway permission error (403)');
       return res.status(200).json({ explanation: AI_UNAVAILABLE_MSG, unavailable: true });
     }
     // Anthropic rejects a credit/billing problem as a 400 (no tokens billed). Don't surface it as a
@@ -233,10 +277,7 @@ Deliver 2-4 sentences of direct, specific analysis grounded in the provided data
     if (e.status === 400) {
       const msg = String(e?.error?.error?.message || e?.message || '').toLowerCase();
       const isBilling = /credit balance|too low|billing|payment|insufficient|quota|upgrade|plan/.test(msg);
-      if (isBilling) {
-        aiUnavailableUntil = Date.now() + AI_UNAVAILABLE_COOLDOWN_MS;
-        console.warn(`Delay explain: Anthropic billing/credit error — AI-unavailable circuit open ${AI_UNAVAILABLE_COOLDOWN_MS / 1000}s`);
-      }
+      if (isBilling) openAiCircuit('Anthropic billing/credit error');
       return res.status(200).json({ explanation: AI_UNAVAILABLE_MSG, unavailable: true });
     }
     return res.status(502).json({ error: 'AI analysis temporarily unavailable' });

--- a/api/fr24-feed.ts
+++ b/api/fr24-feed.ts
@@ -2,7 +2,7 @@ import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
 import { CacheStore } from './_cache.js';
 import { waitUntil } from '@vercel/functions';
-import { parseFr24Feed } from '../src/lib/feed-health.js';
+import { parseFr24Feed, FEED_FRESH_MS } from '../src/lib/feed-health.js';
 import { recordFeedSightings } from './_reg-sightings.js';
 
 const isRateLimited = createRateLimiter('fr24-feed', 30);
@@ -14,15 +14,71 @@ class EmptyFeedError extends Error {
   constructor() { super('Upstream returned empty feed'); this.name = 'EmptyFeedError'; }
 }
 
-// Aircraft entries are every key in the feed body that maps to a position array; the only
-// non-aircraft keys FR24 sends are scalar metadata like full_count/version/stats.
-export function countFeedAircraft(payload: any): number {
-  if (!payload || typeof payload !== 'object') return 0;
-  let count = 0;
-  for (const value of Object.values(payload)) {
-    if (Array.isArray(value)) count++;
-  }
-  return count;
+const FR24_UPSTREAM_TIMEOUT_MS = 15_000;
+
+// Wall-clock budget for ALL upstream work in one invocation, retry included. vercel.json caps this
+// function at maxDuration: 30, and the platform kill lands BEFORE our catch runs — so an invocation
+// that spends the whole 30s upstream never reaches the stale-serve fallback, which is exactly the
+// slowest failure mode stale-serve exists for (a slow empty 200 + a hung retry is ~30.4s of naive
+// per-attempt timeouts). Every attempt is clamped to what is left of this deadline, and the retry is
+// skipped outright when it cannot fit, leaving ~5s for the catch, JSON serialization and teardown.
+const FR24_UPSTREAM_DEADLINE_MS = 25_000;
+
+// Gap between the two upstream attempts. FR24's empty responses are served fast (they are not
+// timeouts), so a short pause is enough to land on a different upstream shard/refresh tick.
+// Overridable via FR24_EMPTY_RETRY_DELAY_MS so tests can zero it instead of burning real seconds.
+const FR24_EMPTY_RETRY_DELAY_DEFAULT_MS = 400;
+
+// Last successful UNITED payload, kept so a failing upstream can be papered over with a
+// recent-but-real feed instead of a 503 that blanks nothing but still counts as an outage.
+//
+// A single slot, not a map keyed by the request's `airline`: this endpoint is unauthenticated and
+// that param is caller-controlled, so a per-airline store (however carefully LRU'd) hands anyone a
+// free way to disarm the fallback — eight curl requests with other real ICAO codes recency-evict
+// UAL, and the next real outage 503s the dashboard. Every product consumer asks for UAL
+// (src/dashboard/main.js, public/js/hub-live-data.js, public/js/newark-live.js), so the one payload
+// worth remembering is the one nobody can name their way out of.
+let lastGoodUal: { payload: any; at: number } | null = null;
+
+// Shared parsing for this handler's numeric env knobs. A DEFINED-BUT-BLANK variable (Vercel stores
+// an empty string when an env row exists with no value) must read as UNSET: Number('') is 0, which
+// on the stale-serve knob would silently arm the kill switch on a deploy nobody meant to change.
+// An explicit '0' is still honoured as 0; garbage and negatives fall back to the default.
+function envMs(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === null || String(raw).trim() === '') return fallback;
+  const configured = Number(raw);
+  return Number.isFinite(configured) && configured >= 0 ? configured : fallback;
+}
+
+// How old a last-known-good payload may be and still be served as a 200. The default IS the client's
+// own FEED_FRESH_MS (src/lib/feed-health.js), imported rather than re-typed so the two can never
+// drift: the LIVE/STALE chip is keyed to payload age, so a payload inside that window is exactly
+// what the client would still be calling "live" if its own last poll had succeeded. An explicit 0
+// disables stale-serve (operator wants hard failures).
+//
+// CLAMPED to that same FEED_FRESH_MS, because the knob only ever moves in the dangerous direction:
+// an operator reaching for it during an outage would type something like 3600000, and hour-old
+// positions served as a clean 200 are not just a lying LIVE chip — the client stamps that payload
+// into the reg-sightings ledger as a fresh flight→tail sighting. The env var can therefore only
+// TIGHTEN the ceiling (0 = kill switch, still honoured), never loosen it.
+function getStaleServeMaxMs(): number {
+  return Math.min(envMs('FR24_FEED_STALE_SERVE_MAX_MS', FEED_FRESH_MS), FEED_FRESH_MS);
+}
+
+function getEmptyRetryDelayMs(): number {
+  return envMs('FR24_EMPTY_RETRY_DELAY_MS', FR24_EMPTY_RETRY_DELAY_DEFAULT_MS);
+}
+
+/**
+ * Test helper: clear every module-level feed store so one test's payloads cannot leak into the next
+ * (repo convention: __resetRateLimitersForTests, __resetAdbSpendForTests). Without it, test files
+ * have to encode "which airline codes are still cold" as declaration order. Production never calls it.
+ */
+export function __resetFeedStateForTests(): void {
+  lastGoodUal = null;
+  feedCache.clear();
+  feedFetching.clear();
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -39,24 +95,44 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(429).json({ error: 'Rate limited — try again shortly' });
   }
 
+  // Normalize BEFORE the regex: a repeated query param (?airline=a&airline=b) arrives as a string[],
+  // and a bare `?airline` can arrive as ''/true depending on the parser. Since this block now sits
+  // OUTSIDE the try (see below), a non-string reaching .test()/.toUpperCase() would surface as an
+  // unhandled 500 instead of the intended 400 — a crafted query must not be able to crash the route.
+  const rawAirline = req.query?.airline as unknown;
+  const airlineParam = Array.isArray(rawAirline) ? rawAirline[0] : rawAirline;
+  const airline = typeof airlineParam === 'string' && airlineParam ? airlineParam : 'UAL';
+  // Validate airline: 2-4 letter ICAO code. Validation + cacheKey live ABOVE the try so the catch
+  // can look up this airline's last-known-good payload; an invalid code has no feed to fall back
+  // to and keeps its plain 400.
+  if (!/^[A-Z0-9]{2,4}$/i.test(airline)) {
+    return res.status(400).json({ error: 'Invalid airline code' });
+  }
+
+  const normalizedAirline = airline.toUpperCase();
+  const cacheKey = `feed:${normalizedAirline}`;
+  // Every resilience mechanism below (fresh cache, last-known-good, stale-serve, the empty-feed
+  // retry) is UNITED-ONLY. The endpoint still answers any validated code for compatibility, but a
+  // caller-controlled key must never occupy or evict the state real users depend on: feedCache holds
+  // exactly one entry, so alternating codes would thrash it into uselessness, and a per-airline
+  // last-known-good store is evictable by anyone with curl. Non-UAL requests are therefore
+  // rate-limited, validated pass-throughs — no cache read, no cache write, no stale fallback. That
+  // costs them nothing real: "an empty feed is never truth" is a claim about United specifically, so
+  // for any other code an empty sky can be the honest answer and a 5xx the honest failure.
+  const isUal = normalizedAirline === 'UAL';
+
   try {
-    const airline = (req.query.airline as string) || 'UAL';
-    // Validate airline: 2-4 letter ICAO code
-    if (!/^[A-Z0-9]{2,4}$/i.test(airline)) {
-      return res.status(400).json({ error: 'Invalid airline code' });
-    }
-
-    const normalizedAirline = airline.toUpperCase();
-    const cacheKey = `feed:${normalizedAirline}`;
-
     // Return cached if fresh
-    const hit = feedCache.get(cacheKey);
+    const hit = isUal ? feedCache.get(cacheKey) : null;
     if (hit) {
       res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate=30');
       return res.status(200).json(hit);
     }
 
-    // Dedup: if already fetching, wait for that
+    // Dedup: if already fetching, wait for that. This one DOES stay per-airline — it holds only
+    // promises for requests currently in flight and deletes itself in a finally, so it can neither
+    // grow unbounded nor evict anything; sharing a concurrent fetch is pure upstream-amplification
+    // relief, which matters most for exactly the caller-supplied codes that get no caching.
     const inFlight = feedFetching.get(cacheKey);
     if (inFlight) {
       const data = await inFlight;
@@ -64,29 +140,78 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(200).json(data);
     }
 
-    const doFetch = async () => {
+    // One upstream attempt, with its OWN controller/timeout — a retried attempt must never inherit
+    // the first attempt's already-armed (or already-fired) abort signal.
+    const fetchUpstreamOnce = async (deadline: number) => {
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 15000);
-      const upstream = await fetch(`https://data-cloud.flightradar24.com/zones/fcgi/feed.js?airline=${encodeURIComponent(normalizedAirline)}`, {
-        signal: controller.signal,
-        headers: {
-          'User-Agent': 'TheBlueBoardDashboard/1.0 (https://theblueboard.co)',
-          'Accept': 'application/json'
+      // Clamp each attempt to whatever is left of the invocation budget, never just its own 15s:
+      // two naive 15s attempts overshoot maxDuration and the platform kills us before the catch
+      // can stale-serve. The 2s floor keeps a nearly-spent budget making a real (if brief) attempt
+      // rather than aborting on arrival.
+      const attemptTimeoutMs = Math.max(2000, Math.min(FR24_UPSTREAM_TIMEOUT_MS, deadline - Date.now()));
+      const timeout = setTimeout(() => controller.abort(), attemptTimeoutMs);
+      try {
+        const upstream = await fetch(`https://data-cloud.flightradar24.com/zones/fcgi/feed.js?airline=${encodeURIComponent(normalizedAirline)}`, {
+          signal: controller.signal,
+          headers: {
+            'User-Agent': 'TheBlueBoardDashboard/1.0 (https://theblueboard.co)',
+            'Accept': 'application/json'
+          }
+        });
+        if (!upstream.ok) {
+          // Drain before discarding: an undrained body keeps its socket checked out of the agent
+          // pool until GC, and this branch is the one that fires in bursts (sustained upstream 5xx).
+          // Same reason the AeroDataBox fetcher reads the body on its !ok path.
+          await upstream.text().catch(() => '');
+          throw new Error('Upstream service unavailable');
         }
-      });
-      clearTimeout(timeout);
-      if (!upstream.ok) throw new Error('Upstream service unavailable');
-      const payload = await upstream.json();
+        return await upstream.json();
+      } finally {
+        clearTimeout(timeout);
+      }
+    };
+
+    const doFetch = async () => {
       // The feed occasionally 200s with a meta-only body ({full_count, version} and zero
       // aircraft entries). Caching/serving that as success wipes the client's map and boards
       // ("NO DATA" cold-load bug, Jul 3 2026 audit). United always has aircraft airborne, so an
       // empty feed is an upstream glitch, never truth — surface it as an error so the client's
       // failure/retry path handles it and CDN/browser caches never store the empty body.
-      if (countFeedAircraft(payload) === 0) throw new EmptyFeedError();
+      //
+      // Retry once before giving up: an Aug 4 2026 probe of the upstream (12 sequential fetches:
+      // 708, 0, 0, 706, 708, 0, 0, 0, 0, 0, 712, 0) shows the empties are a fast upstream glitch,
+      // and a single re-ask recovers whenever the streak is only one deep. Streaks of 2-5 are
+      // common though, which is why the retry alone is not the fix — the catch's last-known-good
+      // fallback is (this pass turned ~20% of requests into 503s, Jul 3 → Aug 4 2026).
+      //
+      // "Empty" is decided by the CLIENT's own parseFr24Feed, not by counting array-valued keys.
+      // The two disagree on a degraded payload of aircraft entries with null positions: key-counting
+      // calls that a success, so it would be cached, written to the last-known-good slot and then
+      // stale-served for the next three minutes — while every client that receives it parses zero
+      // flights and renders NO DATA. A permanent lie is strictly worse than the 503 this guard was
+      // built to raise, so the server's success predicate has to be the client's.
+      const deadline = Date.now() + FR24_UPSTREAM_DEADLINE_MS;
+      let payload = await fetchUpstreamOnce(deadline);
+      let parsed = parseFr24Feed(payload);
+      if (parsed.length === 0) {
+        const retryDelayMs = getEmptyRetryDelayMs();
+        // The retry is UNITED-ONLY. "Empty is never truth" is a claim about UA specifically (always
+        // hundreds airborne); for any other caller-supplied code an empty feed may be the honest
+        // answer, and re-asking would just double the upstream amplification an attacker gets for
+        // free from the open `airline` param. Also skip it when the remaining budget cannot hold the
+        // pause plus a meaningful attempt — better to fall to stale-serve than be killed mid-retry.
+        const canRetry = isUal && (deadline - Date.now()) >= retryDelayMs + 2000;
+        if (!canRetry) throw new EmptyFeedError();
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+        payload = await fetchUpstreamOnce(deadline);
+        parsed = parseFr24Feed(payload);
+        if (parsed.length === 0) throw new EmptyFeedError();
+      }
       // Phase 2: harvest flight→tail sightings from every FRESH feed fetch (cache hits carry
       // nothing new). Throttled inside recordFeedSightings (≤1 upsert/min/instance) and
-      // fire-and-forget — sighting capture must never delay or fail the feed serve.
-      const sightingsTask = recordFeedSightings(parseFr24Feed(payload));
+      // fire-and-forget — sighting capture must never delay or fail the feed serve. Reuses the
+      // parse above rather than re-parsing ~700 aircraft a second time.
+      const sightingsTask = recordFeedSightings(parsed);
       try { waitUntil(sightingsTask); } catch { /* waitUntil unavailable (local dev) — promise still runs best-effort */ }
       return payload;
     };
@@ -95,13 +220,46 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       const inFlightRequest = doFetch();
       feedFetching.set(cacheKey, inFlightRequest);
       const data = await inFlightRequest;
-      feedCache.set(cacheKey, data);
+      if (isUal) {
+        feedCache.set(cacheKey, data);
+        lastGoodUal = { payload: data, at: Date.now() };
+      }
       res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate=30');
       return res.status(200).json(data);
     } finally {
       feedFetching.delete(cacheKey);
     }
   } catch (e: any) {
+    // Bounded stale-serve, ahead of every error response. Whatever the failure mode (empty feed,
+    // upstream timeout, upstream 5xx), a real payload from ≤3 min ago beats an error the client can
+    // only answer by holding the SAME payload it already has — 1,062 of ~5,200 requests/24h were
+    // 503ing this way (Aug 4 2026). The ceiling is the client's own FEED_FRESH_MS, so the LIVE chip
+    // can never overclaim by more than one fresh-window. Deliberately NOT feedCache.set: caching
+    // this would restart the 15s fresh window on old data and stop us from re-trying upstream on
+    // the next poll. UAL-only, for the reason spelled out at `isUal` above.
+    const lastGood = isUal ? lastGoodUal : null;
+    const staleServeMaxMs = getStaleServeMaxMs();
+    if (lastGood && staleServeMaxMs > 0) {
+      const ageMs = Math.max(0, Date.now() - lastGood.at);
+      if (ageMs <= staleServeMaxMs) {
+        const ageSec = Math.round(ageMs / 1000);
+        // warn, not error: from the caller's side this request SUCCEEDED. Logging it at error level
+        // (as this path originally did) leaves the error feed unable to tell a real outage from one
+        // absorbed by stale-serve — and shrinking the first number is the entire point of this pass.
+        console.warn(`FR24 feed upstream failed — served last-known-good (${ageSec}s old):`, e?.message || e);
+        // Let the CDN share this body for whatever is LEFT of its freshness window, capped at the
+        // 15s the fresh path uses. Unconditional no-store made every client in an outage re-ask the
+        // origin independently — the stampede the stale body exists to absorb — while an unclamped
+        // TTL could let an edge serve a payload past the age the client would still call live.
+        // Nothing left → no-store: an expired body must never be cacheable.
+        const shareable = Math.max(0, Math.min(15, Math.floor((staleServeMaxMs - ageMs) / 1000)));
+        res.setHeader('Cache-Control', shareable > 0 ? `s-maxage=${shareable}` : 'no-store');
+        res.setHeader('X-BB-Feed-Stale', String(ageSec));
+        return res.status(200).json(lastGood.payload);
+      }
+    }
+
+    // Past here the request genuinely fails — these are the entries the error feed should count.
     console.error('FR24 feed error:', e);
     if (e.name === 'AbortError') return res.status(504).json({ error: 'Upstream timeout' });
     if (e.name === 'EmptyFeedError') {

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
 import { loadScheduleSnapshot, saveScheduleSnapshot, isSnapshotCandidateBetter } from './_schedule-snapshots.js';
-import { hydrateQuotaBlock, getMirroredQuotaBlockedUntil, persistQuotaBlock, resetMirroredQuotaBlock, __resetAdbSpendForTests, isOfficialFr24DailyCapReached, recordOfficialFr24Call, getOfficialFr24CallsToday, getOfficialFr24DailyCap } from './_cost-state.js';
+import { hydrateQuotaBlock, getMirroredQuotaBlockedUntil, persistQuotaBlock, resetMirroredQuotaBlock, __resetAdbSpendForTests, isOfficialFr24DailyCapReached, recordOfficialFr24Call, getOfficialFr24CallsToday, getOfficialFr24DailyCap, isAdbOrganicRefreshGated, isAdbBudgetExhausted } from './_cost-state.js';
 import { UNITED_HUB_SET, getHubTerminal } from './_hubs.js';
 import { isAuthorizedCronRequest } from './_cron-auth.js';
 import { isOfficialFr24Enabled } from './_official-fr24.js';
@@ -1415,6 +1415,26 @@ async function fetchAllPages(
   }
 
   if (srcPriority === 'provider') {
+    // SPEND GUARD, SNAPSHOT BEFORE THE PROVIDER CALL: fetchViaAeroDataBox returns null for the PACED
+    // organic gate too — spend is ahead of the day's pro-rated line while the absolute budget is
+    // untouched (_cost-state.ts). That state covers many more hours/day than the old flat gate ever
+    // did, and falling through it to the PAID official API would push organic traffic onto a
+    // COSTLIER provider whose only daily ceiling is per-instance — the pacing guard would then
+    // increase spend instead of bounding it. So: while only pacing is holding the provider back,
+    // official stays off. When the budget is TRULY exhausted the legacy behaviour is preserved
+    // (official still allowed, bounded by its own 402 block / 15-min breaker / daily cap), as it is
+    // for budget-exempt cron warms. The FREE live-feed rescue inside tryScheduleRescue runs either
+    // way, so the board still degrades gracefully.
+    //
+    // Read BEFORE the attempt, not after, because the attempt itself moves both inputs. The provider
+    // records its units before the HTTP call, so a call that then 5xx'd or timed out can push spend
+    // past the paced line and self-trigger this guard — suppressing the healthy paid rescue for a
+    // failure that had nothing to do with pacing. Same for a missing key or a thrown error landing
+    // near the line. Suppression must mean "pacing was already gating us when we asked", so a
+    // provider FAILURE with the gate open beforehand keeps the official rescue available exactly as
+    // it was before pacing existed.
+    const pacedOnlyGate = !options.providerBudgetExempt && isAdbOrganicRefreshGated() && !isAdbBudgetExhausted();
+
     // Primary: AeroDataBox returns the full forward schedule (incl. not-yet-departed flights).
     if (allowProviderFallback && process.env.AERODATABOX_API_KEY) {
       try {
@@ -1432,9 +1452,10 @@ async function fetchAllPages(
     }
     // Provider unavailable/empty -> FR24 official (active+completed, breaker-gated) + free live feed.
     // disableOfficialSource (officialFallback=0, e.g. cron) keeps official off so background warming
-    // never burns FR24 credits; it then degrades to the free live feed.
+    // never burns FR24 credits; it then degrades to the free live feed. `pacedOnlyGate` is the
+    // snapshot taken above, before the provider attempt (see its comment for why).
     const fallback = await tryScheduleRescue(
-      logHub, dir, ts, effectiveDeadline, false, !options.disableOfficialSource, !!options.providerBudgetExempt
+      logHub, dir, ts, effectiveDeadline, false, !options.disableOfficialSource && !pacedOnlyGate, !!options.providerBudgetExempt
     );
     if (fallback) return fallback;
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "jonahberg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -12,7 +12,7 @@ import { getStartOfHubDay, getHubDayLabel, defaultSchedDayOffset } from '../lib/
 import { classifyConnection, MIN_CONNECTION_TIMES, TERMINAL_WALK_TIMES } from '../lib/connection-risk.js';
 import { formatDataAge, dataAgeSeverity } from '../lib/data-age.js';
 import { formatTimeWithTz } from '../lib/time-format.js';
-import { parseFr24Feed, applyFeedResult, feedFreshness, nextFeedRetryDelay } from '../lib/feed-health.js';
+import { parseFr24Feed, applyFeedResult, feedFreshness, nextFeedRetryDelay, parseStaleHeader } from '../lib/feed-health.js';
 import { formatDelayMinutes, delayColorVar } from '../lib/delay-format.js';
 import { firstFutureIndex, nowDividerIndex, effectiveRowTime } from '../lib/board-now.js';
 import { deriveOpsHealth, hubProgramMarker } from '../lib/ops-health.js';
@@ -1126,18 +1126,47 @@ async function refreshFlights() {
     const result = applyFeedResult(allFlights, parseFr24Feed(data));
     if (!result.ok) throw new Error('empty feed (zero aircraft in payload)');
 
-    // Healthy live feed: commit the new flights and show LIVE.
+    // Commit the flights either way: the payload is real whether it came from a live upstream
+    // fetch or the server's bounded stale-serve.
     allFlights = result.flights;
     recordRegSightings(allFlights);
-    lastGoodFeedTs = Date.now();
-    feedRetryAttempt = 0;
-    const dot = document.getElementById('status-dot');
-    dot.className = 'status-dot live';
-    dot.style.background = ''; // clear the yellow inline override a prior failure set — dot and label must agree
-    document.getElementById('status-text').textContent = 'LIVE';
-    document.getElementById('header-flight-count').textContent = '· ' + allFlights.length + ' flights';
     const errOverlay = document.getElementById('map-error-overlay');
     if (errOverlay) errOverlay.remove();
+
+    // X-BB-Feed-Stale (seconds) marks a 200 the server built from ITS last-known-good payload
+    // because upstream failed (api/fr24-feed.ts). Treating that as a clean poll would lie twice:
+    // lastGoodFeedTs = now makes the chip claim LIVE off data already up to FEED_FRESH_MS old, and
+    // zeroing feedRetryAttempt disarms the fast-retry ladder at the exact moment upstream is known
+    // broken. Instead: backdate the timestamp by the reported staleness and stay on the failure
+    // cadence, so the client keeps probing until it gets a genuinely fresh feed.
+    const staleMs = parseStaleHeader(res.headers.get('X-BB-Feed-Stale'));
+    const dot = document.getElementById('status-dot');
+    if (staleMs > 0) {
+      lastGoodFeedTs = Date.now() - staleMs;
+      feedFailed = true; // keeps the finally block on the 5s → 10s → 20s → 30s retry ladder
+      // Chip from the same age-keyed rule the catch path uses. The server bounds staleMs at
+      // FEED_FRESH_MS, so a LIVE reading here is exactly as honest as a failed poll against
+      // still-fresh data — never an overclaim.
+      if (feedFreshness(staleMs) === 'live') {
+        dot.className = 'status-dot live';
+        dot.style.background = '';
+        document.getElementById('status-text').textContent = 'LIVE';
+        document.getElementById('header-flight-count').textContent = '· ' + allFlights.length + ' flights';
+      } else {
+        dot.className = 'status-dot';
+        dot.style.background = '#EAB308';
+        document.getElementById('status-text').textContent = 'STALE';
+        document.getElementById('header-flight-count').textContent = '· ' + allFlights.length + ' flights (stale)';
+      }
+    } else {
+      // Healthy live feed: commit the new flights and show LIVE.
+      lastGoodFeedTs = Date.now();
+      feedRetryAttempt = 0;
+      dot.className = 'status-dot live';
+      dot.style.background = ''; // clear the yellow inline override a prior failure set — dot and label must agree
+      document.getElementById('status-text').textContent = 'LIVE';
+      document.getElementById('header-flight-count').textContent = '· ' + allFlights.length + ' flights';
+    }
   } catch (e) {
     // Shared failure path for zero-flight 200s, 5xx (incl. the server's new empty-upstream 503),
     // and network errors. Never wipes allFlights; a fast retry is scheduled in finally.

--- a/src/lib/feed-health.js
+++ b/src/lib/feed-health.js
@@ -75,6 +75,19 @@ export function feedFreshness(msSinceLastGood, freshMs = FEED_FRESH_MS) {
 }
 
 /**
+ * Read the server's `X-BB-Feed-Stale` header into milliseconds. /api/fr24-feed sets it
+ * (in SECONDS) when it answers a 200 from ITS last-known-good payload because upstream
+ * failed — a real body, but already up to FEED_FRESH_MS old. Anything absent, blank,
+ * zero, negative, or unparseable means "not a stale-serve" and returns 0, so the poll
+ * loop's normal fresh-success path applies unchanged. The caller uses the returned age
+ * to backdate lastGoodFeedTs, keeping the LIVE/STALE chip honest about what it is showing.
+ */
+export function parseStaleHeader(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n * 1000 : 0;
+}
+
+/**
  * Fast-retry schedule after a failed/empty poll, separate from the normal 30s
  * cadence: 5s → 10s → 20s, then capped at the normal 30s poll interval.
  */

--- a/tests/cost-state-adb.test.js
+++ b/tests/cost-state-adb.test.js
@@ -12,6 +12,9 @@ import {
   recordAdbUnits,
   getAdbUnitsToday,
   isAdbBudgetExhausted,
+  isAdbOrganicRefreshGated,
+  isAdbBudgetPacingDisabled,
+  getAdbPacedAllowance,
   hydrateAdbSpend,
   __resetAdbSpendForTests,
 } from '../api/_cost-state.js';
@@ -149,6 +152,171 @@ describe('AeroDataBox daily unit budget (cost-state)', () => {
   });
 });
 
+// The UTC-midnight reset lands at 7 PM CDT, so a flat first-come-first-served budget was drained by
+// the US evening + overnight warm crons before the US afternoon peak ever started (Aug 4 2026:
+// 732/700 units by 21:00 UTC, boards frozen at "1:02 PM CDT (3h old)"). Pacing hands out only the
+// day's pro-rated slice — same daily ceiling, spread across all 24 hours.
+describe('AeroDataBox paced organic allowance', () => {
+  const atUtc = (h, m = 0) => Date.UTC(2026, 7, 4, h, m, 0);
+
+  beforeEach(() => {
+    __resetAdbSpendForTests();
+    supabaseMocks.getSupabaseAdmin.mockReset();
+    supabaseMocks.getSupabaseAdmin.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.AERODATABOX_DAILY_UNIT_BUDGET;
+    delete process.env.AERODATABOX_BUDGET_PACING;
+    __resetAdbSpendForTests();
+  });
+
+  it('pro-rates the budget across the UTC day, with a 1h head start and a full-budget cap', () => {
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '700';
+    // Literal expected values, not a copy of the implementation's formula — a copied formula would
+    // happily agree with a broken implementation. Derivations for budget=700:
+    //   00:00 UTC -> floor(700 x  1/24) =  29   (the 1h head start, immediately usable)
+    //   12:00 UTC -> floor(700 x 13/24) = 379
+    //   23:00 UTC -> floor(700 x 24/24) = 700   (head start makes the full budget reachable at 23:00)
+    // Right at rollover the pool is not zero, so the 7 PM CDT crowd is throttled, not locked out.
+    expect(getAdbPacedAllowance(atUtc(0))).toBe(29);
+    expect(getAdbPacedAllowance(atUtc(12))).toBe(379);
+    // ...and never exceeds the budget after — the total daily ceiling is unchanged by pacing.
+    expect(getAdbPacedAllowance(atUtc(23))).toBe(700);
+    expect(getAdbPacedAllowance(atUtc(23, 59))).toBe(700);
+  });
+
+  it('never hands out a literal zero for a small-but-nonzero budget', () => {
+    // floor(budget x 1/24) is 0 for every budget under 24, so at 00:00 UTC a deliberately small
+    // budget used to gate organic refreshes to a DEAD STOP — the exact opposite of the "never
+    // literally zero" promise, and a silent full outage for the operators who tuned the knob down.
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '20';
+    expect(getAdbPacedAllowance(atUtc(0))).toBeGreaterThanOrEqual(1);
+    expect(isAdbOrganicRefreshGated(atUtc(0))).toBe(false); // 0 units spent — the gate must be open
+    // The floor never lets the allowance exceed the budget itself.
+    expect(getAdbPacedAllowance(atUtc(0))).toBeLessThanOrEqual(20);
+  });
+
+  it('keeps a negative epoch (clock skew) inside [1..budget]', () => {
+    // The double modulo exists so a pre-1970 clock still lands inside a day; pin the invariant
+    // rather than the arithmetic, since the only thing that matters is that it stays in range.
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '700';
+    for (const nowMs of [-1, -1000, -86_400_000, -86_400_000 * 3 - 43_200_000]) {
+      const allowance = getAdbPacedAllowance(nowMs);
+      expect(allowance, `nowMs=${nowMs}`).toBeGreaterThanOrEqual(1);
+      expect(allowance, `nowMs=${nowMs}`).toBeLessThanOrEqual(700);
+    }
+  });
+
+  it('treats an explicit 0 budget as an absolute kill switch, and a garbage budget as the 400 default', () => {
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '0';
+    expect(getAdbPacedAllowance(atUtc(12))).toBe(0);
+    expect(isAdbOrganicRefreshGated(atUtc(12))).toBe(true);
+    // Even with pacing switched off, an explicit 0 must still mean STOP — this is metered money.
+    process.env.AERODATABOX_BUDGET_PACING = '0';
+    expect(isAdbOrganicRefreshGated(atUtc(12))).toBe(true);
+
+    // Garbage is NOT "allow nothing": it falls back to the 400 default and gets that budget's paced
+    // line (floor(400 x 13/24) = 216 at noon). Failing closed on a typo would take the boards down;
+    // the explicit 0 above is the deliberate way to stop spend.
+    delete process.env.AERODATABOX_BUDGET_PACING;
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = 'abc';
+    expect(getAdbPacedAllowance(atUtc(12))).toBe(216);
+    expect(isAdbOrganicRefreshGated(atUtc(12))).toBe(false);
+  });
+
+  it('gates the organic path once today’s spend passes the paced line, not just the daily budget', async () => {
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '700';
+    const noonAllowance = 379; // floor(700 x 13/24)
+    await recordAdbUnits(noonAllowance - 4);
+    expect(isAdbOrganicRefreshGated(atUtc(12))).toBe(false);
+    await recordAdbUnits(4);
+    expect(isAdbOrganicRefreshGated(atUtc(12))).toBe(true);
+    // Same spend is still WELL under the absolute daily budget — pacing is what's holding it back,
+    // and the units it withheld are what the 18:00–24:00 UTC peak gets to spend.
+    expect(isAdbBudgetExhausted()).toBe(false);
+    // ...and later in the day that same spend is under the line again, so refreshes resume.
+    expect(isAdbOrganicRefreshGated(atUtc(18))).toBe(false);
+  });
+
+  it('AERODATABOX_BUDGET_PACING off-words restore the flat first-come-first-served gate', async () => {
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '700';
+    await recordAdbUnits(300); // way past the 00:30 UTC paced line, way under the daily budget
+    expect(isAdbOrganicRefreshGated(atUtc(0, 30))).toBe(true);
+    // Trimmed + lowercased, and the same off-words the rest of the codebase honours: an env value
+    // pasted with a stray space, or written 'false', must do what the operator plainly meant.
+    for (const off of ['0', 'off', 'OFF', ' off ', 'false', 'FALSE', 'no']) {
+      process.env.AERODATABOX_BUDGET_PACING = off;
+      expect(isAdbBudgetPacingDisabled(), `pacing=${JSON.stringify(off)}`).toBe(true);
+      expect(isAdbOrganicRefreshGated(atUtc(0, 30)), `pacing=${JSON.stringify(off)}`).toBe(false);
+    }
+    // Anything else — including the affirmative values and an unset/blank var — keeps pacing ON.
+    for (const on of ['1', 'on', 'true', 'yes', '', '  ']) {
+      process.env.AERODATABOX_BUDGET_PACING = on;
+      expect(isAdbBudgetPacingDisabled(), `pacing=${JSON.stringify(on)}`).toBe(false);
+      expect(isAdbOrganicRefreshGated(atUtc(0, 30)), `pacing=${JSON.stringify(on)}`).toBe(true);
+    }
+    delete process.env.AERODATABOX_BUDGET_PACING;
+    expect(isAdbBudgetPacingDisabled()).toBe(false);
+
+    // Disabling pacing does not disable the absolute budget.
+    process.env.AERODATABOX_BUDGET_PACING = 'off';
+    await recordAdbUnits(400);
+    expect(isAdbOrganicRefreshGated(atUtc(0, 30))).toBe(true);
+  });
+
+  it('warns ONCE per UTC day when the budget cannot fund the warm cron plus organic refreshes', async () => {
+    // The hourly warm cron bypasses the organic gate but records ~384 units/day against the SAME
+    // counter the paced line measures, so the code default of 400 leaves ~16 organic units for the
+    // whole day — the boards do not error, they just silently stop refreshing outside the cron ring.
+    // That is a config mistake nobody would ever see without this warning.
+    vi.useFakeTimers({ now: new Date('2026-08-04T09:00:00Z'), toFake: ['Date'] });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const starveWarns = () => warnSpy.mock.calls.filter((c) => /cannot fund the warm cron/.test(String(c[0])));
+
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '400';
+    isAdbOrganicRefreshGated(Date.now());
+    isAdbOrganicRefreshGated(Date.now());
+    expect(starveWarns()).toHaveLength(1);
+    expect(String(starveWarns()[0][0])).toMatch(/~384 units\/day/);
+    expect(String(starveWarns()[0][0])).toMatch(/production runs 700/);
+
+    // A budget with real headroom is silent — this must not become background noise for a healthy
+    // deployment.
+    __resetAdbSpendForTests();
+    warnSpy.mockClear();
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '700';
+    isAdbOrganicRefreshGated(Date.now());
+    expect(starveWarns()).toHaveLength(0);
+
+    // The explicit-0 kill switch is a deliberate operator choice, not a starved budget.
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '0';
+    isAdbOrganicRefreshGated(Date.now());
+    expect(starveWarns()).toHaveLength(0);
+    vi.useRealTimers();
+  });
+
+  it('reopens the gate at UTC midnight: both the counter AND the paced line reset', async () => {
+    // The gate reads two day-scoped values. If only one rolled over, a day that ended gated would
+    // start the next one gated too — the frozen-board failure this whole pass exists to prevent.
+    vi.useFakeTimers({ now: new Date('2026-08-04T23:59:00Z'), toFake: ['Date'] });
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '700';
+    await recordAdbUnits(700);
+    // After 23:00 UTC the paced line has reached the full budget, so late-day gating is the
+    // absolute ceiling doing the work — pacing neither adds nor removes headroom here.
+    expect(getAdbPacedAllowance(Date.now())).toBe(700);
+    expect(isAdbOrganicRefreshGated(Date.now())).toBe(true);
+
+    vi.setSystemTime(new Date('2026-08-05T00:01:00Z'));
+    expect(getAdbUnitsToday()).toBe(0);
+    // The line resets to the head-start slice, not the full budget — the new day is paced too.
+    expect(getAdbPacedAllowance(Date.now())).toBe(29);
+    expect(isAdbOrganicRefreshGated(Date.now())).toBe(false);
+    vi.useRealTimers();
+  });
+});
+
 describe('fetchViaAeroDataBox budget enforcement', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -160,8 +328,10 @@ describe('fetchViaAeroDataBox budget enforcement', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     delete process.env.AERODATABOX_API_KEY;
     delete process.env.AERODATABOX_DAILY_UNIT_BUDGET;
+    delete process.env.AERODATABOX_BUDGET_PACING;
     delete process.env.AERODATABOX_INTER_WINDOW_DELAY_MS;
     __resetAdbSpendForTests();
   });
@@ -188,24 +358,85 @@ describe('fetchViaAeroDataBox budget enforcement', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('logs the budget-exhausted warning at most ONCE per UTC day (no per-request log spam)', async () => {
+  it('logs the organic gate warning at most ONCE per UTC hour (no per-request log spam)', async () => {
     // The warning previously fired on EVERY gated organic request — dozens/hour for ~11h/day,
-    // burying genuine warnings and inflating log-query latency. It must throttle to once per
-    // instance per UTC day (reset here so prior exhausted-path tests don't consume the one allowance).
+    // burying genuine warnings and inflating log-query latency. It throttles to once per instance
+    // per UTC HOUR: the paced gate is episodic (spend crosses the line, the line catches up, spend
+    // crosses again), so a once-per-DAY latch would report the morning episode and swallow every
+    // afternoon one. Reset here so prior gated-path tests don't consume this hour's allowance.
+    vi.useFakeTimers({ now: new Date('2026-08-04T14:20:00Z'), toFake: ['Date'] });
     __resetScheduleWarnsForTests();
     await recordAdbUnits(400);
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: false, status: 500, headers: { get: () => null }, json: async () => ({}), text: async () => '',
     });
+    const gateWarns = () => warnSpy.mock.calls.filter((c) => /organic budget gate/.test(String(c[0])));
 
     const ts = Math.floor(Date.now() / 1000);
     await fetchViaAeroDataBox('ORD', 'departures', ts, 5000);
     await fetchViaAeroDataBox('SFO', 'arrivals', ts, 5000);
     await fetchViaAeroDataBox('DEN', 'departures', ts, 5000);
 
-    const budgetWarns = warnSpy.mock.calls.filter((c) => /daily unit budget exhausted/.test(String(c[0])));
-    expect(budgetWarns).toHaveLength(1);
+    expect(gateWarns()).toHaveLength(1);
+    // The warn must name the PACED line, not just the budget — "400/400" would read as
+    // "we spent the whole day's money" even when the gate tripped at 09:00 UTC on 160 paced units.
+    expect(String(gateWarns()[0][0])).toMatch(/paced allowance \d+ \(budget \d+\/day\)/);
+
+    // Still the same hour: silent.
+    vi.setSystemTime(new Date('2026-08-04T14:59:00Z'));
+    await fetchViaAeroDataBox('IAH', 'departures', ts, 5000);
+    expect(gateWarns()).toHaveLength(1);
+
+    // Next hour is a NEW episode and must be visible — the whole reason this is hourly.
+    vi.setSystemTime(new Date('2026-08-04T15:00:00Z'));
+    await fetchViaAeroDataBox('IAH', 'departures', ts, 5000);
+    expect(gateWarns()).toHaveLength(2);
+  });
+
+  it('names the ABSOLUTE budget (not a phantom paced line) in the warn when pacing is disabled', async () => {
+    // With AERODATABOX_BUDGET_PACING off the gate IS the flat daily budget. Printing a paced
+    // allowance nobody is enforcing sends whoever reads the log chasing a line that doesn't exist.
+    vi.useFakeTimers({ now: new Date('2026-08-04T09:00:00Z'), toFake: ['Date'] });
+    __resetScheduleWarnsForTests();
+    process.env.AERODATABOX_BUDGET_PACING = 'off';
+    await recordAdbUnits(400);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false, status: 500, headers: { get: () => null }, json: async () => ({}), text: async () => '',
+    });
+
+    const result = await fetchViaAeroDataBox('ORD', 'departures', Math.floor(Date.now() / 1000), 5000);
+    expect(result).toBeNull();
+    const messages = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(messages).toMatch(/daily unit budget exhausted \(400\/400\); pacing disabled/);
+    expect(messages).not.toMatch(/paced allowance/);
+    delete process.env.AERODATABOX_BUDGET_PACING;
+  });
+
+  it('gates an organic fetch that is inside the daily budget but ahead of the paced line', async () => {
+    // 00:30 UTC = 7:30 PM CDT, the hour the old flat gate let the evening crowd eat the whole day.
+    vi.useFakeTimers({ now: new Date('2026-08-04T00:30:00Z'), toFake: ['Date'] });
+    __resetScheduleWarnsForTests();
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '700';
+    await recordAdbUnits(300); // 43% of the day's money, 30 minutes into the day
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true, status: 200, headers: { get: () => null }, json: async () => ({ departures: [] }),
+    });
+
+    const result = await fetchViaAeroDataBox('ORD', 'departures', Math.floor(Date.now() / 1000), 5000);
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // The absolute budget is nowhere near gone — those units are being saved for the peak.
+    expect(isAdbBudgetExhausted()).toBe(false);
+
+    // Cron warms must still get through: they are the path that keeps boards from freezing.
+    const warm = await fetchViaAeroDataBox('ORD', 'departures', Math.floor(Date.now() / 1000), 5000, {
+      bypassDailyBudget: true,
+    });
+    expect(warm).not.toBeNull();
+    expect(fetchSpy).toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it('bypassDailyBudget (authorized cron warms, ring-bounded at ~288/day) skips the gate but still records spend', async () => {

--- a/tests/delay-explain.test.js
+++ b/tests/delay-explain.test.js
@@ -10,7 +10,7 @@ vi.mock('@anthropic-ai/sdk', () => ({
   }),
 }));
 
-import handler from '../api/delay-explain.js';
+import handler, { __resetDelayExplainForTests } from '../api/delay-explain.js';
 import { __resetRateLimitersForTests } from '../api/_rate-limit.js';
 
 function createRes() {
@@ -41,6 +41,10 @@ describe('delay-explain API', () => {
     vi.restoreAllMocks();
     mockCreate.mockReset();
     __resetRateLimitersForTests();
+    // Close the module-level AI-unavailable circuit and drop the explanation cache. Before this
+    // seam existed, any test that tripped the circuit poisoned every later test in the file, which
+    // is why the circuit cases had to be declared last and re-import the module to be meaningful.
+    __resetDelayExplainForTests();
     process.env.AI_GATEWAY_API_KEY = 'test-key';
     mockCreate.mockResolvedValue({
       content: [{ type: 'text', text: 'This flight is delayed due to weather.' }],
@@ -245,8 +249,9 @@ describe('delay-explain API', () => {
     expect(prompt).not.toContain('999');
   });
 
-  // --- Graceful AI-unavailable handling (must stay LAST: the billing case opens a module-level
-  // circuit breaker for 5 min, which would short-circuit any normal test that ran after it) ---
+  // --- Graceful AI-unavailable handling. These open a module-level circuit breaker for 5 min;
+  // __resetDelayExplainForTests() in beforeEach closes it again, so declaration order no longer
+  // matters and each case starts from a genuinely CLOSED circuit. ---
 
   it('returns a graceful 200 (not 502) for a non-billing Anthropic 400, leaving the circuit closed', async () => {
     mockCreate.mockRejectedValueOnce(Object.assign(new Error('invalid request: bad field'), { status: 400 }));
@@ -265,6 +270,7 @@ describe('delay-explain API', () => {
   });
 
   it('returns a graceful 200 for an Anthropic credit/billing 400 and opens the circuit', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     mockCreate.mockRejectedValueOnce(
       Object.assign(new Error('Your credit balance is too low to access the Anthropic API'), { status: 400 }),
     );
@@ -273,6 +279,10 @@ describe('delay-explain API', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.unavailable).toBe(true);
     expect(res.body.explanation).toMatch(/temporarily unavailable/i);
+    // All three circuit-opening branches share one logger (openAiCircuit), so the reason string is
+    // the only thing that distinguishes them in the error feed. Pin it.
+    expect(warnSpy.mock.calls.map((c) => String(c[0])).join('\n'))
+      .toMatch(/billing\/credit error — AI-unavailable circuit open 300s/);
 
     // Circuit now open: a subsequent click serves the graceful message WITHOUT calling Anthropic.
     mockCreate.mockClear();
@@ -283,30 +293,83 @@ describe('delay-explain API', () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  // Gateway budget/credit failure (402) trips the same circuit breaker as the
-  // billing-400 case above. Isolated via resetModules + dynamic re-import so it
-  // runs against a CLOSED circuit — the billing-400 test above leaves the shared
-  // module's circuit open, and without a fresh module the early circuit-open
-  // return would make this pass vacuously without ever exercising the 402 branch.
+  // Gateway budget/credit failure (402) trips the same circuit breaker as the billing-400 case.
   it('returns a graceful 200 for a gateway 402 and opens the circuit', async () => {
-    vi.resetModules();
-    const { default: freshHandler } = await import('../api/delay-explain.js');
-    mockCreate.mockReset();
-    process.env.AI_GATEWAY_API_KEY = 'test-key';
-
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     mockCreate.mockRejectedValueOnce(Object.assign(new Error('Payment Required'), { status: 402 }));
     const res = createRes();
-    await freshHandler(makeReq({ body: { flight: 'UAGW402' } }), res);
+    await handler(makeReq({ body: { flight: 'UAGW402' } }), res);
     expect(res.statusCode).toBe(200);
     expect(res.body.unavailable).toBe(true);
     expect(res.body.explanation).toMatch(/temporarily unavailable/i);
+    expect(warnSpy.mock.calls.map((c) => String(c[0])).join('\n'))
+      .toMatch(/budget\/credit error \(402\) — AI-unavailable circuit open 300s/);
 
     // Circuit now open: a subsequent click serves the graceful message WITHOUT calling the gateway.
     mockCreate.mockClear();
     const res2 = createRes();
-    await freshHandler(makeReq({ body: { flight: 'UAGW402B' } }), res2);
+    await handler(makeReq({ body: { flight: 'UAGW402B' } }), res2);
     expect(res2.statusCode).toBe(200);
     expect(res2.body.unavailable).toBe(true);
     expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // Jul 28 – Aug 2 2026: the gateway's credits dipped to free tier and every call came back 403
+  // PermissionDenied ("Free tier users do not have access to …"). That fell through to the generic
+  // 502 branch, so each click re-hit the gateway and logged a fresh error for the whole outage.
+  // A tier/permission rejection is account-wide, so it belongs on the same circuit as the 402.
+  it('returns a graceful 200 for an ACCOUNT-level gateway 403 and opens the circuit', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockCreate.mockRejectedValueOnce(
+      Object.assign(new Error('Free tier users do not have access to this model'), { status: 403 }),
+    );
+    const res = createRes();
+    await handler(makeReq({ body: { flight: 'UAGW403' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.unavailable).toBe(true);
+    expect(res.body.explanation).toMatch(/temporarily unavailable/i);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls.map((c) => String(c[0])).join('\n'))
+      .toMatch(/permission error \(403\) — AI-unavailable circuit open 300s/);
+
+    // Circuit now open: the next click never reaches the gateway (no re-hit, no fresh error log).
+    mockCreate.mockClear();
+    const res2 = createRes();
+    await handler(makeReq({ body: { flight: 'UAGW403B' } }), res2);
+    expect(res2.statusCode).toBe(200);
+    expect(res2.body.unavailable).toBe(true);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('keeps the circuit CLOSED for a request-specific gateway 403 (flight words are not account words)', async () => {
+    // Not every 403 is account-wide: a rejected model route or a per-request policy denial is one
+    // request's problem. Disabling "Explain Delay Risk" for every visitor for five minutes over it
+    // would be a self-inflicted outage, so only the account-level wording above trips the circuit.
+    //
+    // These messages are the reason the matcher stopped accepting bare tokens: 'plan' lives inside
+    // 'flight plan' and 'plane', 'tier' inside 'frontier', 'account' inside 'accounted' — all words
+    // that turn up in flight context and can echo back through an upstream error string.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const requestSpecific = [
+      'flight plan rejected for this route',
+      'no Frontier codeshare route available',
+      'this segment is already accounted for',
+    ];
+    for (const [i, message] of requestSpecific.entries()) {
+      mockCreate.mockRejectedValueOnce(Object.assign(new Error(message), { status: 403 }));
+      const res = createRes();
+      await handler(makeReq({ body: { flight: `UA403REQ${i}` } }), res);
+      // Still graceful — a 403 is never retryable for THIS request.
+      expect(res.statusCode, message).toBe(200);
+      expect(res.body.unavailable, message).toBe(true);
+      expect(warnSpy.mock.calls.map((c) => String(c[0])).join('\n'), message).not.toMatch(/circuit open/);
+    }
+
+    // ...and the next click still reaches the gateway.
+    mockCreate.mockResolvedValueOnce({ content: [{ type: 'text', text: 'fresh after 403' }] });
+    const res2 = createRes();
+    await handler(makeReq({ body: { flight: 'UA403REQB' } }), res2);
+    expect(res2.statusCode).toBe(200);
+    expect(res2.body.explanation).toBe('fresh after 403');
   });
 });

--- a/tests/feed-health.test.js
+++ b/tests/feed-health.test.js
@@ -4,6 +4,7 @@ import {
   applyFeedResult,
   feedFreshness,
   nextFeedRetryDelay,
+  parseStaleHeader,
   FEED_FRESH_MS,
   FEED_RETRY_DELAYS_MS,
 } from '../src/lib/feed-health.js';
@@ -131,6 +132,26 @@ describe('feedFreshness — chip keyed to payload age, not transport signals', (
   it('threshold sits in the sensible 2-3 minute band', () => {
     expect(FEED_FRESH_MS).toBeGreaterThanOrEqual(120000);
     expect(FEED_FRESH_MS).toBeLessThanOrEqual(180000);
+  });
+});
+
+// Aug 4 2026: /api/fr24-feed can answer a 200 from ITS last-known-good payload when upstream fails,
+// tagging it X-BB-Feed-Stale: <seconds>. The poll loop backdates lastGoodFeedTs by that age so the
+// chip keeps telling the truth; anything that is not a positive number must read as "not stale".
+describe('parseStaleHeader — server stale-serve age', () => {
+  it('converts a positive seconds header to milliseconds', () => {
+    expect(parseStaleHeader('40')).toBe(40000);
+    expect(parseStaleHeader('180')).toBe(180000);
+    expect(parseStaleHeader(1)).toBe(1000);
+  });
+
+  it('is 0 for a missing, blank, zero, negative, or unparseable header', () => {
+    expect(parseStaleHeader(null)).toBe(0);        // headers.get() on an absent header
+    expect(parseStaleHeader(undefined)).toBe(0);
+    expect(parseStaleHeader('')).toBe(0);          // Number('') is 0 — must not read as "stale by 0"
+    expect(parseStaleHeader('0')).toBe(0);
+    expect(parseStaleHeader('-5')).toBe(0);
+    expect(parseStaleHeader('abc')).toBe(0);
   });
 });
 

--- a/tests/fr24-feed.test.js
+++ b/tests/fr24-feed.test.js
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import handler, { countFeedAircraft } from '../api/fr24-feed.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import handler, { __resetFeedStateForTests } from '../api/fr24-feed.js';
+import { __resetRateLimitersForTests } from '../api/_rate-limit.js';
+import { FEED_FRESH_MS } from '../src/lib/feed-health.js';
 
 function createRes() {
   return {
@@ -12,10 +14,44 @@ function createRes() {
   };
 }
 
+function feedReq(airline) {
+  const query = airline === undefined ? {} : { airline };
+  return { method: 'GET', headers: { origin: 'http://localhost:3000' }, query };
+}
+
+const EMPTY_BODY = { full_count: 22684, version: 4 };
+
+// One aircraft entry in FR24's positional-array shape. The handler's "is this feed empty?" predicate
+// IS the client's parseFr24Feed, which drops any entry without a truthy lat/lon (indices 1 and 2), so
+// a fixture aircraft has to carry a real position or the whole payload reads as an empty feed.
+const AC = ['a1b2c3', 41.98, -87.9];
+
+// An aircraft entry with NO position — the degraded shape that used to count as a success (it is an
+// array-valued key) while every client parsed it as zero flights.
+const AC_NO_POSITION = ['a1b2c3', null, null];
+
+// Shared per-test reset. The handler keeps THREE module-level stores (fresh cache, in-flight dedup,
+// last-known-good ring) that outlive a test file; before the __resetFeedStateForTests seam existed,
+// tests encoded "which airline codes are still cold" as declaration order, so a shuffled run failed.
+// The retry delay is zeroed here too: it is a REAL setTimeout, and a dozen retry cases at 400ms each
+// is wall-clock time spent asserting nothing.
+function resetFeedTestState() {
+  vi.restoreAllMocks();
+  __resetRateLimitersForTests();
+  __resetFeedStateForTests();
+  process.env.FR24_EMPTY_RETRY_DELAY_MS = '0';
+  delete process.env.FR24_FEED_STALE_SERVE_MAX_MS;
+}
+
+function cleanupFeedTestEnv() {
+  vi.useRealTimers();
+  delete process.env.FR24_EMPTY_RETRY_DELAY_MS;
+  delete process.env.FR24_FEED_STALE_SERVE_MAX_MS;
+}
+
 describe('fr24-feed API', () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
+  beforeEach(resetFeedTestState);
+  afterEach(cleanupFeedTestEnv);
 
   it('rejects non-GET requests', async () => {
     const res = createRes();
@@ -31,31 +67,44 @@ describe('fr24-feed API', () => {
 
   it('rejects invalid airline codes', async () => {
     const res = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: { airline: 'DROP TABLE' },
-    }, res);
+    await handler(feedReq('DROP TABLE'), res);
     expect(res.statusCode).toBe(400);
   });
 
-  // Error tests run before success to avoid module-level cache interference.
-  // The fr24-feed handler uses a persistent in-memory cache that survives across tests.
-
-  it('returns 502 on upstream failure (cold cache)', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: false,
-      status: 500,
+  it('normalizes a non-string airline param instead of throwing (validation now lives outside the try)', async () => {
+    // ?airline=UAL&airline=DAL arrives as an array; a bare/odd param can arrive as ''/true. Since
+    // validation moved ABOVE the try (the catch needs the cacheKey), .test()/.toUpperCase() on a
+    // non-string would escape as an unhandled 500 rather than the intended 400/UAL default.
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...EMPTY_BODY, aa00bb: AC }),
     });
 
+    const arrayRes = createRes();
+    await handler(feedReq(['DAL', 'JBU']), arrayRes);
+    expect(arrayRes.statusCode).toBe(200);
+    expect(String(fetchMock.mock.calls[0][0])).toContain('airline=DAL');
+
+    for (const junk of ['', true, 42, { a: 1 }, [], [null]]) {
+      __resetFeedStateForTests();
+      const res = createRes();
+      await handler(feedReq(junk), res);
+      expect(res.statusCode, `airline=${JSON.stringify(junk)}`).toBe(200);
+    }
+  });
+
+  it('returns 502 on upstream failure (cold cache), draining the error body first', async () => {
+    // An undrained body keeps its socket checked out of the agent pool until GC, and this is the
+    // branch that fires in bursts (sustained upstream 5xx) — the same reason the AeroDataBox fetcher
+    // reads the body on its !ok path.
+    const text = vi.fn(async () => 'upstream exploded');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 500, text });
+
     const res = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: {},
-    }, res);
+    await handler(feedReq(), res);
 
     expect(res.statusCode).toBe(502);
+    expect(text).toHaveBeenCalledTimes(1);
   });
 
   it('returns 504 on timeout (cold cache)', async () => {
@@ -64,28 +113,20 @@ describe('fr24-feed API', () => {
     );
 
     const res = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: {},
-    }, res);
+    await handler(feedReq(), res);
 
     expect(res.statusCode).toBe(504);
   });
 
   it('returns flight data on success', async () => {
-    const mockData = { full_count: 500, version: 4, '2d5c8a': ['data'] };
+    const mockData = { full_count: 500, version: 4, '2d5c8a': AC };
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
       json: async () => mockData,
     });
 
     const res = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: {},
-    }, res);
+    await handler(feedReq(), res);
 
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual(mockData);
@@ -93,65 +134,48 @@ describe('fr24-feed API', () => {
   });
 
 
-  it('uses airline-specific cache keys to avoid cross-airline contamination', async () => {
+  it('serves a non-UAL code as a plain pass-through — no fresh cache read or write', async () => {
+    // The fresh cache holds exactly ONE entry and the airline param is caller-controlled, so letting
+    // arbitrary codes occupy it turns alternating requests into permanent thrash for the one airline
+    // the product actually serves. Non-UAL codes still answer correctly; they just never cache.
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
       const airline = new URL(url).searchParams.get('airline');
       return {
         ok: true,
-        // Must contain at least one aircraft entry (array value) — meta-only bodies are
-        // rejected as empty feeds since the Jul 3 2026 cold-load fix.
-        json: async () => ({ airline, full_count: airline === 'DAL' ? 500 : 120, aabbcc: ['pos'] }),
+        json: async () => ({ airline, full_count: airline === 'DAL' ? 500 : 120, aabbcc: AC }),
       };
     });
 
-    const resUAL = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: { airline: 'DAL' },
-    }, resUAL);
+    const resDAL = createRes();
+    await handler(feedReq('DAL'), resDAL);
 
     const resAAL = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: { airline: 'JBU' },
-    }, resAAL);
+    await handler(feedReq('AAL'), resAAL);
 
-    const resAALCached = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: { airline: 'JBU' },
-    }, resAALCached);
+    // Same code, immediately again: a cached entry would answer without upstream traffic.
+    const resAALAgain = createRes();
+    await handler(feedReq('AAL'), resAALAgain);
 
-    expect(resUAL.statusCode).toBe(200);
-    expect(resUAL.body.airline).toBe('DAL');
+    expect(resDAL.statusCode).toBe(200);
+    expect(resDAL.body.airline).toBe('DAL');
     expect(resAAL.statusCode).toBe(200);
-    expect(resAAL.body.airline).toBe('JBU');
-    expect(resAALCached.body.airline).toBe('JBU');
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(resAAL.body.airline).toBe('AAL');
+    expect(resAALAgain.body.airline).toBe('AAL');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
+
   it('returns cached data on subsequent requests', async () => {
-    const mockData = { full_count: 500, version: 4, '2d5c8a': ['data'] };
+    const mockData = { full_count: 500, version: 4, '2d5c8a': AC };
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
       json: async () => mockData,
     });
 
     const firstRes = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: { airline: 'UAL' },
-    }, firstRes);
+    await handler(feedReq('UAL'), firstRes);
 
     const secondRes = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: { airline: 'UAL' },
-    }, secondRes);
+    await handler(feedReq('UAL'), secondRes);
 
     expect(firstRes.statusCode).toBe(200);
     expect(secondRes.statusCode).toBe(200);
@@ -164,22 +188,17 @@ describe('fr24-feed API', () => {
 // ({full_count, version}, zero aircraft arrays). Serving that as success wiped the client's
 // map/boards into "NO DATA". The handler must surface it as a 503 and never cache it.
 describe('fr24-feed empty-payload rejection', () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
+  beforeEach(resetFeedTestState);
+  afterEach(cleanupFeedTestEnv);
 
   it('returns 503 (no-store) when upstream 200s with a meta-only body', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
-      json: async () => ({ full_count: 22684, version: 4 }),
+      json: async () => EMPTY_BODY,
     });
 
     const res = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: { airline: 'SWA' }, // unique airline → cold cache regardless of test order
-    }, res);
+    await handler(feedReq('UAL'), res);
 
     expect(res.statusCode).toBe(503);
     expect(res.body.error).toMatch(/empty feed/i);
@@ -187,45 +206,462 @@ describe('fr24-feed empty-payload rejection', () => {
   });
 
   it('does not cache the empty body — next request refetches and succeeds', async () => {
+    // Both attempts of the FIRST request must be empty for it to 503 (United retries once since
+    // Aug 4 2026), so the good body lands on the third upstream call.
     let call = 0;
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
       ok: true,
-      json: async () => (++call === 1
-        ? { full_count: 22684, version: 4 }
-        : { full_count: 22684, version: 4, ddeeff: ['pos'] }),
+      json: async () => (++call <= 2 ? EMPTY_BODY : { ...EMPTY_BODY, ddeeff: AC }),
     }));
 
     const first = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: { airline: 'ASA' },
-    }, first);
+    await handler(feedReq('UAL'), first);
     expect(first.statusCode).toBe(503);
 
     const second = createRes();
-    await handler({
-      method: 'GET',
-      headers: { origin: 'http://localhost:3000' },
-      query: { airline: 'ASA' },
-    }, second);
+    await handler(feedReq('UAL'), second);
     expect(second.statusCode).toBe(200);
-    expect(second.body.ddeeff).toEqual(['pos']);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(second.body.ddeeff).toEqual(AC);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does NOT retry for a non-United airline — "empty is never truth" is a UA-only claim', async () => {
+    // United always has hundreds airborne, so an empty UA feed is an upstream glitch. Any other
+    // caller-supplied code may legitimately have nothing flying, and re-asking would just double the
+    // upstream amplification an attacker gets for free from the open `airline` param.
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => EMPTY_BODY,
+    });
+
+    const res = createRes();
+    await handler(feedReq('SWA'), res);
+
+    expect(res.statusCode).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 
-describe('countFeedAircraft', () => {
-  it('counts only array-valued entries', () => {
-    expect(countFeedAircraft({ full_count: 5, version: 4, a1: ['x'], b2: ['y'] })).toBe(2);
-    expect(countFeedAircraft({ full_count: 5, version: 4, stats: { total: 5 } })).toBe(0);
-    expect(countFeedAircraft({ full_count: 22684, version: 4 })).toBe(0);
+// Aug 4 2026: FR24's empty bodies arrive in STREAKS, not isolated blips — 12 sequential probes of
+// the upstream returned 708, 0, 0, 706, 708, 0, 0, 0, 0, 0, 712, 0 aircraft, and 1,062 of ~5,200
+// requests/24h were 503ing on the Jul 3 empty-feed guard. A single retry clears the one-deep
+// streaks; the streaks of 2-5 need the bounded last-known-good serve. The ceiling matches the
+// client's FEED_FRESH_MS (180s) so the LIVE chip can never overclaim by more than a fresh window.
+describe('fr24-feed empty-streak recovery (retry + bounded stale-serve)', () => {
+  const T0 = '2026-08-04T18:00:00Z';
+  const at = (ms) => new Date(Date.parse(T0) + ms);
+
+  beforeEach(resetFeedTestState);
+  afterEach(cleanupFeedTestEnv);
+
+  it('retries the upstream once and serves the second, good payload when the first body is empty', async () => {
+    let call = 0;
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+      ok: true,
+      json: async () => (++call === 1 ? EMPTY_BODY : { ...EMPTY_BODY, aa11bb: AC }),
+    }));
+
+    const res = createRes();
+    await handler(feedReq('UAL'), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.aa11bb).toEqual(AC);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('is 0 for null/undefined/non-object payloads', () => {
-    expect(countFeedAircraft(null)).toBe(0);
-    expect(countFeedAircraft(undefined)).toBe(0);
-    expect(countFeedAircraft('nope')).toBe(0);
-    expect(countFeedAircraft(42)).toBe(0);
+  it('serves the last-known-good payload as a 200 (X-BB-Feed-Stale + shared TTL) when both attempts are empty', async () => {
+    // Fake Date ONLY — setTimeout stays real so the inter-attempt pause still resolves.
+    vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+    const good = { ...EMPTY_BODY, cc22dd: AC };
+    let empty = false;
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+      ok: true,
+      json: async () => (empty ? EMPTY_BODY : good),
+    }));
+
+    const seed = createRes();
+    await handler(feedReq('UAL'), seed);
+    expect(seed.statusCode).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // 40s later: past the 15s fresh cache (so we really refetch) but well inside the 180s ceiling.
+    vi.setSystemTime(at(40_000));
+    empty = true;
+
+    const res = createRes();
+    await handler(feedReq('UAL'), res);
+
+    // Both attempts were made before falling back — stale-serve is the last resort, not the first.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(good);
+    expect(res.headers['X-BB-Feed-Stale']).toBe('40');
+    // 140s of freshness left, so the edge may share it — clamped to the fresh path's own 15s.
+    expect(res.headers['Cache-Control']).toBe('s-maxage=15');
+  });
+
+  it('does not repopulate the fresh cache from a stale-serve — the next poll still asks upstream', async () => {
+    // Deliberately NO feedCache.set on the stale path: caching it would restart the 15s fresh window
+    // on old data and stop us re-trying the upstream that just failed.
+    vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+    let empty = false;
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+      ok: true,
+      json: async () => (empty ? EMPTY_BODY : { ...EMPTY_BODY, ee11ff: AC }),
+    }));
+
+    await handler(feedReq('UAL'), createRes());
+    vi.setSystemTime(at(40_000));
+    empty = true;
+
+    const first = createRes();
+    await handler(feedReq('UAL'), first);
+    expect(first.statusCode).toBe(200);
+    expect(first.headers['X-BB-Feed-Stale']).toBe('40');
+    const callsAfterFirst = fetchMock.mock.calls.length;
+
+    // Same instant, same airline: a cached stale body would answer without any upstream traffic.
+    const second = createRes();
+    await handler(feedReq('UAL'), second);
+    expect(second.statusCode).toBe(200);
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+
+  it('falls back to last-known-good for a non-empty failure too (upstream 5xx, single attempt)', async () => {
+    vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+    const good = { ...EMPTY_BODY, ee33ff: AC };
+    let broken = false;
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      (broken ? { ok: false, status: 500, text: async () => 'upstream exploded' } : { ok: true, json: async () => good }));
+
+    const seed = createRes();
+    await handler(feedReq('UAL'), seed);
+    expect(seed.statusCode).toBe(200);
+
+    vi.setSystemTime(at(20_000));
+    broken = true;
+
+    const res = createRes();
+    await handler(feedReq('UAL'), res);
+    expect(res.statusCode).toBe(200); // was a 502
+    expect(res.body).toEqual(good);
+    expect(res.headers['X-BB-Feed-Stale']).toBe('20');
+    // A hard failure is not the empty-body glitch: exactly ONE upstream attempt (seed + this one).
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves last-known-good on an aborted (timed-out) upstream too', async () => {
+    // The third failure mode the stale-serve comment claims to cover, alongside empty + 5xx.
+    vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+    const good = { ...EMPTY_BODY, gg55hh: AC };
+    let hung = false;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      if (hung) throw Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+      return { ok: true, json: async () => good };
+    });
+
+    await handler(feedReq('UAL'), createRes());
+    vi.setSystemTime(at(35_000));
+    hung = true;
+
+    const res = createRes();
+    await handler(feedReq('UAL'), res);
+    expect(res.statusCode).toBe(200); // was a 504
+    expect(res.body).toEqual(good);
+    expect(res.headers['X-BB-Feed-Stale']).toBe('35');
+  });
+
+  it('still 503s when both attempts are empty and there is no last-known-good payload', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => EMPTY_BODY });
+
+    const res = createRes();
+    await handler(feedReq('UAL'), res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.headers['Cache-Control']).toBe('no-store');
+    expect(res.headers['X-BB-Feed-Stale']).toBeUndefined();
+  });
+
+  it('refuses to serve a last-known-good payload older than the 180s ceiling', async () => {
+    vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+    let empty = false;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+      ok: true,
+      json: async () => (empty ? EMPTY_BODY : { ...EMPTY_BODY, gg44hh: AC }),
+    }));
+
+    const seed = createRes();
+    await handler(feedReq('UAL'), seed);
+    expect(seed.statusCode).toBe(200);
+
+    // 4 min later the payload is older than the client would ever call "live" — fail honestly.
+    vi.setSystemTime(at(240_000));
+    empty = true;
+
+    const res = createRes();
+    await handler(feedReq('UAL'), res);
+    expect(res.statusCode).toBe(503);
+    expect(res.headers['X-BB-Feed-Stale']).toBeUndefined();
+  });
+
+  it('serves AT the ceiling and refuses one millisecond past it', async () => {
+    // The comparison is `ageMs <= staleServeMaxMs`; pin both sides of the boundary so a future
+    // refactor to `<` (or a re-typed literal ceiling) cannot slip through.
+    const seedThenFailAt = async (offsetMs) => {
+      resetFeedTestState();
+      vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+      let empty = false;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+        ok: true,
+        json: async () => (empty ? EMPTY_BODY : { ...EMPTY_BODY, hh66ii: AC }),
+      }));
+      await handler(feedReq('UAL'), createRes());
+      vi.setSystemTime(at(offsetMs));
+      empty = true;
+      const res = createRes();
+      await handler(feedReq('UAL'), res);
+      return res;
+    };
+
+    const exactly = await seedThenFailAt(FEED_FRESH_MS);
+    expect(exactly.statusCode).toBe(200);
+    expect(exactly.headers['X-BB-Feed-Stale']).toBe('180');
+    // Nothing left of the window — the body may be served once, but never cached by an edge.
+    expect(exactly.headers['Cache-Control']).toBe('no-store');
+
+    const past = await seedThenFailAt(FEED_FRESH_MS + 1);
+    expect(past.statusCode).toBe(503);
+    expect(past.headers['X-BB-Feed-Stale']).toBeUndefined();
+  });
+
+  it('clamps the stale-serve CDN TTL inside the remaining freshness window', async () => {
+    // Unconditional no-store made every client in an outage re-ask the origin independently; an
+    // unclamped TTL would let an edge keep serving a body past the age the client calls live.
+    const seedThenFailAt = async (offsetMs) => {
+      resetFeedTestState();
+      vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+      let empty = false;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+        ok: true,
+        json: async () => (empty ? EMPTY_BODY : { ...EMPTY_BODY, ii77jj: AC }),
+      }));
+      await handler(feedReq('UAL'), createRes());
+      vi.setSystemTime(at(offsetMs));
+      empty = true;
+      const res = createRes();
+      await handler(feedReq('UAL'), res);
+      return res;
+    };
+
+    // Young: 160s of window left, so the 15s fresh-path cap is what binds.
+    expect((await seedThenFailAt(20_000)).headers['Cache-Control']).toBe('s-maxage=15');
+    // Nearly expired: only 10s left, so the window binds instead of the cap.
+    expect((await seedThenFailAt(170_000)).headers['Cache-Control']).toBe('s-maxage=10');
+    // Exactly spent: nothing may be cached.
+    expect((await seedThenFailAt(FEED_FRESH_MS)).headers['Cache-Control']).toBe('no-store');
+  });
+
+  it('a burst of other-airline requests cannot evict UAL last-known-good (single UAL-only slot)', async () => {
+    // The whole point of making the slot UAL-only: `airline` is caller-controlled and needs no Origin
+    // header, so ANY per-airline store — however carefully LRU'd — lets a handful of curl requests
+    // with real ICAO codes push out the one payload the dashboard falls back to. Here that burst runs
+    // and UAL still stale-serves.
+    vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+    let empty = false;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      if (empty) return { ok: true, json: async () => EMPTY_BODY };
+      const airline = new URL(url).searchParams.get('airline');
+      return { ok: true, json: async () => ({ ...EMPTY_BODY, [`ac${airline}`]: AC }) };
+    });
+
+    await handler(feedReq('UAL'), createRes());
+    for (const code of ['AAL', 'DAL', 'SWA', 'ASA', 'JBU', 'FFT', 'NKS', 'SKW', 'ACA', 'BAW']) {
+      await handler(feedReq(code), createRes());
+    }
+
+    vi.setSystemTime(at(30_000));
+    empty = true;
+
+    const ual = createRes();
+    await handler(feedReq('UAL'), ual);
+    expect(ual.statusCode).toBe(200);
+    expect(ual.body.acUAL).toEqual(AC);
+    expect(ual.headers['X-BB-Feed-Stale']).toBe('30');
+  });
+
+  it('never remembers a non-UAL payload: a later failure for that code is a plain 5xx', async () => {
+    // A successful AAL request must leave no last-known-good behind — otherwise the slot is
+    // reachable (and therefore poisonable/evictable) from the open airline param after all.
+    vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+    let broken = false;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      (broken ? { ok: false, status: 500, text: async () => 'boom' } : { ok: true, json: async () => ({ ...EMPTY_BODY, acAAL: AC }) }));
+
+    const seed = createRes();
+    await handler(feedReq('AAL'), seed);
+    expect(seed.statusCode).toBe(200);
+
+    vi.setSystemTime(at(20_000));
+    broken = true;
+
+    const res = createRes();
+    await handler(feedReq('AAL'), res);
+    expect(res.statusCode).toBe(502);
+    expect(res.headers['X-BB-Feed-Stale']).toBeUndefined();
+  });
+
+  it('honours FR24_FEED_STALE_SERVE_MAX_MS=0 as an explicit stale-serve kill switch', async () => {
+    vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+    let empty = false;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+      ok: true,
+      json: async () => (empty ? EMPTY_BODY : { ...EMPTY_BODY, ii55jj: AC }),
+    }));
+
+    const seed = createRes();
+    await handler(feedReq('UAL'), seed);
+    expect(seed.statusCode).toBe(200);
+
+    vi.setSystemTime(at(20_000));
+    empty = true;
+    process.env.FR24_FEED_STALE_SERVE_MAX_MS = '0';
+
+    const res = createRes();
+    await handler(feedReq('UAL'), res);
+    // A 20s-old payload is well inside the default ceiling; 0 must still mean "never".
+    expect(res.statusCode).toBe(503);
+    expect(res.headers['X-BB-Feed-Stale']).toBeUndefined();
+  });
+
+  it('treats a blank or garbage FR24_FEED_STALE_SERVE_MAX_MS as UNSET, and honours a real override', async () => {
+    // Number('') is 0, so a defined-but-empty env row (Vercel's default for a value-less variable)
+    // used to silently arm the kill switch above on a deploy nobody meant to change.
+    const seedThenFailAt = async (envValue, offsetMs) => {
+      resetFeedTestState();
+      if (envValue !== undefined) process.env.FR24_FEED_STALE_SERVE_MAX_MS = envValue;
+      vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+      let empty = false;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+        ok: true,
+        json: async () => (empty ? EMPTY_BODY : { ...EMPTY_BODY, jj88kk: AC }),
+      }));
+      await handler(feedReq('UAL'), createRes());
+      vi.setSystemTime(at(offsetMs));
+      empty = true;
+      const res = createRes();
+      await handler(feedReq('UAL'), res);
+      return res;
+    };
+
+    for (const bad of ['', '   ', 'abc', '-1']) {
+      const res = await seedThenFailAt(bad, 40_000);
+      expect(res.statusCode, `env=${JSON.stringify(bad)}`).toBe(200);
+      expect(res.headers['X-BB-Feed-Stale'], `env=${JSON.stringify(bad)}`).toBe('40');
+    }
+
+    // A real value is obeyed in both directions.
+    expect((await seedThenFailAt('60000', 40_000)).statusCode).toBe(200);
+    expect((await seedThenFailAt('60000', 90_000)).statusCode).toBe(503);
+  });
+
+  it('clamps FR24_FEED_STALE_SERVE_MAX_MS to the client freshness window — an hour reads as 180s', async () => {
+    // The knob only ever gets reached for during an outage, and only ever moves the wrong way. An
+    // operator setting 3600000 would have us serving hour-old positions as clean 200s that the client
+    // then stamps into the reg-sightings ledger as fresh sightings, so the env can tighten the
+    // ceiling but never loosen it.
+    const seedThenFailAt = async (offsetMs) => {
+      resetFeedTestState();
+      process.env.FR24_FEED_STALE_SERVE_MAX_MS = '3600000';
+      vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+      let empty = false;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+        ok: true,
+        json: async () => (empty ? EMPTY_BODY : { ...EMPTY_BODY, kk99ll: AC }),
+      }));
+      await handler(feedReq('UAL'), createRes());
+      vi.setSystemTime(at(offsetMs));
+      empty = true;
+      const res = createRes();
+      await handler(feedReq('UAL'), res);
+      return res;
+    };
+
+    // Inside the real 180s ceiling: served, exactly as the default would.
+    const inside = await seedThenFailAt(170_000);
+    expect(inside.statusCode).toBe(200);
+    expect(inside.headers['X-BB-Feed-Stale']).toBe('170');
+
+    // Past it: refused, even though the operator's literal value would have allowed it.
+    const past = await seedThenFailAt(190_000);
+    expect(past.statusCode).toBe(503);
+    expect(past.headers['X-BB-Feed-Stale']).toBeUndefined();
+  });
+});
+
+// R1 (Aug 4 2026): the server's "is this feed empty?" predicate used to count array-valued keys while
+// the client's parseFr24Feed additionally drops entries with no lat/lon. A degraded payload of
+// positionless aircraft therefore counted as SUCCESS server-side — cached, written to the
+// last-known-good slot, and stale-served for the next three minutes — while every client parsed zero
+// flights and rendered NO DATA. A permanent lie is worse than the 503 the guard exists to raise, so
+// both sides now run the same parse.
+describe('fr24-feed emptiness predicate matches the client parse', () => {
+  const T0 = '2026-08-04T18:00:00Z';
+  const at = (ms) => new Date(Date.parse(T0) + ms);
+
+  beforeEach(resetFeedTestState);
+  afterEach(cleanupFeedTestEnv);
+
+  it('treats a payload of positionless aircraft entries as an EMPTY feed, not a success', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...EMPTY_BODY, zz11: AC_NO_POSITION, zz22: AC_NO_POSITION }),
+    });
+
+    const res = createRes();
+    await handler(feedReq('UAL'), res);
+
+    // Key-counting would have made this a cached 200 with two "aircraft".
+    expect(res.statusCode).toBe(503);
+    expect(res.body.error).toMatch(/empty feed/i);
+    expect(res.headers['Cache-Control']).toBe('no-store');
+    // United still gets its one retry — this is the same glitch class as a meta-only body.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let a positionless payload overwrite (poison) the last-known-good slot', async () => {
+    // The dangerous half of the old predicate: the degraded body was not merely served once, it
+    // REPLACED a real payload, so the next three minutes of stale-serves handed out a body the
+    // client parses as empty.
+    vi.useFakeTimers({ now: at(0), toFake: ['Date'] });
+    const good = { ...EMPTY_BODY, mm33nn: AC };
+    let degraded = false;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+      ok: true,
+      json: async () => (degraded ? { ...EMPTY_BODY, zz11: AC_NO_POSITION } : good),
+    }));
+
+    await handler(feedReq('UAL'), createRes());
+    vi.setSystemTime(at(30_000));
+    degraded = true;
+
+    const res = createRes();
+    await handler(feedReq('UAL'), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(good);
+    expect(res.headers['X-BB-Feed-Stale']).toBe('30');
+  });
+
+  it('accepts a mixed payload: one positioned aircraft among positionless ones is a real feed', async () => {
+    // The predicate must not be "any entry is malformed" — FR24 sends the occasional junk row, and
+    // a board with 699 good aircraft is not an outage.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...EMPTY_BODY, zz11: AC_NO_POSITION, oo44pp: AC }),
+    });
+
+    const res = createRes();
+    await handler(feedReq('UAL'), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.oo44pp).toEqual(AC);
   });
 });

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -15,7 +15,7 @@ vi.mock('@vercel/functions', () => vercelFunctionMocks);
 import handler, { shouldAttemptOfficialFallback, recordFallback, resetFallbackBreaker, __resetScheduleCachesForTests, shouldEnableProviderForBackgroundRefresh } from '../api/schedule.js';
 import { getStartOfDayForHub } from '../api/irops.js';
 import { __resetRateLimitersForTests } from '../api/_rate-limit.js';
-import { recordAdbUnits } from '../api/_cost-state.js';
+import { recordAdbUnits, isAdbOrganicRefreshGated, __resetAdbSpendForTests } from '../api/_cost-state.js';
 import { getStartOfHubDay } from '../src/lib/hubTz.js';
 import { classifySchedStatus } from '../src/lib/schedule-status.js';
 
@@ -2361,6 +2361,125 @@ describe('forceRefresh (cron-authorized cache bypass)', () => {
       query: { ...baseQuery(), forceRefresh: '1' },
     }, createRes());
     expect(fetchSpy.mock.calls.filter(([url]) => /aerodatabox|aedbx/i.test(String(url))).length).toBeGreaterThan(0);
+  });
+});
+
+// The paced organic gate (api/_cost-state.ts) makes fetchViaAeroDataBox return null for many more
+// hours/day than the old flat budget ever did. Provider-mode's fallthrough answers a null provider
+// by reaching for the PAID FR24 official API — whose only daily ceiling is per-instance — so without
+// a guard the pacing "spend guard" would quietly MOVE organic traffic onto a costlier provider for
+// most of the day. That is the opposite of what it was built to do.
+describe('paced provider gate must not spill onto the paid official API', () => {
+  beforeEach(() => {
+    resetScheduleTestState();
+    resetFallbackBreaker(); // also clears the ADB counters via __resetAdbSpendForTests
+    __resetAdbSpendForTests();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'provider';
+    process.env.AERODATABOX_API_KEY = 'adb-test-key';
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '700';
+    // 00:30 UTC = 7:30 PM CDT: half an hour into the day, so the paced line is tiny while the
+    // absolute budget is nearly untouched — precisely the state that only pacing can be gating.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-04T00:30:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.AERODATABOX_DAILY_UNIT_BUDGET;
+    cleanupScheduleTestEnv();
+  });
+
+  // Provider-mode board whose provider call is gated, so the fallthrough decides everything.
+  async function loadGatedBoard() {
+    const ts = getStartOfHubDay('IAH', 0);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{
+              fr24_id: 'x1', flight: 'UA795', callsign: 'UAL795', operating_as: 'UAL', type: 'A21N', reg: 'N1',
+              orig_icao: 'KIAH', datetime_takeoff: new Date((ts + 9 * 3600) * 1000).toISOString().replace('.000Z', 'Z'),
+              dest_icao: 'KEWR', dest_icao_actual: 'KEWR', datetime_landed: new Date((ts + 12 * 3600) * 1000).toISOString().replace('.000Z', 'Z'),
+              flight_ended: true,
+            }],
+          }),
+        };
+      }
+      if (urlStr.includes('data-cloud.flightradar24.com')) {
+        return {
+          ok: true,
+          json: async () => ({
+            full_count: 1, version: 4,
+            'live-1': ['B1', 29.98, -95.34, 270, 35000, 430, '', '', 'B38M', 'N2', ts + 14 * 3600, 'IAH', 'SFO', 'UA999', 0, -500, 'UAL999', '', 'UAL'],
+          }),
+        };
+      }
+      return { ok: false, status: 403, text: async () => 'blocked', headers: { get: () => null } };
+    });
+
+    const res = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'IAH', dir: 'departures', timestamp: String(ts) },
+    }, res);
+
+    const calledHost = (needle) => fetchSpy.mock.calls.some((c) => String(c[0]).includes(needle));
+    return { res, fetchSpy, calledHost };
+  }
+
+  it('keeps the paid official API OFF while only pacing is holding the provider back', async () => {
+    await recordAdbUnits(300); // way past the 00:30 paced line (43), way under the 700 budget
+
+    const { res, calledHost } = await loadGatedBoard();
+
+    expect(res.statusCode).toBe(200);
+    // The provider really was gated (setup sanity — otherwise the assertion below is vacuous)...
+    expect(calledHost('aedbx/aerodatabox')).toBe(false);
+    // ...and the gate did NOT hand the traffic to the costlier provider.
+    expect(calledHost('fr24api.flightradar24.com')).toBe(false);
+    // The FREE live-feed rescue still runs, so the board degrades gracefully rather than going dark.
+    expect(calledHost('data-cloud.flightradar24.com')).toBe(true);
+  });
+
+  it('still allows the official API once the budget is TRULY exhausted (legacy behaviour preserved)', async () => {
+    await recordAdbUnits(700); // the absolute daily budget, not merely the paced line
+
+    const { res, calledHost } = await loadGatedBoard();
+
+    expect(res.statusCode).toBe(200);
+    expect(calledHost('aedbx/aerodatabox')).toBe(false);
+    // Exhaustion is the pre-existing state this fallthrough was written for; official stays
+    // reachable there, bounded by its own 402 block / 15-min breaker / daily call cap.
+    expect(calledHost('fr24api.flightradar24.com')).toBe(true);
+  });
+
+  it('keeps the official rescue AVAILABLE when the gate was open and the provider merely FAILED', async () => {
+    // The gate has to be read BEFORE the provider attempt, because the attempt moves the very inputs
+    // it is read from: fetchViaAeroDataBox bills its units before each HTTP call, so a call that then
+    // fails can push spend past the paced line and make the post-hoc check say "pacing is gating us"
+    // — suppressing the healthy paid rescue for a failure pacing had nothing to do with. 40 units at
+    // the 00:30 line of 43 is exactly that knife edge: open on entry, closed by the failed attempt's
+    // own 4 units.
+    process.env.AERODATABOX_INTER_WINDOW_DELAY_MS = '0'; // both windows fail; don't burn 1.5s waiting
+    await recordAdbUnits(40);
+    expect(isAdbOrganicRefreshGated(Date.now())).toBe(false); // setup sanity: the gate is OPEN
+
+    // loadGatedBoard's catch-all answers the AeroDataBox host with a 403, so the provider is really
+    // attempted and really fails.
+    const { res, calledHost } = await loadGatedBoard();
+
+    expect(res.statusCode).toBe(200);
+    expect(calledHost('aedbx/aerodatabox')).toBe(true);
+    // The attempt's own spend closed the gate behind it — which is precisely what must NOT decide
+    // this. Legacy behaviour (provider down => official rescue) is preserved.
+    expect(isAdbOrganicRefreshGated(Date.now())).toBe(true);
+    expect(calledHost('fr24api.flightradar24.com')).toBe(true);
+    // (cleanupScheduleTestEnv in afterEach clears AERODATABOX_INTER_WINDOW_DELAY_MS)
   });
 });
 

--- a/vercel.json
+++ b/vercel.json
@@ -66,6 +66,7 @@
       "source": "/api/(.*)",
       "headers": [
         { "key": "Access-Control-Allow-Origin", "value": "https://theblueboard.co" },
+        { "key": "Access-Control-Expose-Headers", "value": "X-BB-Feed-Stale" },
         { "key": "X-Robots-Tag", "value": "noindex, nofollow" }
       ]
     },


### PR DESCRIPTION
## Summary

**Live map reliability**
- Retry FR24 empty-feed responses once and serve bounded last-known-good UAL positions when upstream stays empty.
- Keep LIVE/STALE truthful with `X-BB-Feed-Stale` and fast client retries.

**Schedule freshness**
- Pace organic AeroDataBox spend across the UTC day instead of exhausting it before afternoon.
- Preserve cron warming and prevent a pacing-only gate from spilling into paid FR24 calls.

**AI explanations**
- Treat account-level Gateway 403s as an AI availability outage, returning the calm fallback and opening the five-minute circuit.

## Test Coverage

All materially changed success, error, timeout, stale-data, pacing-boundary, and circuit paths have regression coverage.

Tests: 1,268 → 1,302 (+34); test files: 85 → 85.

## Pre-Landing Review

Multiple specialist and adversarial review rounds completed. Findings around timeout budgets, stale-feed poisoning, fallback eviction, paid-provider spill, client freshness, and test isolation were fixed before final verification. Final checklist pass: no open issues.

## Design Review

No visual design changes; only feed-health state handling changed in the dashboard.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

CLEAN — limited to the three production reliability incidents and their tests, docs, and configuration.

## Plan Completion

No plan file detected.

## Verification Results

- [x] `bun run test` — 85 files / 1,302 tests
- [x] `bun run typecheck`
- [x] `bun run build` — 48 pages
- [x] Shuffled focused suites, seeds 1 and 3 — 156/156

## TODOS

No TODO item completed. The existing circuit-breaker/graceful-degradation backlog item records the v1.7.14 partial progress.

## Test plan

- [x] FR24 empty response retries and recovers
- [x] Recent UAL payload stale-serves across empty, 5xx, and timeout failures
- [x] Stale response age keeps client retrying and freshness honest
- [x] AeroDataBox pacing preserves afternoon budget and cannot spill into paid FR24 fallback
- [x] Gateway account-level 403 opens the AI circuit; request-specific 403 does not

🤖 Generated with [Codex](https://openai.com/codex/)
