### PR TITLE
fix(cron): validate Starlink payloads before persisting or serving (v1.7.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.17] - 2026-08-11
+
+### Fixed
+- **The Starlink sync accepted structurally broken upstream feeds and persisted them as the durable "good" snapshot.** The cron's only guard was `length === 0`, which passes anything non-empty — so the failure mode that matters most goes through untouched: if unitedstarlinktracker.com renames `TailNumber` (it already reshaped `flights[]`/`fallback.segments[]` into `flightsByTail` between June and August without notice), the normalizer emits 513 records with empty tails, the guard waves them through, Supabase stores them for 12h, every tail lookup on the board silently stops matching, and every endpoint keeps returning green 200s. The cron now runs §05 structural validators before persisting: an absolute floor of 400 aircraft (live count is 513), a ≥98% valid-N-number tail ratio, a ≥90%-of-previous-snapshot relative check (read back via `loadStarlinkSnapshot`, skipped when no snapshot exists), and a fleetStats-vs-record-count agreement check with a ±max(5, 2%) tolerance — tolerance rather than equality, since upstream double-counts the MAX 9 and a benign one-off drift must not freeze snapshot updates. A rejected payload returns 502 with the specific `reasons`, and the snapshot, the globalThis fast path, and the in-memory cache are all left holding the last good data. Missing fleetStats and a >6h-old upstream `lastUpdated` are logged as warnings, not failures: degraded metadata is still the best data available. The same validators now run on `/api/starlink-data`'s direct-fetch fallback, where a failure throws into the existing degrade ladder (stale snapshot → committed static file) instead of serving a 10-aircraft board and caching it for the next four hours. (`api/_starlink-normalize.ts`, `api/cron/sync-starlink.ts`, `api/starlink-data.ts`)
+
 ## [1.7.16] - 2026-08-11
 
 ### Changed

--- a/api/_starlink-normalize.ts
+++ b/api/_starlink-normalize.ts
@@ -189,3 +189,59 @@ export function normalizeStarlinkPayload(upstream: any, syncedAt: string = new D
     syncedAt,
   };
 }
+
+// §05 validators (research audit 2026-08-11): the length===0 guard the cron
+// used accepts a structurally broken feed — e.g. a TailNumber field rename
+// yields 513 records with empty tails, persists, and silently breaks all tail
+// matching while every endpoint returns green 200s. These checks reject that
+// class of payload before it can poison the durable snapshot.
+
+export const STARLINK_MIN_AIRCRAFT = 400;            // absolute floor (live count 513 on 2026-08-11)
+export const STARLINK_MIN_VALID_TAIL_RATIO = 0.98;   // catches field renames → empty tails
+export const STARLINK_MIN_RELATIVE_RATIO = 0.9;      // catches partial feeds vs the last snapshot
+export const STARLINK_STALE_MS = 6 * 60 * 60 * 1000; // upstream refreshes ~5-minutely
+
+export interface StarlinkValidation {
+  ok: boolean;
+  failures: string[];  // reject the payload
+  warnings: string[];  // log, but the payload is still the best data available
+}
+
+export function validateStarlinkPayload(payload: StarlinkPayload, previousTotal?: number): StarlinkValidation {
+  const failures: string[] = [];
+  const warnings: string[] = [];
+  const n = payload.aircraft.length;
+
+  if (n < STARLINK_MIN_AIRCRAFT) {
+    failures.push(`aircraft count ${n} below absolute floor ${STARLINK_MIN_AIRCRAFT}`);
+  }
+
+  const validTails = payload.aircraft.filter((a) => /^N\d/.test(a.tail)).length;
+  if (n > 0 && validTails / n < STARLINK_MIN_VALID_TAIL_RATIO) {
+    failures.push(`only ${validTails}/${n} aircraft carry a valid N-number tail — upstream field rename?`);
+  }
+
+  if (typeof previousTotal === 'number' && previousTotal > 0 && n < STARLINK_MIN_RELATIVE_RATIO * previousTotal) {
+    failures.push(`aircraft count ${n} under 90% of previous snapshot ${previousTotal} — partial feed?`);
+  }
+
+  const fs = payload.fleetStats;
+  if (fs) {
+    // Tolerance, not equality: upstream double-counts the MAX 9 (±1 today), and a
+    // benign small drift must not freeze snapshot updates.
+    const statsTotal = fs.mainline + fs.express;
+    const tolerance = Math.max(5, Math.round(0.02 * n));
+    if (Math.abs(statsTotal - n) > tolerance) {
+      failures.push(`fleetStats total ${statsTotal} disagrees with aircraft count ${n} beyond ±${tolerance}`);
+    }
+  } else {
+    warnings.push('fleetStats missing from upstream payload');
+  }
+
+  const updatedMs = Date.parse(payload.lastUpdated);
+  if (Number.isFinite(updatedMs) && Date.now() - updatedMs > STARLINK_STALE_MS) {
+    warnings.push(`upstream lastUpdated ${payload.lastUpdated} is over 6h old`);
+  }
+
+  return { ok: failures.length === 0, failures, warnings };
+}

