### PR TITLE
fix(map): add CARTO basemap API key to both tile layers (v1.7.21)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,3 +92,13 @@ RESEND_API_KEY=re_your-key-here
 # when set — the owner MUST set it before sending outbound email to be compliant.
 # Example: "The Blue Board, PO Box 12345, Chicago, IL 60601"
 EMAIL_POSTAL_ADDRESS=
+
+# CARTO basemap tiles (both Leaflet maps: Live Ops + NEXRAD radar). CARTO started requiring a free
+# API key on its raster basemaps in Sep 2026 — without one every tile is stamped "API KEY REQUIRED".
+# Request a key at https://carto.com/basemaps/apikey (no account needed; emailed back within minutes).
+# Free tier: 5,000,000 tile requests per calendar month across raster + vector; CARTO + OpenStreetMap
+# attribution must stay visible in exchange (it is — pinned by tests/compliance.test.js).
+# The VITE_ prefix means Vite inlines this into public/js/dashboard.js at build time. It is a public,
+# per-domain tile key rather than a secret, but keep it out of the repo: set it in Vercel
+# (Production + Preview). Empty → the map still draws, just watermarked (src/lib/basemap.js).
+VITE_CARTO_BASEMAP_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.21] - 2026-09-02
+
+### Fixed
+- **Every map tile was stamped "API KEY REQUIRED".** CARTO began requiring a free API key on its raster basemaps, and a request with no key now returns each dark tile with a diagonal "API KEY REQUIRED — carto.com/basemaps/apikey" watermark. Both Leaflet maps (Live Ops and the NEXRAD radar) hit that path. The tile template now comes from one helper that appends `?key=` when a key is present, and the key is inlined at build time from `VITE_CARTO_BASEMAP_KEY` (set in Vercel Production + Preview) so it never sits in this public repo — it is a public, per-domain tile key rather than a secret, but it is not referer-locked, so it stays out of git. A missing key falls back to the bare template — the map still draws, just watermarked — with a loud build warning rather than a failed build, because a failed production build on this project fails no visible check. The `@2x` retina variant, the `{s}` subdomain rotation, the preconnect hints, and the `img-src` CSP allowance are unchanged; the keyed tile was verified byte-for-byte different from the watermarked one on both the legacy `dark_all` and `rastertiles/dark_all` paths. CARTO is retiring raster basemaps and the same key covers its vector service, so that migration is the follow-up. (`src/lib/basemap.js`, `src/dashboard/main.js`, `vite.dashboard.config.js`, `.env.example`, `README.md`, `tests/basemap.test.js`)
+
 ## [1.7.20] - 2026-08-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Living, data-driven pages that follow aviation's long-running stories — each w
 ## Tech Stack
 
 - **Frontend:** Vanilla HTML/CSS/JS — single-file dashboard, Astro-templated content pages
