### PR TITLE
fix(api): adapt check-flight to live upstream shapes + prediction evidence guards (v1.7.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.15] - 2026-08-11
+
+### Fixed
+- **The Starlink badge read upstream's current responses wrong in three different ways, and invented a number in a fourth.** The check-flight adapter still assumed the single `{hasStarlink, confidence, flights}` shape from the endpoint's documentation, but a live probe on Aug 11 found three: a statistical prediction when no tail is assigned yet, a verified result carried in `fallback.segments[]`, and a verified result carried in top-level `flights[]`. Only the last one worked. A legitimate "~71% of recent departures, 4 observations" forecast was discarded and rendered as nothing; a verified-negative segment (tail `N838UA`, Panasonic wifi) had its data thrown away; and `confidence ?? 'likely'` turned any positive response upstream didn't label into a fabricated 70% badge reading "0 observations". The adapter now derives truth from the segments and the prediction object rather than branching on top-level `hasStarlink`/`confidence`, which also covers the unprobed-but-plausible positive-via-fallback shape. Segment wifi values are matched against both live spellings (`Starlink` and `StrLnk` — 170 and 343 aircraft respectively, so an exact-match check would have missed two thirds of the fleet). Predictions now need real evidence behind them: zero observations or a `fleet_prior_*` method is a fleet-wide average rather than an answer about this flight, and upstream serves those as confident-looking 200s, so both are suppressed instead of shown. Predicted responses reach the badge as `confidence: 'predicted'` carrying the real upstream probability, and the dashboard gives them the forecast treatment — "likely ~71%", low-data gating, and a tooltip that reads as an estimate — instead of the deterministic verified badge. The verified path renders exactly as before. (`api/check-flight.ts`, `src/dashboard/main.js`)
+
 ## [1.7.14] - 2026-08-04
 
 ### Fixed

--- a/api/check-flight.ts
+++ b/api/check-flight.ts
@@ -1,7 +1,7 @@
-// Proxy endpoint for Starlink flight status (documented upstream contract).
-// Wraps unitedstarlinktracker.com/api/check-flight and adapts the
-// {hasStarlink, confidence, flights} shape into a probability-bearing payload
-// so the existing dashboard render code keeps working.
+// Proxy endpoint for Starlink flight status.
+// Wraps unitedstarlinktracker.com/api/check-flight and adapts its three live
+// response shapes (see adapt() below) into a probability-bearing payload so the
+// existing dashboard render code keeps working.
 
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
@@ -20,50 +20,125 @@ export function _resetCacheForTest(): void {
   upstreamUnhealthyUntil = 0;
 }
 