--- a/api/cron/sync-starlink.ts
+++ b/api/cron/sync-starlink.ts
@@ -6,8 +6,8 @@
 // Config in vercel.json: { "path": "/api/cron/sync-starlink", "schedule": "0 */4 * * *" }
 
 import type { VercelRequest, VercelResponse } from '../types.js';
-import { normalizeStarlinkPayload } from '../_starlink-normalize.js';
-import { saveStarlinkSnapshot } from '../_starlink-snapshot.js';
+import { normalizeStarlinkPayload, validateStarlinkPayload } from '../_starlink-normalize.js';
+import { loadStarlinkSnapshot, saveStarlinkSnapshot } from '../_starlink-snapshot.js';
 import { isAuthorizedCronRequest } from '../_cron-auth.js';
 
 const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/data';
@@ -35,10 +35,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const upstream = await resp.json();
     const enriched = normalizeStarlinkPayload(upstream);
 
-    // Refuse to persist an empty board — a transient empty 200 must not poison the durable snapshot
+    // §05 validators: refuse to persist a structurally broken payload — a
+    // transient empty/partial/renamed feed must not poison the durable snapshot
     // and get served as the "good" fallback for the next 12h.
-    if (enriched.aircraft.length === 0) {
-      return res.status(502).json({ error: 'Upstream returned 0 Starlink aircraft — snapshot not updated' });
+    const previous = await loadStarlinkSnapshot();
+    const validation = validateStarlinkPayload(enriched, previous?.data.aircraft.length);
+    for (const warning of validation.warnings) {
+      console.warn(`Cron sync-starlink warning: ${warning}`);
+    }
+    if (!validation.ok) {
+      console.error(`Cron sync-starlink rejected upstream payload: ${validation.failures.join('; ')}`);
+      return res.status(502).json({
+        error: 'Upstream payload failed validation — snapshot not updated',
+        reasons: validation.failures,
+      });
     }
 
     // Same-instance fast path (cheap; harmless). The durable cross-instance handoff is Supabase.

--- a/api/starlink-data.ts
+++ b/api/starlink-data.ts
@@ -11,7 +11,7 @@
 import { createRequire } from 'node:module';
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
-import { normalizeStarlinkPayload, normalizeOperator, normalizeType, type StarlinkPayload } from './_starlink-normalize.js';
+import { normalizeStarlinkPayload, normalizeOperator, normalizeType, validateStarlinkPayload, type StarlinkPayload } from './_starlink-normalize.js';
 import { loadStarlinkSnapshot, type PersistedStarlinkSnapshot } from './_starlink-snapshot.js';
 
 const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/data';
@@ -67,7 +67,7 @@ function staticPayload(): StarlinkPayload | null {
   };
 }
 
-async function fetchUpstream(): Promise<StarlinkPayload> {
+async function fetchUpstream(previousTotal?: number): Promise<StarlinkPayload> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 15000);
 