-- **Map:** [Leaflet](https://leafletjs.com) + CartoDB dark tiles
+- **Map:** [Leaflet](https://leafletjs.com) + CARTO dark tiles (needs a free [CARTO basemaps key](https://carto.com/basemaps/apikey) in `VITE_CARTO_BASEMAP_KEY` — see `.env.example`)
 - **Radar:** Iowa State NEXRAD WMS tiles
 - **Fonts:** Satoshi (headings) + DM Sans (body) + [JetBrains Mono](https://www.jetbrains.com/lp/mono/) (data) — self-hosted WOFF2 (see [DESIGN.md](DESIGN.md))
 - **Build:** [Astro](https://astro.build) (static pages) + [Vite](https://vite.dev) (dashboard bundle)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "jonahberg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.7.20",
+  "version": "1.7.21",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -27,6 +27,7 @@ import { matchAircraft as matchAircraftInFleet } from '../lib/fleet-match.js';
 import { matchesScheduleFilters } from '../lib/schedule-board-filters.js';
 import { analyzeSwapImpact as classifySwapImpact, CABIN_RANK } from '../lib/swap-impact.js';
 import { escapeHtml } from '../lib/escape.js';
+import { cartoBasemapUrl } from '../lib/basemap.js';
 import { atcAirports, atcMeta, unitedHubsMeta, unitedProjects } from '../data/trackers/index.js';
 
 injectSpeedInsights();
@@ -543,6 +544,12 @@ function getBasemapTileOptions() {
   };
 }
 
+// CARTO requires a key on its raster basemaps (Sep 2026) — without one every tile carries an
+// "API KEY REQUIRED" watermark. Vite inlines VITE_CARTO_BASEMAP_KEY here at build time (set in
+// Vercel; see .env.example) so the key never sits in this public repo. Empty key → bare template:
+// the map still draws, just watermarked. Both maps below share this one URL. (src/lib/basemap.js)
+const CARTO_DARK_TILES = cartoBasemapUrl(import.meta.env.VITE_CARTO_BASEMAP_KEY);
+
 // ═══ TAB SWITCHING ═══
 const TAB_HASHES = {'tab-myflight':'#myflight','tab-live':'#live','tab-schedule':'#schedule','tab-fleet':'#fleet','tab-starlink':'#starlink','tab-weather':'#weather','tab-analytics':'#stats','tab-sources':'#sources'};
 const HASH_TABS = Object.fromEntries(Object.entries(TAB_HASHES).map(([k,v])=>[v,k]));
@@ -1034,7 +1041,7 @@ function initMap() {
   // getBasemapTileOptions). Drop the "Leaflet" prefix: micro-text, dark-theme styled in style.css.
   map.attributionControl.setPrefix('');
   L.control.zoom({ position: 'bottomright' }).addTo(map);
-  L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', basemapTileOptions).addTo(map);
+  L.tileLayer(CARTO_DARK_TILES, basemapTileOptions).addTo(map);
 
   // Clear route on popup close and remove flight URL param
   map.on('popupclose', () => {
@@ -3801,7 +3808,7 @@ async function initWeatherTab() {
   radarMap = L.map('radar-map', {center:[39,-97],zoom:4,zoomControl:false});
   radarMap.attributionControl.setPrefix(''); // OSM/CARTO credit from tile options (ODbL)
   L.control.zoom({ position: 'bottomleft' }).addTo(radarMap);
-  L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', basemapTileOptions).addTo(radarMap);
+  L.tileLayer(CARTO_DARK_TILES, basemapTileOptions).addTo(radarMap);
   L.tileLayer('https://mesonet.agron.iastate.edu/cache/tile.py/1.0.0/nexrad-n0q-900913/{z}/{x}/{y}.png',{opacity:0.6}).addTo(radarMap);
   setTimeout(() => radarMap.invalidateSize(), 200);
   document.getElementById('radar-title').textContent = `🌧 NEXRAD Radar — ${new Date().toUTCString().slice(17,25)}Z`;

--- a/src/lib/basemap.js
+++ b/src/lib/basemap.js
@@ -1,0 +1,30 @@
+// CARTO basemap tile URL.
+//
+// CARTO started requiring an API key on its raster basemaps in Sep 2026. A request with no `?key=`
+// still returns a tile, but every one is stamped with a diagonal "API KEY REQUIRED —
+// carto.com/basemaps/apikey" watermark. Both Leaflet maps (Live Ops and the NEXRAD radar) draw
+// these tiles, so both go through this one template.
+//
+// The key is a public, per-domain tile key — it rides on every tile URL in the browser, so it is
+// not a secret — but the repo is public, so it is inlined at build time from
+// VITE_CARTO_BASEMAP_KEY (Vercel Production + Preview; see .env.example) rather than committed.
+// Free tier: 5,000,000 tile requests per calendar month across CARTO's raster + vector services.
+// CARTO + OpenStreetMap attribution must stay visible in exchange (pinned by
+// tests/compliance.test.js). CARTO is retiring raster; the same key covers vector, which is the
+// eventual migration.
+
+export const CARTO_DARK_TILE_TEMPLATE = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+
+/**
+ * Build the Leaflet tile URL template for CARTO's dark basemap.
+ *
+ * @param {string | undefined | null} key  CARTO Basemaps API key. Empty/blank → the bare template,
+ *   which still draws (watermarked) rather than breaking the map.
+ * @param {string} [template]  Tile template; defaults to the dark raster basemap.
+ * @returns {string}
+ */
+export function cartoBasemapUrl(key, template = CARTO_DARK_TILE_TEMPLATE) {
+  const trimmed = typeof key === 'string' ? key.trim() : '';
+  if (!trimmed) return template;
+  return `${template}?key=${encodeURIComponent(trimmed)}`;
+}

--- a/tests/basemap.test.js
+++ b/tests/basemap.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { cartoBasemapUrl, CARTO_DARK_TILE_TEMPLATE } from '../src/lib/basemap.js';
+
+// CARTO started requiring an API key on its raster basemaps (Sep 2026). Without `?key=` on the
+// request every tile is served with a diagonal "API KEY REQUIRED" watermark. These pins make sure
+// both Leaflet maps go through the one keyed template and that the key is wired in at build time.
+
+const mainJs = readFileSync(new URL('../src/dashboard/main.js', import.meta.url), 'utf8');
+const envExample = readFileSync(new URL('../.env.example', import.meta.url), 'utf8');
+
+describe('cartoBasemapUrl', () => {
+  it('appends the key as a query parameter', () => {
+    expect(cartoBasemapUrl('abc123')).toBe(`${CARTO_DARK_TILE_TEMPLATE}?key=abc123`);
+  });
+
+  it('keeps every Leaflet placeholder intact and puts the query after the extension', () => {
+    const url = cartoBasemapUrl('abc123');
+    for (const placeholder of ['{s}', '{z}', '{x}', '{y}', '{r}']) expect(url).toContain(placeholder);
+    expect(url).toMatch(/\{r\}\.png\?key=abc123$/);
+  });
+
+  it('falls back to the bare template when the key is missing (watermarked, but the map still draws)', () => {
+    expect(cartoBasemapUrl('')).toBe(CARTO_DARK_TILE_TEMPLATE);
+    expect(cartoBasemapUrl(undefined)).toBe(CARTO_DARK_TILE_TEMPLATE);
+    expect(cartoBasemapUrl(null)).toBe(CARTO_DARK_TILE_TEMPLATE);
+    expect(cartoBasemapUrl('   ')).toBe(CARTO_DARK_TILE_TEMPLATE);
+    expect(cartoBasemapUrl('')).not.toContain('?');
+  });
+
+  it('URL-encodes the key so a stray character cannot break the tile URL', () => {
+    expect(cartoBasemapUrl('a b&c')).toBe(`${CARTO_DARK_TILE_TEMPLATE}?key=a%20b%26c`);
+  });
+
+  it('template is the CARTO dark raster basemap with subdomain + retina placeholders', () => {
+    expect(CARTO_DARK_TILE_TEMPLATE).toBe('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png');
+  });
+});
+
+describe('dashboard wires the key into every CARTO tile layer', () => {
+  it('no L.tileLayer call carries a bare basemaps.cartocdn.com literal', () => {
+    const bare = mainJs.match(/L\.tileLayer\(\s*['"`]https?:\/\/[^'"`]*basemaps\.cartocdn\.com[^)]*/g) || [];
+    expect(bare).toEqual([]);
+  });
+
+  it('both maps (Live Ops + NEXRAD radar) use the keyed template', () => {
+    const uses = mainJs.match(/L\.tileLayer\(CARTO_DARK_TILES,/g) || [];
+    expect(uses).toHaveLength(2);
+  });
+
+  it('the key is read from VITE_CARTO_BASEMAP_KEY at build time', () => {
+    expect(mainJs).toContain('cartoBasemapUrl(import.meta.env.VITE_CARTO_BASEMAP_KEY)');
+  });
+
+  it('.env.example documents VITE_CARTO_BASEMAP_KEY', () => {
+    expect(envExample).toMatch(/^VITE_CARTO_BASEMAP_KEY=/m);
+  });
+});

--- a/vite.dashboard.config.js
+++ b/vite.dashboard.config.js
@@ -1,23 +1,38 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 
-export default defineConfig({
-  publicDir: false,
-  build: {
-    outDir: 'public/js',
-    emptyOutDir: false,
-    lib: {
-      entry: 'src/dashboard/main.js',
-      formats: ['iife'],
-      name: 'BB',
-      fileName: () => 'dashboard.js',
-    },
-    rollupOptions: {
-      external: ['leaflet'],
-      output: {
-        globals: { leaflet: 'L' },
+export default defineConfig(({ mode }) => {
+  // CARTO basemap key (public tile key, inlined into the bundle as import.meta.env.VITE_CARTO_BASEMAP_KEY).
+  // Vite reads it from the process env (Vercel) or a local .env. Missing key is a loud warning, not a
+  // build failure: a watermarked map is visible, while a failed production build on this project fails
+  // no visible check (see CHANGELOG 1.7.21 / .env.example).
+  const env = { ...loadEnv(mode, process.cwd(), 'VITE_'), ...process.env };
+  if (!(env.VITE_CARTO_BASEMAP_KEY || '').trim()) {
+    const where = process.env.VERCEL_ENV ? `Vercel ${process.env.VERCEL_ENV}` : 'local';
+    console.warn(
+      `\n[dashboard build] VITE_CARTO_BASEMAP_KEY is not set (${where}): CARTO tiles will render with an ` +
+      `"API KEY REQUIRED" watermark. Set it in Vercel (Production + Preview) or a local .env — see .env.example.\n`
+    );
+  }
+
+  return {
+    publicDir: false,
+    build: {
+      outDir: 'public/js',
+      emptyOutDir: false,
+      lib: {
+        entry: 'src/dashboard/main.js',
+        formats: ['iife'],
+        name: 'BB',
+        fileName: () => 'dashboard.js',
       },
+      rollupOptions: {
+        external: ['leaflet'],
+        output: {
+          globals: { leaflet: 'L' },
+        },
+      },
+      minify: 'esbuild',
+      sourcemap: false,
     },
-    minify: 'esbuild',
-    sourcemap: false,
-  },
+  };
 });


### PR DESCRIPTION
## What

CARTO began requiring a free API key on its raster basemaps. A request with no key now returns every dark tile stamped with a diagonal **"API KEY REQUIRED — carto.com/basemaps/apikey"** watermark, which is what the live map has been showing (both Live Ops and the NEXRAD radar map).

## How

- `src/lib/basemap.js` — one keyed tile template: `cartoBasemapUrl(key)` appends `?key=` when a key is present, returns the bare template when it is empty (map still draws, just watermarked).
- `src/dashboard/main.js` — both `L.tileLayer` calls use it; the key comes from `import.meta.env.VITE_CARTO_BASEMAP_KEY`, inlined by Vite at build time.
- `vite.dashboard.config.js` — loud build warning when the key is missing. Deliberately **not** a build failure: a watermarked map is visible, a failed production build on this project fails no visible GitHub check.
- `.env.example` / `README.md` — document the variable, the 5M tiles/month free tier, and the attribution requirement.
- `tests/basemap.test.js` — helper behaviour + source pins (no bare `basemaps.cartocdn.com` literal in any `L.tileLayer` call; both maps use the keyed constant; `.env.example` documents the var).

The key is a public, per-domain tile key (it rides on every tile URL in the browser) but it is **not** referer-locked, so it is kept out of this public repo and set in Vercel (Production, Preview, Development — already done).

## Verified

- `bun run test` — 92 files / 1437 tests pass (9 new)
- `bun run typecheck` — clean
- `bun run build` with a sentinel `VITE_CARTO_BASEMAP_KEY=LOCALTEST` — sentinel lands in `public/js/dashboard.js` and `dist/js/dashboard.js`; no `import.meta.env` survives in the IIFE bundle
- Keyed tile fetched from CARTO is byte-for-byte different from the unkeyed/wrong-key (watermarked) tile, on both `dark_all` and `rastertiles/dark_all` paths and for the `@2x` retina variant
- CSP `img-src` already allows `https://*.basemaps.cartocdn.com`; query strings don't affect it

## Follow-up

CARTO is retiring raster basemaps; the same key covers its vector service. Migrating to vector (per-style table at carto.com/basemaps/apikey) is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SR6nNAcLgqqsBkiCGKDw3G