-interface UpstreamFlight {
+interface UpstreamSegment {
   tail_number?: string;
   aircraft_type?: string;
+  aircraft_model?: string;
   flight_number?: string;
   ua_flight_number?: string;
   departure_airport?: string;
   arrival_airport?: string;
+  origin?: string;
+  destination?: string;
   departure_time?: number;
   arrival_time?: number;
   departure_time_formatted?: string;
   arrival_time_formatted?: string;
   operated_by?: string | null;
   fleet_type?: string | null;
+  hasStarlink?: boolean;
+  confidence?: string;
+  verified_wifi?: string;
+  verified_at?: number | string;
+}
+
+interface UpstreamPrediction {
+  probability?: number;
+  confidence?: string;
+  n_observations?: number;
 }
 
 interface UpstreamResponse {
-  hasStarlink: boolean;
-  confidence?: 'verified' | 'likely';
-  flights?: UpstreamFlight[];
+  hasStarlink?: boolean;
+  confidence?: string;
+  method?: string;
+  prediction?: UpstreamPrediction;
+  flights?: UpstreamSegment[];
+  fallback?: { segments?: UpstreamSegment[] };
   message?: string;
 }
 
 interface AdaptedResponse {
   hasStarlink: boolean;
   probability: number;
-  confidence: 'verified' | 'likely' | 'none';
+  confidence: 'verified' | 'likely' | 'predicted' | 'none';
   n_observations: number;
-  flights: UpstreamFlight[];
+  flights: UpstreamSegment[];
 }
 
-// Maps upstream's discrete {hasStarlink, confidence} into a 0..1 score the
-// existing badge UI can render. Verified matches read as 95%, likely as 70%,
-// no-match as 0% (the dashboard hides the badge below 5%).
+// Matches both live spellings of the wifi value ("Starlink" 170 / "StrLnk" 343
+// as of 2026-08-11) — an exact-match check would drop 67% of the fleet.
+const STARLINK_WIFI_RE = /star\s*l|strlnk/i;
+
+// Adapts the three live response shapes (verified via segments, verified via
+// top-level, statistical prediction) into the probability payload the badge
+// renders. Truth is derived from segment data and the prediction object first;
+// top-level hasStarlink/confidence alone can no longer mint a badge — that
+// default was the fabricated-70% path.
 function adapt(u: UpstreamResponse): AdaptedResponse {
-  const hasStarlink = !!u.hasStarlink;
-  const confidence = u.confidence ?? (hasStarlink ? 'likely' : 'none');
-  const probability = !hasStarlink ? 0 : confidence === 'verified' ? 0.95 : 0.7;
-  return {
-    hasStarlink,
-    probability,
-    confidence,
-    n_observations: u.flights?.length ?? 0,
-    flights: u.flights ?? [],
-  };
+  const segments = [
+    ...(Array.isArray(u.flights) ? u.flights : []),
+    ...(Array.isArray(u.fallback?.segments) ? u.fallback!.segments! : []),
+  ];
+
+  // 1) Per-segment verification signals (only fallback-path segments carry them).
+  const signal = segments.filter((s) => typeof s.hasStarlink === 'boolean' || s.verified_wifi != null);
+  if (signal.length > 0) {
+    const positive = signal.some(
+      (s) => s.hasStarlink === true || STARLINK_WIFI_RE.test(String(s.verified_wifi ?? '')),
+    );
+    return {
+      hasStarlink: positive,
+      probability: positive ? 0.95 : 0,
+      confidence: 'verified',
+      n_observations: segments.length,
+      flights: segments,
+    };
+  }
+
+  // 2) Top-level verified (primary path: tail assigned, flights[] populated).
+  if (u.confidence === 'verified') {
+    const positive = u.hasStarlink === true;
+    return {
+      hasStarlink: positive,
+      probability: positive ? 0.95 : 0,
+      confidence: 'verified',
+      n_observations: segments.length,
+      flights: segments,
+    };
+  }
+
+  // 3) Statistical prediction — only with real evidence. n_observations of 0 or
+  //    a fleet_prior_* method is a fleet-wide average, not an answer about this
+  //    flight; upstream returns those as confident-looking 200s.
+  const p = u.prediction;
+  if (p && typeof p.probability === 'number') {
+    const n = Number(p.n_observations) || 0;
+    const isPrior = n === 0 || /^fleet_prior/.test(String(u.method ?? ''));
+    if (!isPrior) {
+      return {
+        hasStarlink: false,
+        probability: p.probability,
+        confidence: 'predicted',
+        n_observations: n,
+        flights: segments,
+      };
+    }
+    return { hasStarlink: false, probability: 0, confidence: 'none', n_observations: 0, flights: segments };
+  }
+
+  // 4) Legacy documented shape: an explicit top-level 'likely'.
+  if (u.hasStarlink === true && u.confidence === 'likely') {
+    return {
+      hasStarlink: true,
+      probability: 0.7,
+      confidence: 'likely',
+      n_observations: segments.length,
+      flights: segments,
+    };
+  }
+
+  return { hasStarlink: false, probability: 0, confidence: 'none', n_observations: segments.length, flights: segments };
 }
 
 function isValidDate(s: string): boolean {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "jonahberg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -1726,7 +1726,11 @@ function applyStarlinkPrediction(el, data) {
   // check-flight badge (tail already resolved) must render exactly as it did on
   // main — otherwise a verified-95% confirmation (n_observations≈1) would be
   // demoted to a muted "· low data" with a self-contradictory tooltip.
-  const forecast = el.getAttribute('data-mode') === 'forecast';
+  // check-flight now returns confidence:'predicted' when no tail is assigned
+  // yet; that is a statistical estimate, so it must get the forecast treatment
+  // ("likely ~N%", low-data gating) — never the deterministic verified badge.
+  // Verified responses are untouched, keeping that path byte-identical.
+  const forecast = el.getAttribute('data-mode') === 'forecast' || data.confidence === 'predicted';
 
   if (!forecast) {
     // ---- Legacy check-flight badge — byte-identical to main ----

--- a/tests/check-flight.test.js
+++ b/tests/check-flight.test.js
@@ -128,6 +128,206 @@ describe('check-flight API', () => {
     expect(res.body.n_observations).toBe(0);
   });
 
+  // Fixtures probed live from unitedstarlinktracker.com on 2026-08-11. Upstream
+  // serves three distinct shapes; truth has to come from the segments and the
+  // prediction object, never from top-level hasStarlink/confidence alone.
+  it('adapts a statistical prediction into the real upstream probability', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        hasStarlink: false,
+        confidence: 'predicted',
+        prediction: { probability: 0.7068803883056011, confidence: 'medium', n_observations: 4 },
+        message: 'Aircraft assignment not yet published — United Airlines assigns aircraft ~2 days before departure. ~71% of recent departures of this flight used a Starlink-equipped aircraft (4 observations).',
+        flights: [],
+      }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA700', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.hasStarlink).toBe(false);
+    expect(res.body.probability).toBe(0.7068803883056011);
+    expect(res.body.confidence).toBe('predicted');
+    expect(res.body.n_observations).toBe(4);
+  });
+
+  it('suppresses a prediction backed by zero observations', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        hasStarlink: false,
+        confidence: 'predicted',
+        prediction: { probability: 0.7068803883056011, confidence: 'medium', n_observations: 0 },
+        flights: [],
+      }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA701', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.hasStarlink).toBe(false);
+    expect(res.body.probability).toBe(0);
+    expect(res.body.confidence).toBe('none');
+    expect(res.body.n_observations).toBe(0);
+  });
+
+  it('suppresses a fleet-prior prediction even with observations', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        hasStarlink: false,
+        confidence: 'predicted',
+        method: 'fleet_prior_mainline',
+        prediction: { probability: 0.7068803883056011, confidence: 'medium', n_observations: 4 },
+        flights: [],
+      }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA702', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.probability).toBe(0);
+    expect(res.body.confidence).toBe('none');
+    expect(res.body.n_observations).toBe(0);
+  });
+
+  it('keeps a verified-negative fallback segment instead of discarding it', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        hasStarlink: false,
+        method: 'fr24_tail_lookup',
+        flights: [],
+        fallback: {
+          segments: [{
+            tail_number: 'N838UA',
+            aircraft_model: 'Airbus A319-131',
+            origin: 'BNA',
+            destination: 'ORD',
+            departure_time: 1786451400,
+            arrival_time: 1786458600,
+            hasStarlink: false,
+            confidence: 'negative',
+            verified_wifi: 'Panasonic',
+            verified_at: 1785834401,
+          }],
+        },
+      }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA703', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.hasStarlink).toBe(false);
+    expect(res.body.probability).toBe(0);
+    expect(res.body.confidence).toBe('verified');
+    expect(res.body.n_observations).toBe(1);
+    expect(res.body.flights[0].tail_number).toBe('N838UA');
+  });
+
+  it('reads a verified-positive fallback segment', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        hasStarlink: false,
+        method: 'fr24_tail_lookup',
+        flights: [],
+        fallback: {
+          segments: [{
+            tail_number: 'N838UA',
+            hasStarlink: true,
+            confidence: 'verified',
+            verified_wifi: 'Starlink',
+            verified_at: 1785834401,
+          }],
+        },
+      }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA704', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.hasStarlink).toBe(true);
+    expect(res.body.probability).toBeCloseTo(0.95, 2);
+    expect(res.body.confidence).toBe('verified');
+    expect(res.body.n_observations).toBe(1);
+  });
+
+  it('reads the StrLnk wifi spelling with no hasStarlink key on the segment', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        hasStarlink: false,
+        method: 'fr24_tail_lookup',
+        flights: [],
+        fallback: {
+          segments: [{ tail_number: 'N838UA', verified_wifi: 'StrLnk', verified_at: 1785834401 }],
+        },
+      }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA705', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.hasStarlink).toBe(true);
+    expect(res.body.probability).toBeCloseTo(0.95, 2);
+    expect(res.body.confidence).toBe('verified');
+    expect(res.body.n_observations).toBe(1);
+  });
+
+  it('adapts the primary-path verified positive (segments carry no wifi signal)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        hasStarlink: true,
+        confidence: 'verified',
+        method: 'fr24_tail_lookup',
+        flights: [{
+          tail_number: 'N626SY',
+          aircraft_type: 'Embraer E175LL',
+          flight_number: 'UA5779',
+          ua_flight_number: 'UA5779',
+          departure_airport: 'DEN',
+          arrival_airport: 'ASE',
+          departure_time: 1786497300,
+          arrival_time: 1786500960,
+          departure_time_formatted: '2026-08-12T01:15:00.000Z',
+          arrival_time_formatted: '2026-08-12T02:16:00.000Z',
+          operated_by: 'Skywest dba UAX',
+          fleet_type: 'express',
+        }],
+      }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA706', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.hasStarlink).toBe(true);
+    expect(res.body.probability).toBeCloseTo(0.95, 2);
+    expect(res.body.confidence).toBe('verified');
+    expect(res.body.n_observations).toBe(1);
+  });
+
+  it('never mints a badge from a bare top-level hasStarlink', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ hasStarlink: true, flights: [] }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA707', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.hasStarlink).toBe(false);
+    expect(res.body.probability).toBe(0);
+    expect(res.body.confidence).toBe('none');
+  });
+
+  it('still honors the documented legacy likely shape', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ hasStarlink: true, confidence: 'likely', flights: [] }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA708', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.hasStarlink).toBe(true);
+    expect(res.body.probability).toBeCloseTo(0.7, 2);
+    expect(res.body.confidence).toBe('likely');
+  });
+
   it('strips ICAO UAL prefix before forwarding to upstream', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Premise correction first

The June research memo said this endpoint reads the `/api/data` feed's removed `flights[]` and needed porting to `flightsByTail`. Live probing on Aug 11 shows that's outdated: commit 4f070d5 already migrated it to upstream's dedicated `/api/check-flight`, which is alive — and the verified-positive path already renders correctly. A literal `flightsByTail` port would have *regressed* the endpoint (BB's snapshot only covers Starlink tails, can't say "no", and can't match marketing UA numbers against operator-code rows like `OO…`/`YX…`).