@@ -78,7 +78,19 @@ async function fetchUpstream(): Promise<StarlinkPayload> {
   clearTimeout(timeout);
 
   if (!resp.ok) throw new Error(`Upstream ${resp.status}`);
-  return normalizeStarlinkPayload(await resp.json());
+  const payload = normalizeStarlinkPayload(await resp.json());
+
+  // §05 validators: a parseable 200 is not proof of a usable feed. Throwing here routes a
+  // structurally broken payload into the existing degrade ladder (stale snapshot → static)
+  // instead of serving it and caching it in memory for the next 4h.
+  const validation = validateStarlinkPayload(payload, previousTotal);
+  for (const warning of validation.warnings) {
+    console.warn(`Starlink data warning: ${warning}`);
+  }
+  if (!validation.ok) {
+    throw new Error(`Upstream payload failed validation: ${validation.failures.join('; ')}`);
+  }
+  return payload;
 }
 
 function serveFresh(res: VercelResponse, payload: StarlinkPayload, source: string) {
@@ -128,7 +140,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(429).json({ error: 'Too many requests' });
     }
 
-    inMemoryCache = await fetchUpstream();
+    inMemoryCache = await fetchUpstream(snapshot?.data.aircraft.length);
     lastFetch = Date.now();
     return serveFresh(res, inMemoryCache, 'upstream');
   } catch (err: any) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "jonahberg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.16",
