### PR TITLE
fix(starlink): recognize N76265

### DIFF
--- a/api/_starlink-normalize.ts
+++ b/api/_starlink-normalize.ts
@@ -18,6 +18,9 @@
 //      client can pick the next UPCOMING flight and format the time.
 //   5. enrichment: we now carry DateFound (powers the "NEW" badge / weekly-adds) and WiFi.
 
+import { applyVerifiedStarlinkOverrides } from '../src/lib/starlink-overrides.js';
+export { applyVerifiedStarlinkOverrides } from '../src/lib/starlink-overrides.js';
+
 export interface StarlinkAircraft {
   tail: string;
   fleet: string;        // "Mainline" | "Express"
@@ -55,6 +58,28 @@ export interface StarlinkPayload {
   flightsByTail: Record<string, StarlinkFlight[]>;
   lastUpdated: string;
   syncedAt: string;
+}
+
+export function applyVerifiedStarlinkPayloadOverrides(payload: StarlinkPayload): StarlinkPayload {
+  // Preserve an empty payload so validation and degraded-path selection still see the outage.
+  if (payload.aircraft.length === 0) return payload;
+
+  const aircraft = applyVerifiedStarlinkOverrides(payload.aircraft) as StarlinkAircraft[];
+  const additions = aircraft.slice(payload.aircraft.length);
+  if (additions.length === 0) return payload;
+
+  const mainlineAdditions = additions.filter((a) => a.fleet === 'Mainline').length;
+  const expressAdditions = additions.filter((a) => a.fleet === 'Express').length;
+  const fleetStats = payload.fleetStats ? {
+    ...payload.fleetStats,
+    mainline: payload.fleetStats.mainline + mainlineAdditions,
+    express: payload.fleetStats.express + expressAdditions,
+    total: payload.fleetStats.total + additions.length,
+    mainlinePct: pct(payload.fleetStats.mainline + mainlineAdditions, payload.fleetStats.mainlineTotal),
+    expressPct: pct(payload.fleetStats.express + expressAdditions, payload.fleetStats.expressTotal),
+  } : null;
+
+  return { ...payload, aircraft, totalCount: aircraft.length, fleetStats };
 }
 
 // Canonical carrier spellings. Any case-insensitive occurrence of the token is rewritten so future
@@ -128,7 +153,7 @@ function pct(part: number, whole: number): number {
 export function normalizeStarlinkPayload(upstream: any, syncedAt: string = new Date().toISOString()): StarlinkPayload {
   const planes: any[] = Array.isArray(upstream?.starlinkPlanes) ? upstream.starlinkPlanes : [];
 
-  const aircraft: StarlinkAircraft[] = planes.map((p) => ({
+  const upstreamAircraft: StarlinkAircraft[] = planes.map((p) => ({
     tail: String(p?.TailNumber ?? '').trim(),
     fleet: capitalizeFleet(p?.fleet),
     type: normalizeType(p?.Aircraft),
@@ -136,7 +161,6 @@ export function normalizeStarlinkPayload(upstream: any, syncedAt: string = new D
     dateFound: String(p?.DateFound ?? '').trim(),
     wifi: normalizeWifi(p?.WiFi),
   }));
-
   const fs = upstream?.fleetStats;
   const mainline = Number(fs?.mainline?.starlink ?? 0) || 0;
   const express = Number(fs?.express?.starlink ?? 0) || 0;
@@ -144,7 +168,7 @@ export function normalizeStarlinkPayload(upstream: any, syncedAt: string = new D
   const expressTotal = Number(fs?.express?.total ?? 0) || 0;
   // total = real Starlink count. Prefer upstream.combined when present, else mainline+express, else
   // the array length. Never upstream.totalCount (that is the whole tracked fleet).
-  const total = Number(fs?.combined?.starlink ?? (mainline + express || aircraft.length)) || aircraft.length;
+  const total = Number(fs?.combined?.starlink ?? (mainline + express || upstreamAircraft.length)) || upstreamAircraft.length;
   const fleetStats: StarlinkFleetStats | null = fs ? {
     mainline,
     express,
@@ -180,14 +204,17 @@ export function normalizeStarlinkPayload(upstream: any, syncedAt: string = new D
     flightsByTail[tail] = mapped;
   }
 
-  return {
-    aircraft,
-    totalCount: aircraft.length,
+  const payload: StarlinkPayload = {
+    aircraft: upstreamAircraft,
+    totalCount: upstreamAircraft.length,
     fleetStats,
     flightsByTail,
     lastUpdated: typeof upstream?.lastUpdated === 'string' && upstream.lastUpdated ? upstream.lastUpdated : syncedAt,
     syncedAt,
   };
+  // Do not turn an empty/malformed upstream response into a seemingly healthy payload. The
+  // validator must still see zero records and reject it. A non-empty feed can be augmented.
+  return applyVerifiedStarlinkPayloadOverrides(payload);
 }
 
 // §05 validators (research audit 2026-08-11): the length===0 guard the cron

--- a/api/starlink-data.ts
+++ b/api/starlink-data.ts
@@ -11,7 +11,15 @@
 import { createRequire } from 'node:module';
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
-import { normalizeStarlinkPayload, normalizeOperator, normalizeType, validateStarlinkPayload, type StarlinkPayload } from './_starlink-normalize.js';
+import {
+  applyVerifiedStarlinkOverrides,
+  applyVerifiedStarlinkPayloadOverrides,
+  normalizeStarlinkPayload,
+  normalizeOperator,
+  normalizeType,
+  validateStarlinkPayload,
+  type StarlinkPayload,
+} from './_starlink-normalize.js';
 import { loadStarlinkSnapshot, type PersistedStarlinkSnapshot } from './_starlink-snapshot.js';
 
 const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/data';
@@ -49,14 +57,14 @@ function loadStaticAircraft(): Array<{ tail: string; fleet: string; type: string
 function staticPayload(): StarlinkPayload | null {
   const raw = loadStaticAircraft();
   if (raw.length === 0) return null;
-  const aircraft = raw.map((a) => ({
+  const aircraft = applyVerifiedStarlinkOverrides(raw.map((a) => ({
     tail: a.tail,
     fleet: a.fleet,
     type: normalizeType(a.type),
     operator: normalizeOperator(a.operator),
     dateFound: '',
     wifi: 'Starlink',
-  }));
+  })));
   return {
     aircraft,
     totalCount: aircraft.length,
@@ -96,13 +104,13 @@ async function fetchUpstream(previousTotal?: number): Promise<StarlinkPayload> {
 function serveFresh(res: VercelResponse, payload: StarlinkPayload, source: string) {
   res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600');
   res.setHeader('X-Starlink-Source', source);
-  return res.status(200).json(payload);
+  return res.status(200).json(applyVerifiedStarlinkPayloadOverrides(payload));
 }
 
 function serveDegraded(res: VercelResponse, payload: StarlinkPayload, source: string) {
   res.setHeader('Cache-Control', 'public, s-maxage=300');
   res.setHeader('X-Starlink-Source', source);
-  return res.status(200).json(payload);
+  return res.status(200).json(applyVerifiedStarlinkPayloadOverrides(payload));
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -3,8 +3,9 @@ import { computeDelayRiskModel, HUB_COORDINATES, HUB_RISK_PROFILES } from '../li
 import { formatDelayExplainFAAStatus, getScheduleRiskContext, describeFaaProgram } from '../lib/delay-explain-context.js';
 import { getMetarStationForIata, INTL_AIRPORTS } from '../lib/airport-metadata.js';
 import { chunkMetarStationIds, normalizeMetarPayload } from '../lib/metar.js';
-import { categorizeFleetStatus, FLEET_HEALTH_CATEGORIES, FLEET_FAMILIES, normalizeWifi, sortFleetData, filterFleetData } from '../lib/fleet-utils.js';
+import { applyStarlinkWifiOverlay, categorizeFleetStatus, FLEET_HEALTH_CATEGORIES, FLEET_FAMILIES, normalizeWifi, sortFleetData, filterFleetData } from '../lib/fleet-utils.js';
 import { bucketInstallsByMonth, computeInstallPace, buildDeparturesBoard } from '../lib/starlink-utils.js';
+import { applyVerifiedStarlinkOverrides } from '../lib/starlink-overrides.js';
 import { getFlightPopupMetrics } from '../lib/flight-popup.js';
 import { getScheduleFleetFamily } from '../lib/schedule-filters.js';
 import { classifySchedStatus } from '../lib/schedule-status.js';
@@ -175,7 +176,9 @@ async function loadFleetData() {
     fleetLoadFailed = true;
   }
 
+  STARLINK_DB = applyVerifiedStarlinkOverrides(STARLINK_DB);
   STARLINK_TAILS = new Set(STARLINK_DB.map(s => s.tail));
+  FLEET_DB = applyStarlinkWifiOverlay(FLEET_DB, STARLINK_TAILS);
   Object.keys(FLEET_BY_REG).forEach(key => delete FLEET_BY_REG[key]);
   FLEET_DB.forEach(a => { FLEET_BY_REG[a.r] = a; });
   buildSpecialAircraftIndex();

--- a/src/data/starlink-live.json
+++ b/src/data/starlink-live.json
@@ -4,9 +4,9 @@
     "asOf": "mid-2026"
   },
   "live": {
-    "count": 513,
-    "label": "500+",
+    "count": 547,
+    "label": "525+",
     "asOf": "August 2026",
-    "fetchedAt": "2026-08-11T22:03:19.860Z"
+    "fetchedAt": "2026-08-30T04:07:14.481Z"
   }
 }

--- a/src/lib/fleet-utils.js
+++ b/src/lib/fleet-utils.js
@@ -66,6 +66,18 @@ export function normalizeWifi(raw) {
   return WIFI_DISPLAY[raw] || raw;
 }
 
+// The base fleet registry changes more slowly than the live Starlink feed. Reconcile the WiFi
+// label from the stronger live signal so confirmed retrofits do not simultaneously show
+// "ViaSat Ka" in the fleet table/modal and "Starlink: Yes" beside it.
+export function applyStarlinkWifiOverlay(fleetDb, starlinkTails) {
+  if (!Array.isArray(fleetDb) || !starlinkTails) return fleetDb;
+  return fleetDb.map((aircraft) => (
+    starlinkTails.has(aircraft.r) && aircraft.w !== 'Starlink'
+      ? { ...aircraft, w: 'Starlink' }
+      : aircraft
+  ));
+}
+
 // ─── Fleet Sort ───
 // Numeric column keys that should be compared as integers
 const NUMERIC_SORT_COLS = new Set(['tot', 'd', 'a']);

--- a/src/lib/starlink-overrides.js
+++ b/src/lib/starlink-overrides.js
@@ -1,0 +1,22 @@
+// Evidence-backed additions that have not reached the upstream tracker yet.
+// Keep this list deliberately small and require direct proof. Overrides are merged by tail, so
+// the upstream record wins automatically as soon as it appears and no duplicate is created.
+//
+// N76265: passenger screenshot identified fleet 3265 / tail N76265 with Starlink on 2026-08-29.
+// Source: https://github.com/jonahberg/the-blue-board/issues/248
+export const VERIFIED_STARLINK_OVERRIDES = Object.freeze([
+  Object.freeze({
+    tail: 'N76265',
+    fleet: 'Mainline',
+    type: '737-800',
+    operator: 'United Airlines',
+    dateFound: '2026-08-29',
+    wifi: 'Starlink',
+  }),
+]);
+
+export function applyVerifiedStarlinkOverrides(aircraft) {
+  const knownTails = new Set(aircraft.map((a) => String(a.tail || '').toUpperCase()));
+  const additions = VERIFIED_STARLINK_OVERRIDES.filter((a) => !knownTails.has(a.tail));
+  return additions.length > 0 ? [...aircraft, ...additions] : aircraft;
+}

--- a/tests/fleet-tab.test.js
+++ b/tests/fleet-tab.test.js
@@ -3,6 +3,7 @@ import {
   categorizeFleetStatus,
   FLEET_FAMILIES,
   normalizeWifi,
+  applyStarlinkWifiOverlay,
   sortFleetData,
   filterFleetData,
 } from '../src/lib/fleet-utils.js';
@@ -359,5 +360,25 @@ describe('normalizeWifi', () => {
   it('returns the raw value if not in the lookup table', () => {
     expect(normalizeWifi('Unknown Wifi')).toBe('Unknown Wifi');
     expect(normalizeWifi('')).toBe('');
+  });
+});
+
+describe('applyStarlinkWifiOverlay', () => {
+  it('replaces stale ViaSat metadata for a Starlink-confirmed tail', () => {
+    const fleet = [
+      { r: 'N76265', w: 'ViaSatKA' },
+      { r: 'N12345', w: 'ViaSatKA' },
+    ];
+    const out = applyStarlinkWifiOverlay(fleet, new Set(['N76265']));
+
+    expect(out[0].w).toBe('Starlink');
+    expect(out[1].w).toBe('ViaSatKA');
+    expect(fleet[0].w).toBe('ViaSatKA');
+  });
+
+  it('preserves rows that already agree with the live feed', () => {
+    const aircraft = { r: 'N76265', w: 'Starlink' };
+    const out = applyStarlinkWifiOverlay([aircraft], new Set(['N76265']));
+    expect(out[0]).toBe(aircraft);
   });
 });

--- a/tests/starlink-data.test.js
+++ b/tests/starlink-data.test.js
@@ -33,7 +33,7 @@ function mockUpstreamResponse() {
   while (starlinkPlanes.length < 513) {
     const i = starlinkPlanes.length;
     starlinkPlanes.push({
-      TailNumber: `N${20000 + i}`,
+      TailNumber: i === 2 ? 'N76265' : `N${20000 + i}`,
       fleet: i < 170 ? 'mainline' : 'express',
       Aircraft: 'Boeing 737-824',
       OperatedBy: 'United Airlines',
@@ -213,7 +213,8 @@ describe('starlink-data API — Supabase snapshot + rate-limit branches', () => 
 
     expect(res.statusCode).toBe(200);
     expect(res.headers['X-Starlink-Source']).toBe('supabase');
-    expect(res.body.aircraft).toHaveLength(1);
+    expect(res.body.aircraft).toHaveLength(2);
+    expect(res.body.aircraft.some((a) => a.tail === 'N76265')).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -244,7 +245,8 @@ describe('starlink-data API — Supabase snapshot + rate-limit branches', () => 
 
     expect(res.statusCode).toBe(200);
     expect(res.headers['X-Starlink-Source']).toBe('supabase-stale');
-    expect(res.body.aircraft).toHaveLength(1);
+    expect(res.body.aircraft).toHaveLength(2);
+    expect(res.body.aircraft.some((a) => a.tail === 'N76265')).toBe(true);
     errSpy.mockRestore();
     warnSpy.mockRestore();
   });

--- a/tests/starlink-normalize.test.js
+++ b/tests/starlink-normalize.test.js
@@ -3,6 +3,7 @@ import {
   normalizeOperator,
   normalizeType,
   normalizeStarlinkPayload,
+  applyVerifiedStarlinkOverrides,
   validateStarlinkPayload,
 } from '../api/_starlink-normalize.js';
 
@@ -67,7 +68,7 @@ describe('normalizeStarlinkPayload', () => {
 
   it('reports the real Starlink count, NOT upstream.totalCount (the whole fleet)', () => {
     const out = normalizeStarlinkPayload(upstream, '2026-05-31T23:40:00.000Z');
-    expect(out.totalCount).toBe(2);
+    expect(out.totalCount).toBe(3);
     expect(out.totalCount).not.toBe(1781);
   });
 
@@ -80,7 +81,7 @@ describe('normalizeStarlinkPayload', () => {
   it('derives fleetStats incl. rollout percentages when upstream omits `combined`', () => {
     const out = normalizeStarlinkPayload(upstream, '2026-05-31T23:40:00.000Z');
     expect(out.fleetStats).toMatchObject({
-      mainline: 51, express: 320, total: 371,
+      mainline: 52, express: 320, total: 372,
       mainlineTotal: 1122, expressTotal: 659, fleetTotal: 1781,
       mainlinePct: 5, expressPct: 49,
     });
@@ -102,6 +103,26 @@ describe('normalizeStarlinkPayload', () => {
     expect(normalizeStarlinkPayload({}).totalCount).toBe(0);
     expect(normalizeStarlinkPayload(null).aircraft).toEqual([]);
     expect(normalizeStarlinkPayload({ starlinkPlanes: [] }).fleetStats).toBeNull();
+  });
+
+  it('adds the evidence-backed N76265 override while upstream is missing it', () => {
+    const out = normalizeStarlinkPayload(upstream, '2026-08-29T23:40:00.000Z');
+    expect(out.aircraft).toContainEqual({
+      tail: 'N76265',
+      fleet: 'Mainline',
+      type: '737-800',
+      operator: 'United Airlines',
+      dateFound: '2026-08-29',
+      wifi: 'Starlink',
+    });
+  });
+
+  it('does not duplicate N76265 after upstream catches up', () => {
+    const existing = applyVerifiedStarlinkOverrides([
+      { tail: 'N76265', fleet: 'Mainline', type: '737-800', operator: 'United Airlines', dateFound: '2026-08-30', wifi: 'Starlink' },
+    ]);
+    expect(existing).toHaveLength(1);
+    expect(existing[0].dateFound).toBe('2026-08-30');
   });
 
   // Upstream occasionally ships departure_time as millisecond epochs or ISO strings instead of

--- a/tests/sync-starlink.test.js
+++ b/tests/sync-starlink.test.js
@@ -38,7 +38,7 @@ function makeReq(overrides = {}) {
 function mockUpstream(planes = 513, { tailKey = 'TailNumber' } = {}) {
   return {
     starlinkPlanes: Array.from({ length: planes }, (_, i) => ({
-      [tailKey]: `N${10000 + i}`,
+      [tailKey]: i === planes - 1 ? 'N76265' : `N${10000 + i}`,
       fleet: i % 2 === 0 ? 'mainline' : 'express',
       Aircraft: 'Boeing 737-824',
       OperatedBy: 'Skywest dba UAX',


### PR DESCRIPTION
## Summary
- add an evidence-backed N76265 Starlink override while the upstream detailed feed is missing the tail
- apply the override across fresh, cached, degraded, and static client fallbacks
- reconcile the fleet WiFi label so the row shows Starlink and the SL badge consistently
- dedupe automatically when the upstream tracker adds N76265

## Evidence
- passenger reports and screenshot: https://github.com/jonahberg/the-blue-board/issues/248
- upstream fleet summary reports 547 equipped while the detailed list contains 546

## Verification
- `bun run test` — 1,432 passed
- `bun run typecheck`
- `bun run build` — 66 pages
- browser QA: N76265 renders as `Starlink` with `SL`

Fixes #248