What was actually broken, against the three shapes the endpoint returns today:

1. **Predictions were discarded entirely.** When no tail is assigned yet, upstream returns `confidence:"predicted"` + a `prediction` object ("71%, 4 observations" for UA1001). The adapter mapped it to probability 0 → badge hidden.
2. **Verified-negative segment data was thrown away** (`fallback.segments[]` with `verified_wifi:"Panasonic"`).
3. **No evidence guards** — nothing checked `n_observations` or `method`.
4. **One live fabrication path**: `confidence ?? 'likely'` turned any positive upstream didn't label into a fake 70% badge reading "0 observations".

## The fix

The adapter derives truth from segments and the prediction object — top-level `hasStarlink`/`confidence` alone can no longer mint a badge. Segment wifi matches both live spellings (`Starlink` 170 / `StrLnk` 343 — exact-match would drop 67% of the fleet). Predictions require real evidence: `n_observations === 0` or a `fleet_prior_*` method is a fleet-wide average served as a confident-looking 200, so both are suppressed. Predicted responses reach the dashboard as `confidence:'predicted'` with the *real* upstream probability, and `applyStarlinkPrediction` gives them the forecast treatment ("likely ~N%", low-data gating, estimate-worded tooltip). The verified badge path renders byte-identically to main.

Tests: 9 cases added using the live-probed fixtures verbatim (7 reproduce bugs, 2 are regression guards). Gates: `bun run test` 1311 passed, `tsc --noEmit` clean, `bun run build` clean.

**Deliberately not added:** a local-snapshot fallback tier for upstream outages — a yes-only answer from a ≤12h-stale snapshot on a decorative badge reintroduces the wrong-badge class this PR kills; hidden-badge-on-outage is the honest behavior.

⚠️ Version bump (1.7.15) will conflict with #242/#243 — rebase after the first merge, same as the Jun 14 six-PR wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