+  "version": "1.7.17",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/tests/starlink-data.test.js
+++ b/tests/starlink-data.test.js
@@ -22,24 +22,38 @@ function makeReq(overrides = {}) {
 
 // Mirrors the live upstream: totalCount is the WHOLE tracked fleet (not the Starlink count),
 // fleetStats has no `combined`, departure_time is a UNIX-seconds integer, operator/type casing
-// is inconsistent.
+// is inconsistent. Sized to the live equipped count (513 on 2026-08-11) so it clears the §05
+// absolute floor; the two hand-written aircraft stay at indexes 0 and 1 for the normalisation
+// assertions, and fleetStats (170 mainline + 343 express) sums to the record count.
 function mockUpstreamResponse() {
+  const starlinkPlanes = [
+    { TailNumber: 'N37559', fleet: 'mainline', Aircraft: 'Boeing 737-824', OperatedBy: 'United Airlines', DateFound: '2020-01-01', WiFi: 'Starlink' },
+    { TailNumber: 'N77296', fleet: 'express', Aircraft: 'Bombardier CRJ-550', OperatedBy: 'Skywest dba UAX', DateFound: '2020-01-01', WiFi: 'StrLnk' },
+  ];
+  while (starlinkPlanes.length < 513) {
+    const i = starlinkPlanes.length;
+    starlinkPlanes.push({
+      TailNumber: `N${20000 + i}`,
+      fleet: i < 170 ? 'mainline' : 'express',
+      Aircraft: 'Boeing 737-824',
+      OperatedBy: 'United Airlines',
+      DateFound: '2020-01-01',
+      WiFi: 'Starlink',
+    });
+  }
   return {
-    starlinkPlanes: [
-      { TailNumber: 'N37559', fleet: 'mainline', Aircraft: 'Boeing 737-824', OperatedBy: 'United Airlines', DateFound: '2020-01-01', WiFi: 'Starlink' },
-      { TailNumber: 'N77296', fleet: 'express', Aircraft: 'Bombardier CRJ-550', OperatedBy: 'Skywest dba UAX', DateFound: '2020-01-01', WiFi: 'StrLnk' },
-    ],
+    starlinkPlanes,
     totalCount: 1781,
     fleetStats: {
-      mainline: { starlink: 51, total: 1122 },
-      express: { starlink: 320, total: 659 },
+      mainline: { starlink: 170, total: 1122 },
+      express: { starlink: 343, total: 659 },
     },
     flightsByTail: {
       N37559: [
         { flight_number: 'UA1234', departure_airport: 'ORD', arrival_airport: 'LAX', departure_time: 1780270800, arrival_time: 1780280100, airline: 'UA' },
       ],
     },
-    lastUpdated: '2026-05-31T23:02:04.479Z',
+    lastUpdated: new Date().toISOString(),
   };
 }
 
@@ -118,7 +132,7 @@ describe('starlink-data API', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.headers['X-Starlink-Source']).toBe('upstream');
-    expect(res.body.aircraft).toHaveLength(2);
+    expect(res.body.aircraft).toHaveLength(513);
     expect(res.body.aircraft[0].tail).toBe('N37559');
     expect(res.body.aircraft[0].fleet).toBe('Mainline');
     expect(res.body.aircraft[1].fleet).toBe('Express');
@@ -126,10 +140,10 @@ describe('starlink-data API', () => {
     expect(res.body.aircraft[0].type).toBe('737-800');   // from "Boeing 737-824"
     expect(res.body.aircraft[1].type).toBe('CRJ-550');   // from "Bombardier CRJ-550"
     expect(res.body.aircraft[1].operator).toBe('SkyWest dba UAX'); // from "Skywest dba UAX"
-    expect(res.body.fleetStats.mainline).toBe(51);
-    expect(res.body.fleetStats.express).toBe(320);
+    expect(res.body.fleetStats.mainline).toBe(170);
+    expect(res.body.fleetStats.express).toBe(343);
     // The headline fix: serve the real Starlink count, NOT upstream.totalCount (1781 = whole fleet)
-    expect(res.body.totalCount).toBe(2);
+    expect(res.body.totalCount).toBe(513);
     expect(res.body.totalCount).not.toBe(1781);
 
     // Verify flight normalization: epoch → ISO string + numeric ts
@@ -212,7 +226,27 @@ describe('starlink-data API — Supabase snapshot + rate-limit branches', () => 
 
     expect(res.statusCode).toBe(200);
     expect(res.headers['X-Starlink-Source']).toBe('upstream');
-    expect(res.body.aircraft).toHaveLength(2);
+    expect(res.body.aircraft).toHaveLength(513);
+  });
+
+  // §05 validators on the direct-fetch path: a structurally broken upstream 200 must not be
+  // served just because it parsed. The stale snapshot is better data than a 10-aircraft board.
+  it('rejects a structurally broken upstream 200 and degrades to the stale snapshot', async () => {
+    loadStarlinkSnapshot.mockResolvedValue({ refreshedAt: Date.now() - 7 * 60 * 60 * 1000, data: snapshotPayload() });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const broken = mockUpstreamResponse();
+    broken.starlinkPlanes = broken.starlinkPlanes.slice(0, 10);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => broken });
+
+    const res = createRes();
+    await handler(makeReq(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['X-Starlink-Source']).toBe('supabase-stale');
+    expect(res.body.aircraft).toHaveLength(1);
+    errSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   it('degrades to the stale snapshot ("supabase-stale") when the rate limiter trips', async () => {

--- a/tests/starlink-normalize.test.js
+++ b/tests/starlink-normalize.test.js
@@ -3,6 +3,7 @@ import {
   normalizeOperator,
   normalizeType,
   normalizeStarlinkPayload,
+  validateStarlinkPayload,
 } from '../api/_starlink-normalize.js';
 
 describe('normalizeOperator', () => {
@@ -135,5 +136,90 @@ describe('normalizeStarlinkPayload', () => {
     const flight = out.flightsByTail.N32[0];
     expect(flight.departure_ts).toBe(1780270800);
     expect(flight.departure_time).toBe(iso);
+  });
+});
+
+describe('validateStarlinkPayload', () => {
+  // Builds the NORMALIZED payload shape (the validator's input) rather than raw upstream —
+  // validation runs after normalizeStarlinkPayload at both call sites.
+  function makePayload({ count = 513, tail, fleetStats, lastUpdated = new Date().toISOString() } = {}) {
+    const aircraft = Array.from({ length: count }, (_, i) => ({
+      tail: tail ? tail(i) : `N${100 + i}`,
+      fleet: i % 2 === 0 ? 'Mainline' : 'Express',
+      type: '737-800',
+      operator: 'United Airlines',
+      dateFound: '2026-01-01',
+      wifi: 'Starlink',
+    }));
+    const mainline = Math.ceil(count / 2);
+    const express = Math.floor(count / 2);
+    return {
+      aircraft,
+      totalCount: count,
+      fleetStats: fleetStats === undefined
+        ? { mainline, express, total: count, mainlineTotal: 1122, expressTotal: 659, fleetTotal: 1781, mainlinePct: 15, expressPct: 52 }
+        : fleetStats,
+      flightsByTail: {},
+      lastUpdated,
+      syncedAt: new Date().toISOString(),
+    };
+  }
+
+  it('accepts a healthy full-size payload', () => {
+    const out = validateStarlinkPayload(makePayload());
+    expect(out.ok).toBe(true);
+    expect(out.failures).toEqual([]);
+    expect(out.warnings).toEqual([]);
+  });
+
+  it('rejects a payload under the absolute aircraft floor', () => {
+    const out = validateStarlinkPayload(makePayload({ count: 300 }));
+    expect(out.ok).toBe(false);
+    expect(out.failures.join('; ')).toMatch(/absolute floor/);
+  });
+
+  it('rejects a partial feed relative to the previous snapshot', () => {
+    const out = validateStarlinkPayload(makePayload({ count: 500 }), 600);
+    expect(out.ok).toBe(false);
+    expect(out.failures.join('; ')).toMatch(/previous snapshot/);
+  });
+
+  it('skips the relative check when no previous snapshot is supplied', () => {
+    const out = validateStarlinkPayload(makePayload());
+    expect(out.ok).toBe(true);
+  });
+
+  // The June-flagged failure mode: an upstream TailNumber → tail_number rename yields a full-size
+  // record count with empty tails, which the old length===0 guard waved through.
+  it('rejects a full-size payload whose tails are all empty (upstream field rename)', () => {
+    const out = validateStarlinkPayload(makePayload({ tail: () => '' }));
+    expect(out.ok).toBe(false);
+    expect(out.failures.join('; ')).toMatch(/valid N-number/);
+  });
+
+  it('rejects fleetStats that disagree with the aircraft count beyond tolerance', () => {
+    const fleetStats = { mainline: 300, express: 300, total: 600, mainlineTotal: 1122, expressTotal: 659, fleetTotal: 1781, mainlinePct: 27, expressPct: 46 };
+    const out = validateStarlinkPayload(makePayload({ fleetStats }));
+    expect(out.ok).toBe(false);
+    expect(out.failures.join('; ')).toMatch(/fleetStats/);
+  });
+
+  it('tolerates a ±1 fleetStats drift (upstream double-counts the MAX 9)', () => {
+    const fleetStats = { mainline: 257, express: 257, total: 514, mainlineTotal: 1122, expressTotal: 659, fleetTotal: 1781, mainlinePct: 23, expressPct: 39 };
+    const out = validateStarlinkPayload(makePayload({ fleetStats }));
+    expect(out.ok).toBe(true);
+  });
+
+  it('warns but accepts when fleetStats is missing', () => {
+    const out = validateStarlinkPayload(makePayload({ fleetStats: null }));
+    expect(out.ok).toBe(true);
+    expect(out.warnings.join('; ')).toMatch(/fleetStats/);
+  });
+
+  it('warns but accepts a stale upstream lastUpdated', () => {
+    const twelveHoursAgo = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
+    const out = validateStarlinkPayload(makePayload({ lastUpdated: twelveHoursAgo }));
+    expect(out.ok).toBe(true);
+    expect(out.warnings.join('; ')).toMatch(/6h old/);
   });
 });

--- a/tests/sync-starlink.test.js
+++ b/tests/sync-starlink.test.js
@@ -5,8 +5,13 @@ import { saveStarlinkSnapshot } from '../api/_starlink-snapshot.js';
 // The durable cross-instance handoff is the Supabase snapshot, not globalThis (which does not
 // survive across serverless instances — the bug the cron header documents it replaces). In the
 // test env getSupabaseAdmin() returns null, so the real saveStarlinkSnapshot is a silent no-op;
-// mock it so the persistence call itself is observable.
-vi.mock('../api/_starlink-snapshot.js', () => ({ saveStarlinkSnapshot: vi.fn() }));
+// mock it so the persistence call itself is observable. loadStarlinkSnapshot (read back for the
+// validator's relative-size check) returns null so the check is skipped, matching an unconfigured
+// Supabase — the implementation is passed at creation so it survives vi.restoreAllMocks().
+vi.mock('../api/_starlink-snapshot.js', () => ({
+  saveStarlinkSnapshot: vi.fn(),
+  loadStarlinkSnapshot: vi.fn(async () => null),
+}));
 
 function createRes() {
   return {
@@ -27,10 +32,13 @@ function makeReq(overrides = {}) {
   };
 }
 
-function mockUpstream(planes = 2) {
+// Default size is a realistic live fleet (513 equipped on 2026-08-11) because the §05 validators
+// reject anything under the absolute floor. fleetStats tracks the mainline/express split the loop
+// assigns, so the stats-vs-count consistency check passes at every size.
+function mockUpstream(planes = 513, { tailKey = 'TailNumber' } = {}) {
   return {
     starlinkPlanes: Array.from({ length: planes }, (_, i) => ({
-      TailNumber: `N${10000 + i}`,
+      [tailKey]: `N${10000 + i}`,
       fleet: i % 2 === 0 ? 'mainline' : 'express',
       Aircraft: 'Boeing 737-824',
       OperatedBy: 'Skywest dba UAX',
@@ -39,11 +47,11 @@ function mockUpstream(planes = 2) {
     })),
     totalCount: 1781, // upstream's whole-fleet number; must not become the Starlink count
     fleetStats: {
-      mainline: { starlink: 1, total: 800 },
-      express: { starlink: 1, total: 500 },
+      mainline: { starlink: Math.ceil(planes / 2), total: 800 },
+      express: { starlink: Math.floor(planes / 2), total: 500 },
     },
     flightsByTail: {},
-    lastUpdated: '2026-05-31T23:02:04.479Z',
+    lastUpdated: new Date().toISOString(),
   };
 }
 
@@ -75,7 +83,7 @@ describe('sync-starlink cron', () => {
   it('syncs data from upstream and stores in globalThis', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
-      json: async () => mockUpstream(3),
+      json: async () => mockUpstream(513),
     });
 
     const res = createRes();
@@ -83,25 +91,25 @@ describe('sync-starlink cron', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.body.status).toBe('ok');
-    expect(res.body.aircraft_count).toBe(3);
+    expect(res.body.aircraft_count).toBe(513);
 
     // Verify globalThis cache was populated
     const cache = (globalThis).__starlinkCache;
     expect(cache).toBeDefined();
-    expect(cache.aircraft).toHaveLength(3);
+    expect(cache.aircraft).toHaveLength(513);
     expect(cache.syncedAt).toBeDefined();
 
     // The durable cross-instance handoff: the enriched payload must be persisted to Supabase.
     // Without this assertion, deleting the saveStarlinkSnapshot call regresses to the prior
     // globalThis-only no-op incident with the whole suite still green.
     expect(saveStarlinkSnapshot).toHaveBeenCalledTimes(1);
-    expect(saveStarlinkSnapshot.mock.calls[0][0].aircraft).toHaveLength(3);
+    expect(saveStarlinkSnapshot.mock.calls[0][0].aircraft).toHaveLength(513);
   });
 
   it('normalizes aircraft data format', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
-      json: async () => mockUpstream(1),
+      json: async () => mockUpstream(513),
     });
 
     const res = createRes();
@@ -112,7 +120,7 @@ describe('sync-starlink cron', () => {
     expect(cache.aircraft[0].fleet).toBe('Mainline');        // capitalized
     expect(cache.aircraft[0].type).toBe('737-800');          // normalized from "Boeing 737-824"
     expect(cache.aircraft[0].operator).toBe('SkyWest dba UAX'); // normalized casing
-    expect(cache.totalCount).toBe(1);                        // real Starlink count, not upstream 1781
+    expect(cache.totalCount).toBe(513);                      // real Starlink count, not upstream 1781
   });
 
   it('refuses to persist an empty board (does not poison the snapshot/cache)', async () => {
@@ -120,15 +128,56 @@ describe('sync-starlink cron', () => {
       ok: true,
       json: async () => mockUpstream(0),
     });
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const res = createRes();
     await handler(makeReq(), res);
 
     expect(res.statusCode).toBe(502);
-    expect(res.body.error).toMatch(/0 Starlink/);
+    expect(res.body.reasons.join('; ')).toMatch(/absolute floor/);
     expect((globalThis).__starlinkCache).toBeUndefined();
     // An empty board must never reach the durable snapshot.
     expect(saveStarlinkSnapshot).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  // §05 validators. The old length===0 guard passed anything non-empty, so a shrunken or
+  // structurally broken feed persisted and was then served as the "good" fallback for 12h.
+
+  it('refuses to persist a payload under the absolute aircraft floor', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => mockUpstream(300),
+    });
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const res = createRes();
+    await handler(makeReq(), res);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body.reasons.join('; ')).toMatch(/absolute floor/);
+    expect((globalThis).__starlinkCache).toBeUndefined();
+    expect(saveStarlinkSnapshot).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('refuses to persist a full-size feed whose tail field was renamed upstream', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => mockUpstream(513, { tailKey: 'tail_number' }),
+    });
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const res = createRes();
+    await handler(makeReq(), res);
+
+    // 513 records, every tail empty — the count guard sees a healthy feed; only the tail-ratio
+    // check catches it before it silently breaks every tail lookup on the board.
+    expect(res.statusCode).toBe(502);
+    expect(res.body.reasons.join('; ')).toMatch(/valid N-number/);
+    expect((globalThis).__starlinkCache).toBeUndefined();
+    expect(saveStarlinkSnapshot).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 
   it('returns 502 when upstream returns error status', async () => {


### PR DESCRIPTION
## The failure mode this closes

The Starlink sync cron's only guard was `length === 0`. The specific risk (flagged in June, re-confirmed live Aug 11): an upstream field rename (`TailNumber` → `tail_number`) yields 513 records with **empty tails**, passes that guard, persists to Supabase, and silently breaks all tail matching for 12h while every endpoint returns green 200s. Not hypothetical — this feed already reshaped once without notice between June and August (`flights[]`/`fallback.segments[]` → `flightsByTail`).

## What's added

`validateStarlinkPayload()` in `api/_starlink-normalize.ts`, wired into **both** consumers:

- **Reject** (snapshot not persisted / payload not served): count below 400 absolute floor; <98% valid N-number tails (the rename detector); <90% of the previous snapshot (partial-feed detector, skipped when no previous snapshot loads); fleetStats disagreeing with the record count beyond ±max(5, 2%) — tolerance, not equality, because upstream double-counts the MAX 9 today and a benign ±1 must not freeze updates.
- **Warn only** (logged, still served): missing fleetStats, upstream `lastUpdated` >6h old — degraded metadata is still the best data available.

`sync-starlink.ts` returns 502 with the specific `reasons` and persists nothing; `starlink-data.ts`'s direct-fetch path throws into the existing degrade ladder (stale snapshot → committed static) instead of serving and caching a broken board for 4h. The cron's new `loadStarlinkSnapshot` read degrades to null on any Supabase failure — it can skip the relative check but never block a sync.

**Already done, no code needed:** the StrLnk half of the brief. `normalizeWifi()` has matched both upstream spellings since May (`/star\s*l|strlnk|starlink/i`, test-covered), so no `wifi === 'Starlink'` landmine exists in BB code — any future wifi filter must keep using the normalized field.

Gates: `bun run test` 1314 passed (+12 new: 9 validator, 2 cron, 1 degrade-path), `tsc --noEmit` clean, `bun run build` clean.

⚠️ Version bump (1.7.17) will conflict with #241/#242 — rebase after the first merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

